### PR TITLE
feat: Add type guards and improve type handling

### DIFF
--- a/examples/in/rfc/guard/basic_guard.ft
+++ b/examples/in/rfc/guard/basic_guard.ft
@@ -1,5 +1,25 @@
+package main
+
+import "os"
+
 type Password = String
 
 is (password Password) Strong {
     return len(password) >= 12
 }
+
+func main() {
+	password: Password = "1234567890123"
+	ensure password is Strong() {
+		os.Exit(1)
+	}
+}
+
+// func main() {
+// 	password := "1234567890123"
+// 	if password is Strong() {
+// 		os.Exit(0)
+// 	} else {
+// 		os.Exit(1)
+// 	}
+// }

--- a/examples/type_guards.forst
+++ b/examples/type_guards.forst
@@ -1,0 +1,14 @@
+type Password = string
+
+fn validatePassword(pwd: Password): bool {
+    return len(pwd) >= 8
+}
+
+fn main() {
+    password := Password("12345678")
+    if validatePassword(password) {
+        print("Password is valid")
+    } else {
+        print("Password is invalid")
+    }
+} 

--- a/forst/cmd/forst/main.go
+++ b/forst/cmd/forst/main.go
@@ -35,13 +35,29 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		if err := program.compileFile(); err != nil {
+		code, err := program.compileFile()
+		if err != nil {
 			log.Error(err)
 			os.Exit(1)
 		}
 
+		outputPath := args.outputPath
+		if outputPath == "" {
+			// Create temp directory if needed
+			tempDir, err := os.MkdirTemp("", "forst-*")
+			if err != nil {
+				log.Error(err)
+				os.Exit(1)
+			}
+			outputPath = fmt.Sprintf("%s/main.go", tempDir)
+			if err := os.WriteFile(outputPath, []byte(*code), 0644); err != nil {
+				log.Error(err)
+				os.Exit(1)
+			}
+		}
+
 		if args.command == "run" {
-			if err := runGoProgram(args.outputPath); err != nil {
+			if err := runGoProgram(outputPath); err != nil {
 				log.Error(err)
 				os.Exit(1)
 			}

--- a/forst/internal/ast/node.go
+++ b/forst/internal/ast/node.go
@@ -36,4 +36,5 @@ const (
 	NodeKindEnsureBlock       NodeKind = "EnsureBlock"
 	NodeKindAssignment        NodeKind = "Assignment"
 	NodeKindShape             NodeKind = "Shape"
+	NodeKindTypeGuard         NodeKind = "TYPE_GUARD"
 )

--- a/forst/internal/ast/typeguard.go
+++ b/forst/internal/ast/typeguard.go
@@ -1,0 +1,28 @@
+package ast
+
+import (
+	"fmt"
+)
+
+// TypeGuardNode represents a type guard declaration
+type TypeGuardNode struct {
+	Node
+	// Name of the type guard
+	Ident Identifier
+	// Parameters of the type guard
+	Parameters []ParamNode
+	// Body of the type guard
+	Body []Node
+}
+
+func (t TypeGuardNode) Kind() NodeKind {
+	return NodeKindTypeGuard
+}
+
+func (t TypeGuardNode) Id() string {
+	return string(t.Ident)
+}
+
+func (t TypeGuardNode) String() string {
+	return fmt.Sprintf("TypeGuardNode(%s)", t.Ident)
+}

--- a/forst/internal/parser/assignment.go
+++ b/forst/internal/parser/assignment.go
@@ -4,6 +4,15 @@ import "forst/internal/ast"
 
 func (p *Parser) parseAssignment() ast.AssignmentNode {
 	ident := p.expect(ast.TokenIdentifier)
+
+	// Check for optional type annotation
+	var explicitType *ast.TypeNode = nil
+	if p.current().Type == ast.TokenColon {
+		p.advance() // consume ':'
+		typeNode := p.parseType()
+		explicitType = &typeNode
+	}
+
 	// Expect assignment operator
 	assignToken := p.current()
 	if assignToken.Type != ast.TokenEquals && assignToken.Type != ast.TokenColonEquals {
@@ -18,7 +27,7 @@ func (p *Parser) parseAssignment() ast.AssignmentNode {
 			{Ident: ast.Ident{Id: ast.Identifier(ident.Value)}},
 		},
 		RValues:       []ast.ExpressionNode{expr},
-		ExplicitTypes: []*ast.TypeNode{nil},
+		ExplicitTypes: []*ast.TypeNode{explicitType},
 		IsShort:       assignToken.Type == ast.TokenColonEquals,
 	}
 }

--- a/forst/internal/parser/expression.go
+++ b/forst/internal/parser/expression.go
@@ -38,8 +38,8 @@ func (p *Parser) parseExpressionLevel(level int) ast.ExpressionNode {
 		expr = p.parseExpressionLevel(level + 1)
 		// Check for function call
 		p.expect(ast.TokenRParen) // Consume the right parenthesis
-	} else if p.current().Type == ast.TokenIdentifier && (p.peek().Type == ast.TokenLParen || p.peek().Type == ast.TokenDot) {
-		// Parse the function identifier, allowing for dot chaining
+	} else if p.current().Type == ast.TokenIdentifier {
+		// Parse the identifier, allowing for dot chaining
 		ident := p.expect(ast.TokenIdentifier)
 		var curIdent ast.Identifier = ast.Identifier(ident.Value)
 
@@ -67,12 +67,11 @@ func (p *Parser) parseExpressionLevel(level int) ast.ExpressionNode {
 				Function:  ast.Ident{Id: curIdent},
 				Arguments: args,
 			}
-			return expr
-		}
-
-		// Otherwise treat as a field access
-		expr = ast.VariableNode{
-			Ident: ast.Ident{Id: curIdent},
+		} else {
+			// Otherwise treat as a variable
+			expr = ast.VariableNode{
+				Ident: ast.Ident{Id: curIdent},
+			}
 		}
 	} else {
 		expr = p.parseValue() // parseValue should advance the token internally

--- a/forst/internal/parser/function.go
+++ b/forst/internal/parser/function.go
@@ -2,8 +2,6 @@ package parser
 
 import (
 	"forst/internal/ast"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func (p *Parser) parseParameterType() ast.TypeNode {
@@ -46,18 +44,16 @@ func (p *Parser) parseDestructuredParameter() ast.ParamNode {
 }
 
 func (p *Parser) parseSimpleParameter() ast.ParamNode {
-	name := p.expect(ast.TokenIdentifier)
-	p.expect(ast.TokenColon)
-
-	paramType := p.parseParameterType()
-	log.Trace("parsed param type", paramType)
-
-	param := ast.SimpleParamNode{
-		Ident: ast.Ident{Id: ast.Identifier(name.Value)},
-		Type:  paramType,
+	ident := p.expect(ast.TokenIdentifier)
+	// If the next token is a colon, consume it; otherwise, assume the next token is the type
+	if p.current().Type == ast.TokenColon {
+		p.advance()
 	}
-
-	return param
+	typ := p.parseParameterType()
+	return ast.SimpleParamNode{
+		Ident: ast.Ident{Id: ast.Identifier(ident.Value)},
+		Type:  typ,
+	}
 }
 
 func (p *Parser) parseParameter() ast.ParamNode {

--- a/forst/internal/parser/parse.go
+++ b/forst/internal/parser/parse.go
@@ -59,6 +59,10 @@ func (p *Parser) ParseFile() ([]ast.Node, error) {
 			function := p.parseFunctionDefinition()
 			logParsedNodeWithMessage(function, "Parsed function")
 			nodes = append(nodes, function)
+		case ast.TokenIs:
+			typeGuard := p.parseTypeGuard()
+			logParsedNodeWithMessage(typeGuard, "Parsed type guard")
+			nodes = append(nodes, typeGuard)
 		default:
 			return nil, &ParseError{
 				Token:   token,

--- a/forst/internal/parser/parse_test.go
+++ b/forst/internal/parser/parse_test.go
@@ -238,3 +238,111 @@ func TestParseFile_WithFunctions(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFile_WithTypeGuards(t *testing.T) {
+	tests := []struct {
+		name     string
+		tokens   []ast.Token
+		validate func(t *testing.T, nodes []ast.Node)
+	}{
+		{
+			name: "basic type guard",
+			tokens: []ast.Token{
+				{Type: ast.TokenIs, Value: "is", Line: 1, Column: 1},
+				{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 4},
+				{Type: ast.TokenIdentifier, Value: "password", Line: 1, Column: 5},
+				{Type: ast.TokenColon, Value: ":", Line: 1, Column: 13},
+				{Type: ast.TokenIdentifier, Value: "Password", Line: 1, Column: 15},
+				{Type: ast.TokenRParen, Value: ")", Line: 1, Column: 22},
+				{Type: ast.TokenIdentifier, Value: "Strong", Line: 1, Column: 24},
+				{Type: ast.TokenLBrace, Value: "{", Line: 1, Column: 30},
+				{Type: ast.TokenReturn, Value: "return", Line: 2, Column: 4},
+				{Type: ast.TokenIdentifier, Value: "len", Line: 2, Column: 11},
+				{Type: ast.TokenLParen, Value: "(", Line: 2, Column: 14},
+				{Type: ast.TokenIdentifier, Value: "password", Line: 2, Column: 15},
+				{Type: ast.TokenRParen, Value: ")", Line: 2, Column: 22},
+				{Type: ast.TokenGreaterEqual, Value: ">=", Line: 2, Column: 24},
+				{Type: ast.TokenIntLiteral, Value: "12", Line: 2, Column: 27},
+				{Type: ast.TokenRBrace, Value: "}", Line: 3, Column: 1},
+				{Type: ast.TokenEOF, Value: "", Line: 3, Column: 2},
+			},
+			validate: func(t *testing.T, nodes []ast.Node) {
+				if len(nodes) != 1 {
+					t.Fatalf("Expected 1 node, got %d", len(nodes))
+				}
+				typeGuardNode := assertNodeType[*ast.TypeGuardNode](t, nodes[0], "*ast.TypeGuardNode")
+				if typeGuardNode.Id() != "Strong" {
+					t.Errorf("Expected type guard name 'Strong', got %s", typeGuardNode.Id())
+				}
+				if len(typeGuardNode.Parameters) != 1 {
+					t.Errorf("Expected 1 parameter, got %d", len(typeGuardNode.Parameters))
+				}
+				param, ok := typeGuardNode.Parameters[0].(ast.SimpleParamNode)
+				if !ok {
+					t.Fatalf("Expected SimpleParamNode, got %T", typeGuardNode.Parameters[0])
+				}
+				if param.Ident.Id != "password" {
+					t.Errorf("Expected parameter name 'password', got %s", param.Ident.Id)
+				}
+				if param.Type.Ident != "Password" {
+					t.Errorf("Expected parameter type 'Password', got %s", param.Type.Ident)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := setupParser(tt.tokens)
+			nodes, err := p.ParseFile()
+			if err != nil {
+				t.Fatalf("ParseFile failed: %v", err)
+			}
+			tt.validate(t, nodes)
+		})
+	}
+}
+
+func TestParseFile_WithBinaryExpressionInFunction(t *testing.T) {
+	tokens := []ast.Token{
+		{Type: ast.TokenFunction, Value: "func", Line: 1, Column: 1},
+		{Type: ast.TokenIdentifier, Value: "passwordStrength", Line: 1, Column: 6},
+		{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 14},
+		{Type: ast.TokenIdentifier, Value: "password", Line: 1, Column: 15},
+		{Type: ast.TokenColon, Value: ":", Line: 1, Column: 23},
+		{Type: ast.TokenIdentifier, Value: "Password", Line: 1, Column: 25},
+		{Type: ast.TokenRParen, Value: ")", Line: 1, Column: 32},
+		{Type: ast.TokenLBrace, Value: "{", Line: 1, Column: 34},
+		{Type: ast.TokenReturn, Value: "return", Line: 2, Column: 4},
+		{Type: ast.TokenIdentifier, Value: "len", Line: 2, Column: 11},
+		{Type: ast.TokenLParen, Value: "(", Line: 2, Column: 14},
+		{Type: ast.TokenIdentifier, Value: "password", Line: 2, Column: 15},
+		{Type: ast.TokenRParen, Value: ")", Line: 2, Column: 22},
+		{Type: ast.TokenPlus, Value: "+", Line: 2, Column: 24},
+		{Type: ast.TokenIntLiteral, Value: "12", Line: 2, Column: 27},
+		{Type: ast.TokenRBrace, Value: "}", Line: 3, Column: 1},
+		{Type: ast.TokenEOF, Value: "", Line: 3, Column: 2},
+	}
+
+	p := setupParser(tokens)
+	nodes, err := p.ParseFile()
+	if err == nil {
+		if len(nodes) != 1 {
+			t.Fatalf("Expected 1 node, got %d", len(nodes))
+		}
+		functionNode := assertNodeType[ast.FunctionNode](t, nodes[0], "ast.FunctionNode")
+		if functionNode.Id() != "passwordStrength" {
+			t.Errorf("Expected function name 'isStrong', got %s", functionNode.Id())
+		}
+		if len(functionNode.Body) != 1 {
+			t.Errorf("Expected 1 statement in function body, got %d", len(functionNode.Body))
+		}
+		returnNode := assertNodeType[ast.ReturnNode](t, functionNode.Body[0], "ast.ReturnNode")
+		// Optionally, check that the return value is a binary expression
+		if _, ok := returnNode.Value.(ast.BinaryExpressionNode); !ok {
+			t.Errorf("Expected return value to be a BinaryExpressionNode, got %T", returnNode.Value)
+		}
+	} else {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+}

--- a/forst/internal/parser/statement.go
+++ b/forst/internal/parser/statement.go
@@ -22,27 +22,28 @@ func (p *Parser) parseBlockStatement(blockContext *BlockContext) []ast.Node {
 		body = append(body, returnStatement)
 	} else if token.Type == ast.TokenIdentifier {
 		next := p.peek()
-		// Look ahead to see if this is a function call or assignment
-		if next.Type == ast.TokenLParen || next.Type == ast.TokenDot {
-			// Function call
-			expr := p.parseExpression()
-			logParsedNode(expr)
-			body = append(body, expr)
-		} else if next.Type == ast.TokenComma {
-			// Multiple assignment
+		if next.Type == ast.TokenComma {
 			assignment := p.parseMultipleAssignment()
 			logParsedNode(assignment)
 			body = append(body, assignment)
 		} else if next.Type == ast.TokenColonEquals || next.Type == ast.TokenEquals {
-			// Single assignment
+			assignment := p.parseAssignment()
+			logParsedNode(assignment)
+			body = append(body, assignment)
+		} else if next.Type == ast.TokenColon && (p.peek(2).Type == ast.TokenIdentifier || p.peek(2).Type == ast.TokenString || p.peek(2).Type == ast.TokenInt || p.peek(2).Type == ast.TokenFloat || p.peek(2).Type == ast.TokenBool || p.peek(2).Type == ast.TokenVoid) && (p.peek(3).Type == ast.TokenColonEquals || p.peek(3).Type == ast.TokenEquals) {
+			// identifier: Type := ...
 			assignment := p.parseAssignment()
 			logParsedNode(assignment)
 			body = append(body, assignment)
 		} else {
-			panic(parseErrorWithValue(token, "Expected function call or assignment after identifier"))
+			expr := p.parseExpression()
+			logParsedNode(expr)
+			body = append(body, expr)
 		}
 	} else {
-		panic(parseErrorWithValue(token, "Unexpected token in function body"))
+		expr := p.parseExpression()
+		logParsedNode(expr)
+		body = append(body, expr)
 	}
 
 	return body

--- a/forst/internal/parser/typeguard.go
+++ b/forst/internal/parser/typeguard.go
@@ -1,0 +1,35 @@
+package parser
+
+import (
+	"forst/internal/ast"
+)
+
+// parseTypeGuard parses a type guard declaration
+func (p *Parser) parseTypeGuard() *ast.TypeGuardNode {
+	p.expect(ast.TokenIs)
+	p.expect(ast.TokenLParen)
+
+	// Parse parameters
+	var params []ast.ParamNode
+	for p.current().Type != ast.TokenRParen {
+		param := p.parseParameter()
+		params = append(params, param)
+
+		if p.current().Type == ast.TokenComma {
+			p.advance()
+		}
+	}
+	p.expect(ast.TokenRParen)
+
+	// Parse type guard name
+	name := p.expect(ast.TokenIdentifier)
+
+	// Parse body
+	body := p.parseBlock(&BlockContext{AllowReturn: true})
+
+	return &ast.TypeGuardNode{
+		Ident:      ast.Identifier(name.Value),
+		Parameters: params,
+		Body:       body,
+	}
+}

--- a/forst/internal/transformer/go/transform.go
+++ b/forst/internal/transformer/go/transform.go
@@ -38,6 +38,12 @@ func (t *Transformer) TransformForstFileToGo(nodes []ast.Node) (*goast.File, err
 				return nil, fmt.Errorf("failed to transform type def %s: %w", def.Ident, err)
 			}
 			t.Output.AddType(decl)
+		case *ast.TypeGuardNode:
+			decl, err := t.transformTypeGuard(*def)
+			if err != nil {
+				return nil, fmt.Errorf("failed to transform type guard %s: %w", def.Ident, err)
+			}
+			t.Output.AddFunction(decl)
 		}
 	}
 
@@ -88,4 +94,55 @@ func (t *Transformer) isMainFunction() bool {
 		return false
 	}
 	return currentFunction.HasMainFunctionName()
+}
+
+func (t *Transformer) transformTypeGuard(n ast.TypeGuardNode) (*goast.FuncDecl, error) {
+	// Create function parameters
+	params := &goast.FieldList{
+		List: []*goast.Field{},
+	}
+
+	for _, param := range n.Parameters {
+		var paramName string
+		var paramType ast.TypeNode
+
+		switch p := param.(type) {
+		case ast.SimpleParamNode:
+			paramName = string(p.Ident.Id)
+			paramType = p.Type
+		case ast.DestructuredParamNode:
+			// Handle destructured params if needed
+			continue
+		}
+
+		ident, err := t.transformType(paramType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to transform type: %s", err)
+		}
+		params.List = append(params.List, &goast.Field{
+			Names: []*goast.Ident{goast.NewIdent(paramName)},
+			Type:  ident,
+		})
+	}
+
+	// Create function body statements
+	stmts := []goast.Stmt{}
+
+	for _, stmt := range n.Body {
+		goStmt := t.transformStatement(stmt)
+		stmts = append(stmts, goStmt)
+	}
+
+	// Create the function declaration
+	return &goast.FuncDecl{
+		Recv: nil,
+		Name: goast.NewIdent(string(n.Ident)),
+		Type: &goast.FuncType{
+			Params:  params,
+			Results: &goast.FieldList{List: []*goast.Field{{Type: goast.NewIdent("bool")}}},
+		},
+		Body: &goast.BlockStmt{
+			List: stmts,
+		},
+	}, nil
 }

--- a/forst/internal/transformer/go/type.go
+++ b/forst/internal/transformer/go/type.go
@@ -8,6 +8,9 @@ import (
 
 // transformType converts a Forst type node to a Go type declaration
 func (t *Transformer) transformType(n ast.TypeNode) (*goast.Ident, error) {
+	if n.Ident == "" {
+		return nil, fmt.Errorf("TypeNode is missing an identifier: %+v", n)
+	}
 	switch n.Ident {
 	case ast.TypeInt:
 		return goast.NewIdent("int"), nil
@@ -27,8 +30,10 @@ func (t *Transformer) transformType(n ast.TypeNode) (*goast.Ident, error) {
 			return nil, fmt.Errorf("failed to lookup assertion type: %s", err)
 		}
 		return goast.NewIdent(string(ident.Ident)), nil
+	default:
+		// For user-defined types (aliases, shapes, etc.), just use the type name
+		return goast.NewIdent(string(n.Ident)), nil
 	}
-	return nil, fmt.Errorf("unknown type: %s", n.Ident)
 }
 
 func (t *Transformer) transformTypes(types []ast.TypeNode) (*goast.FieldList, error) {

--- a/forst/internal/transformer/go/typedef.go
+++ b/forst/internal/transformer/go/typedef.go
@@ -191,6 +191,9 @@ func (t *Transformer) transformTypeDefExpr(expr ast.TypeDefExpr) (*goast.Expr, e
 
 		var result goast.Expr = baseTypeIdent
 		return &result, nil
+	case *ast.TypeDefAssertionExpr:
+		// Handle pointer by dereferencing and reusing value logic
+		return t.transformTypeDefExpr(*e)
 	case ast.TypeDefBinaryExpr:
 		// binaryExpr := expr.(ast.TypeDefBinaryExpr)
 		// if binaryExpr.IsConjunction() {

--- a/forst/internal/typechecker/hash.go
+++ b/forst/internal/typechecker/hash.go
@@ -35,6 +35,7 @@ var NodeKind = map[string]uint8{
 	"BoolLiteral":      8,
 	"Function":         9,
 	"Ensure":           10,
+	"TYPE_GUARD":       11,
 }
 
 // HashNodes generates a structural hash for multiple AST nodes
@@ -276,6 +277,20 @@ func (h *StructuralHasher) HashNode(node ast.Node) NodeHash {
 		for _, node := range n.Body {
 			writeHash(hasher, h.HashNode(node))
 		}
+	case ast.TypeGuardNode:
+		writeHash(hasher, NodeKind["TYPE_GUARD"])
+		writeHash(hasher, []byte(n.Ident))
+		for _, param := range n.Parameters {
+			writeHash(hasher, h.HashNode(param))
+		}
+		writeHash(hasher, h.HashNodes(n.Body))
+	case *ast.TypeGuardNode:
+		writeHash(hasher, NodeKind["TYPE_GUARD"])
+		writeHash(hasher, []byte(n.Ident))
+		for _, param := range n.Parameters {
+			writeHash(hasher, h.HashNode(param))
+		}
+		writeHash(hasher, h.HashNodes(n.Body))
 	default:
 		panic(fmt.Sprintf("unsupported node type: %T", n))
 	}

--- a/forst/internal/typechecker/infer.go
+++ b/forst/internal/typechecker/infer.go
@@ -358,6 +358,9 @@ func (tc *TypeChecker) inferNodeType(node ast.Node) ([]ast.TypeNode, error) {
 
 	case ast.ReturnNode:
 		return nil, nil
+
+	case *ast.TypeGuardNode:
+		return nil, nil
 	}
 
 	panic(typecheckErrorMessageWithNode(&node, fmt.Sprintf("unsupported node type %T", node)))

--- a/forst/internal/typechecker/typechecker.go
+++ b/forst/internal/typechecker/typechecker.go
@@ -85,6 +85,11 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 
 		tc.popScope()
 		tc.registerFunction(n)
+	case *ast.TypeGuardNode:
+		// Register type guard in Defs
+		if _, exists := tc.Defs[ast.TypeIdent(n.Ident)]; !exists {
+			tc.Defs[ast.TypeIdent(n.Ident)] = n
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This commit introduces type guards to the Forst language, allowing users to define custom type validation functions. Type guards are declared using the 'is' keyword and can be used in 'ensure' statements to validate types at runtime. The implementation adds a new AST node type 'TypeGuardNode' with corresponding parser support, transforms type guards into Go functions that return boolean values, and supports type guard assertions in ensure statements. The changes also improve type handling for user-defined types and type aliases, enhance error handling for type transformations, and improve temporary file handling in the compiler.