### PR TITLE
feat(lexer): improve token handling and standardization

### DIFF
--- a/forst/cmd/forst/program.go
+++ b/forst/cmd/forst/program.go
@@ -71,7 +71,8 @@ func (p *Program) compileFile() (*string, error) {
 	memBefore := getMemStats()
 
 	// Lexical Analysis
-	tokens := lexer.Lexer(source, lexer.Context{FilePath: p.Args.filePath})
+	l := lexer.NewLexer(source, p.Args.filePath)
+	tokens := l.Lex()
 
 	memAfter := getMemStats()
 	p.logMemUsage("lexical analysis", memBefore, memAfter)

--- a/forst/internal/ast/tokens.go
+++ b/forst/internal/ast/tokens.go
@@ -12,8 +12,8 @@ const (
 	// TokenIdentifier is the token for user-defined identifiers
 	TokenIdentifier TokenIdent = "IDENTIFIER"
 
-	// TokenFunction is the token for function keyword
-	TokenFunction TokenIdent = "FUNCTION"
+	// TokenFunc is the token for function keyword
+	TokenFunc TokenIdent = "FUNCTION"
 	// TokenType is the token for type keyword
 	TokenType TokenIdent = "TYPE"
 
@@ -84,8 +84,8 @@ const (
 	TokenPlus TokenIdent = "PLUS" // +
 	// TokenMinus is the token for minus operator
 	TokenMinus TokenIdent = "MINUS" // -
-	// TokenMultiply is the token for multiply operator
-	TokenMultiply TokenIdent = "MULTIPLY" // *
+	// TokenStar is the token for multiply operator, also used for pointer dereference
+	TokenStar TokenIdent = "STAR" // *
 	// TokenDivide is the token for divide operator
 	TokenDivide TokenIdent = "DIVIDE" // /
 	// TokenModulo is the token for modulo operator
@@ -127,6 +127,8 @@ const (
 	TokenElse TokenIdent = "ELSE"
 	// TokenFor is the token for for loop
 	TokenFor TokenIdent = "FOR"
+	// TokenRange is the token for range keyword
+	TokenRange TokenIdent = "RANGE"
 	// TokenBreak is the token for break statement
 	TokenBreak TokenIdent = "BREAK"
 	// TokenContinue is the token for continue statement
@@ -142,6 +144,8 @@ const (
 
 	// TokenVar is the token for var keyword
 	TokenVar TokenIdent = "VAR"
+	// TokenConst is the token for const keyword
+	TokenConst TokenIdent = "CONST"
 	// TokenMap is the token for map keyword
 	TokenMap TokenIdent = "MAP"
 	// TokenChan is the token for chan keyword
@@ -150,6 +154,12 @@ const (
 	TokenArrow TokenIdent = "ARROW"
 	// TokenInterface is the token for interface keyword
 	TokenInterface TokenIdent = "INTERFACE"
+	// TokenGo is the token for go keyword
+	TokenGo TokenIdent = "GO"
+	// TokenDefer is the token for defer keyword
+	TokenDefer TokenIdent = "DEFER"
+	// TokenGoto is the token for goto keyword
+	TokenGoto TokenIdent = "GOTO"
 )
 
 // Token structure
@@ -164,7 +174,7 @@ type Token struct {
 // IsBinaryOperator returns true if the token is a binary operator
 func (t TokenIdent) IsBinaryOperator() bool {
 	return t == TokenPlus || t == TokenMinus ||
-		t == TokenMultiply || t == TokenDivide ||
+		t == TokenStar || t == TokenDivide ||
 		t == TokenModulo || t == TokenEquals ||
 		t == TokenNotEquals || t == TokenGreater ||
 		t == TokenLess || t == TokenGreaterEqual ||
@@ -184,7 +194,7 @@ func (t TokenIdent) IsLiteral() bool {
 
 // IsArithmeticBinaryOperator returns true if the token is an arithmetic binary operator
 func (t TokenIdent) IsArithmeticBinaryOperator() bool {
-	return t == TokenPlus || t == TokenMinus || t == TokenMultiply || t == TokenDivide || t == TokenModulo
+	return t == TokenPlus || t == TokenMinus || t == TokenStar || t == TokenDivide || t == TokenModulo
 }
 
 // IsComparisonBinaryOperator returns true if the token is a comparison binary operator

--- a/forst/internal/lexer/core.go
+++ b/forst/internal/lexer/core.go
@@ -1,0 +1,45 @@
+package lexer
+
+import "forst/internal/ast"
+
+// Context for tracking file information
+type Context struct {
+	FilePath string
+}
+
+// LexerLocation tracks the current state of the lexer
+type LexerLocation struct {
+	LineNum int
+	Column  int
+	Path    string
+}
+
+// Lexer represents the lexer for the Forst language
+type Lexer struct {
+	input    []byte
+	tokens   []ast.Token
+	context  Context
+	location LexerLocation
+
+	// Block comment state
+	accumulatingBlockComment bool
+	blockCommentValue        string
+	blockCommentStartLine    int
+	blockCommentStartCol     int
+	blockCommentNesting      int
+
+	// Backtick string state
+	accumulatingBacktickString bool
+	backtickStringValue        string
+	backtickStringStartLine    int
+	backtickStringStartCol     int
+}
+
+// NewLexer creates a new lexer instance
+func NewLexer(input []byte, filePath string) *Lexer {
+	return &Lexer{
+		input:    input,
+		context:  Context{FilePath: filePath},
+		location: LexerLocation{Path: filePath},
+	}
+}

--- a/forst/internal/lexer/lexer.go
+++ b/forst/internal/lexer/lexer.go
@@ -7,52 +7,191 @@ import (
 	"unicode"
 
 	"forst/internal/ast"
+
+	log "github.com/sirupsen/logrus"
 )
 
-// Context for tracking file information
-type Context struct {
-	FilePath string
-}
-
-// Lexer converts Forst code into tokens
-func Lexer(input []byte, ctx Context) []ast.Token {
-	tokens := []ast.Token{}
-	reader := bufio.NewReader(bytes.NewReader(input))
-	path := ctx.FilePath
-	lineNum := 0
+// Lex converts the input into a slice of tokens
+func (l *Lexer) Lex() []ast.Token {
+	reader := bufio.NewReader(bytes.NewReader(l.input))
+	l.location = LexerLocation{
+		Path: l.context.FilePath,
+	}
 
 	for {
 		line, err := reader.ReadBytes('\n')
 		if err != nil && len(line) == 0 {
 			break
 		}
-		lineNum++
+		l.location.LineNum++
 		line = bytes.TrimRight(line, "\n")
-		column := 0
+		l.location.Column = 0
 
-		// Process each word in the line
-		for len(line[column:]) > 0 {
-			// Skip whitespace
-			for column < len(line) && unicode.IsSpace(rune(line[column])) {
-				column++
+		log.Tracef("Processing line %d: %q\n", l.location.LineNum, line)
+
+		// Handle accumulating block comment
+		if l.accumulatingBlockComment {
+			l.blockCommentValue += "\n"
+			for l.location.Column < len(line) {
+				if l.location.Column+1 < len(line) && line[l.location.Column] == '/' && line[l.location.Column+1] == '*' {
+					l.blockCommentValue += "/*"
+					l.blockCommentNesting++
+					l.location.Column += 2
+					continue
+				}
+				if l.location.Column+1 < len(line) && line[l.location.Column] == '*' && line[l.location.Column+1] == '/' {
+					l.blockCommentValue += "*/"
+					l.blockCommentNesting--
+					l.location.Column += 2
+					if l.blockCommentNesting == 0 {
+						// Emit the full block comment token
+						l.storeToken(ast.Token{
+							Type:   ast.TokenComment,
+							Value:  l.blockCommentValue,
+							Path:   l.location.Path,
+							Line:   l.blockCommentStartLine,
+							Column: l.blockCommentStartCol,
+						})
+						l.accumulatingBlockComment = false
+						l.blockCommentValue = ""
+						break
+					}
+					continue
+				}
+				l.blockCommentValue += string(line[l.location.Column])
+				l.location.Column++
 			}
-			if column >= len(line) {
+			if l.accumulatingBlockComment {
+				continue
+			}
+		}
+
+		// Handle accumulating backtick string
+		if l.accumulatingBacktickString {
+			l.backtickStringValue += "\n"
+			lineStart := 0
+			if l.location.Column > 0 {
+				lineStart = l.location.Column
+			}
+			lineRest := line[lineStart:]
+			endIdx := bytes.IndexByte(lineRest, '`')
+			if endIdx != -1 {
+				// Found closing backtick
+				l.backtickStringValue += string(lineRest[:endIdx])
+				// Include backticks in the value
+				valueWithBackticks := "`" + l.backtickStringValue + "`"
+				l.storeToken(ast.Token{
+					Type:   ast.TokenStringLiteral,
+					Value:  valueWithBackticks,
+					Path:   l.location.Path,
+					Line:   l.backtickStringStartLine,
+					Column: l.backtickStringStartCol,
+				})
+				l.accumulatingBacktickString = false
+				l.backtickStringValue = ""
+				l.location.Column = lineStart + endIdx + 1
+				// Continue lexing after the closing backtick
+			} else {
+				l.backtickStringValue += string(lineRest)
+				continue
+			}
+		}
+
+		for len(line[l.location.Column:]) > 0 {
+			for l.location.Column < len(line) && unicode.IsSpace(rune(line[l.location.Column])) {
+				l.location.Column++
+			}
+			if l.location.Column >= len(line) {
 				break
 			}
 
-			// Check for string literals
-			if line[column] == '"' {
-				token, newColumn := processStringLiteral(line, column, path, lineNum)
-				tokens = append(tokens, token)
-				column = newColumn
+			// Handle string literals (double quotes, single quotes)
+			if line[l.location.Column] == '"' || line[l.location.Column] == '\'' {
+				token, newCol := processStringLiteral(line, l.location.Column, l.location.Path, l.location.LineNum)
+				l.storeToken(token)
+				l.location.Column = newCol
+				continue
+			}
+
+			// Handle start of backtick string
+			if line[l.location.Column] == '`' {
+				l.accumulatingBacktickString = true
+				l.backtickStringValue = ""
+				l.backtickStringStartLine = l.location.LineNum
+				l.backtickStringStartCol = l.location.Column + 1
+				// Check if closing backtick is on the same line
+				lineRest := line[l.location.Column+1:]
+				endIdx := bytes.IndexByte(lineRest, '`')
+				if endIdx != -1 {
+					l.backtickStringValue = string(lineRest[:endIdx])
+					// Include backticks in the value
+					valueWithBackticks := "`" + l.backtickStringValue + "`"
+					l.storeToken(ast.Token{
+						Type:   ast.TokenStringLiteral,
+						Value:  valueWithBackticks,
+						Path:   l.location.Path,
+						Line:   l.backtickStringStartLine,
+						Column: l.backtickStringStartCol,
+					})
+					l.accumulatingBacktickString = false
+					l.backtickStringValue = ""
+					l.location.Column += endIdx + 2 // skip both backticks
+					continue
+				} else {
+					l.backtickStringValue = string(line[l.location.Column+1:])
+					// Will continue accumulating in the next line
+					break
+				}
+			}
+
+			// Start of block comment
+			if l.location.Column+1 < len(line) && line[l.location.Column] == '/' && line[l.location.Column+1] == '*' {
+				l.accumulatingBlockComment = true
+				l.blockCommentValue = "/*"
+				l.blockCommentStartLine = l.location.LineNum
+				l.blockCommentStartCol = l.location.Column + 1
+				l.blockCommentNesting = 1
+				l.location.Column += 2
+				for l.location.Column < len(line) {
+					if l.location.Column+1 < len(line) && line[l.location.Column] == '/' && line[l.location.Column+1] == '*' {
+						l.blockCommentValue += "/*"
+						l.blockCommentNesting++
+						l.location.Column += 2
+						continue
+					}
+					if l.location.Column+1 < len(line) && line[l.location.Column] == '*' && line[l.location.Column+1] == '/' {
+						l.blockCommentValue += "*/"
+						l.blockCommentNesting--
+						l.location.Column += 2
+						if l.blockCommentNesting == 0 {
+							l.storeToken(ast.Token{
+								Type:   ast.TokenComment,
+								Value:  l.blockCommentValue,
+								Path:   l.location.Path,
+								Line:   l.blockCommentStartLine,
+								Column: l.blockCommentStartCol,
+							})
+							l.accumulatingBlockComment = false
+							l.blockCommentValue = ""
+							break
+						}
+						continue
+					}
+					l.blockCommentValue += string(line[l.location.Column])
+					l.location.Column++
+				}
+				if l.accumulatingBlockComment {
+					// Continue accumulating in the next line
+					break
+				}
 				continue
 			}
 
 			// Check for special characters that should be separate tokens
-			if isSpecialChar(line[column]) {
-				token, newColumn := processSpecialChar(line, column, path, lineNum)
-				tokens = append(tokens, token)
-				column = newColumn
+			if isSpecialChar(line[l.location.Column]) {
+				token, newColumn := processSpecialChar(line, l.location.Column, l.location.Path, l.location.LineNum)
+				l.storeToken(token)
+				l.location.Column = newColumn
 
 				if token.Type == ast.TokenComment {
 					break
@@ -61,21 +200,27 @@ func Lexer(input []byte, ctx Context) []ast.Token {
 				continue
 			}
 
-			// Process regular words
-			token, newColumn := processWord(line, column, path, lineNum)
-			tokens = append(tokens, token)
-			column = newColumn
+			// Otherwise, process as a word/identifier/number
+			token, newCol := processWord(line, l.location.Column, l.location.Path, l.location.LineNum)
+			l.storeToken(token)
+			l.location.Column = newCol
 		}
 	}
 
-	// End of file token with final line/column position
-	tokens = append(tokens, ast.Token{
+	// Emit EOF token
+	l.storeToken(ast.Token{
 		Type:   ast.TokenEOF,
 		Value:  "",
-		Path:   path,
-		Line:   lineNum,
+		Path:   l.location.Path,
+		Line:   l.location.LineNum + 1,
 		Column: 1,
 	})
 
-	return tokens
+	return l.tokens
+}
+
+// storeToken adds a token to the lexer's token list
+func (l *Lexer) storeToken(token ast.Token) {
+	log.Tracef("Storing token: Type=%q, Value=%q, Line=%d, Column=%d\n", token.Type, token.Value, token.Line, token.Column)
+	l.tokens = append(l.tokens, token)
 }

--- a/forst/internal/lexer/lexer_test.go
+++ b/forst/internal/lexer/lexer_test.go
@@ -1,0 +1,587 @@
+package lexer
+
+import (
+	"forst/internal/ast"
+	"testing"
+)
+
+func TestLexer_BasicTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []ast.Token
+	}{
+		{
+			name:  "identifiers",
+			input: "hello world _123",
+			expected: []ast.Token{
+				{Type: ast.TokenIdentifier, Value: "hello", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenIdentifier, Value: "world", Path: "test.forst", Line: 1, Column: 7},
+				{Type: ast.TokenIdentifier, Value: "_123", Path: "test.forst", Line: 1, Column: 13},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "numbers",
+			input: "123 0x1F 0b1010 0o77 1.23 1e-10 1.23i",
+			expected: []ast.Token{
+				{Type: ast.TokenIntLiteral, Value: "123", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenIntLiteral, Value: "0x1F", Path: "test.forst", Line: 1, Column: 5},
+				{Type: ast.TokenIntLiteral, Value: "0b1010", Path: "test.forst", Line: 1, Column: 10},
+				{Type: ast.TokenIntLiteral, Value: "0o77", Path: "test.forst", Line: 1, Column: 17},
+				{Type: ast.TokenFloatLiteral, Value: "1.23", Path: "test.forst", Line: 1, Column: 22},
+				{Type: ast.TokenFloatLiteral, Value: "1e-10", Path: "test.forst", Line: 1, Column: 27},
+				{Type: ast.TokenFloatLiteral, Value: "1.23i", Path: "test.forst", Line: 1, Column: 33},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "strings",
+			input: `"hello" 'world' ` + "`raw\nstring`",
+			expected: []ast.Token{
+				{Type: ast.TokenStringLiteral, Value: `"hello"`, Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenStringLiteral, Value: "'world'", Path: "test.forst", Line: 1, Column: 9},
+				{Type: ast.TokenStringLiteral, Value: "`raw\nstring`", Path: "test.forst", Line: 1, Column: 17},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "operators",
+			input: "+ - * / % & |",
+			expected: []ast.Token{
+				{Type: ast.TokenPlus, Value: "+", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenMinus, Value: "-", Path: "test.forst", Line: 1, Column: 3},
+				{Type: ast.TokenStar, Value: "*", Path: "test.forst", Line: 1, Column: 5},
+				{Type: ast.TokenDivide, Value: "/", Path: "test.forst", Line: 1, Column: 7},
+				{Type: ast.TokenModulo, Value: "%", Path: "test.forst", Line: 1, Column: 9},
+				{Type: ast.TokenBitwiseAnd, Value: "&", Path: "test.forst", Line: 1, Column: 11},
+				{Type: ast.TokenBitwiseOr, Value: "|", Path: "test.forst", Line: 1, Column: 13},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "comparison operators",
+			input: "== != < <= > >=",
+			expected: []ast.Token{
+				{Type: ast.TokenEquals, Value: "==", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenNotEquals, Value: "!=", Path: "test.forst", Line: 1, Column: 3},
+				{Type: ast.TokenLess, Value: "<", Path: "test.forst", Line: 1, Column: 5},
+				{Type: ast.TokenLessEqual, Value: "<=", Path: "test.forst", Line: 1, Column: 7},
+				{Type: ast.TokenGreater, Value: ">", Path: "test.forst", Line: 1, Column: 9},
+				{Type: ast.TokenGreaterEqual, Value: ">=", Path: "test.forst", Line: 1, Column: 11},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "logical operators",
+			input: "&& || !",
+			expected: []ast.Token{
+				{Type: ast.TokenLogicalAnd, Value: "&&", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenLogicalOr, Value: "||", Path: "test.forst", Line: 1, Column: 3},
+				{Type: ast.TokenLogicalNot, Value: "!", Path: "test.forst", Line: 1, Column: 5},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "delimiters",
+			input: "()[]{}.,;:",
+			expected: []ast.Token{
+				{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 1, Column: 2},
+				{Type: ast.TokenLBracket, Value: "[", Path: "test.forst", Line: 1, Column: 3},
+				{Type: ast.TokenRBracket, Value: "]", Path: "test.forst", Line: 1, Column: 4},
+				{Type: ast.TokenLBrace, Value: "{", Path: "test.forst", Line: 1, Column: 5},
+				{Type: ast.TokenRBrace, Value: "}", Path: "test.forst", Line: 1, Column: 6},
+				{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 1, Column: 7},
+				{Type: ast.TokenComma, Value: ",", Path: "test.forst", Line: 1, Column: 8},
+				{Type: ast.TokenSemicolon, Value: ";", Path: "test.forst", Line: 1, Column: 9},
+				{Type: ast.TokenColon, Value: ":", Path: "test.forst", Line: 1, Column: 10},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLexerTokens(t, tt)
+		})
+	}
+}
+
+func TestLexer_Keywords(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []ast.Token
+	}{
+		{
+			name:  "basic keywords",
+			input: "package import type var const func",
+			expected: []ast.Token{
+				{Type: ast.TokenPackage, Value: "package", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenImport, Value: "import", Path: "test.forst", Line: 1, Column: 9},
+				{Type: ast.TokenType, Value: "type", Path: "test.forst", Line: 1, Column: 15},
+				{Type: ast.TokenVar, Value: "var", Path: "test.forst", Line: 1, Column: 19},
+				{Type: ast.TokenConst, Value: "const", Path: "test.forst", Line: 1, Column: 23},
+				{Type: ast.TokenFunc, Value: "func", Path: "test.forst", Line: 1, Column: 28},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "control flow keywords",
+			input: "if else for range switch case default",
+			expected: []ast.Token{
+				{Type: ast.TokenIf, Value: "if", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenElse, Value: "else", Path: "test.forst", Line: 1, Column: 3},
+				{Type: ast.TokenFor, Value: "for", Path: "test.forst", Line: 1, Column: 5},
+				{Type: ast.TokenRange, Value: "range", Path: "test.forst", Line: 1, Column: 8},
+				{Type: ast.TokenSwitch, Value: "switch", Path: "test.forst", Line: 1, Column: 13},
+				{Type: ast.TokenCase, Value: "case", Path: "test.forst", Line: 1, Column: 19},
+				{Type: ast.TokenDefault, Value: "default", Path: "test.forst", Line: 1, Column: 23},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "type keywords",
+			input: "struct interface map chan",
+			expected: []ast.Token{
+				{Type: ast.TokenStruct, Value: "struct", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenInterface, Value: "interface", Path: "test.forst", Line: 1, Column: 7},
+				{Type: ast.TokenMap, Value: "map", Path: "test.forst", Line: 1, Column: 15},
+				{Type: ast.TokenChan, Value: "chan", Path: "test.forst", Line: 1, Column: 18},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "other keywords",
+			input: "go defer return break continue fallthrough goto",
+			expected: []ast.Token{
+				{Type: ast.TokenGo, Value: "go", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenDefer, Value: "defer", Path: "test.forst", Line: 1, Column: 3},
+				{Type: ast.TokenReturn, Value: "return", Path: "test.forst", Line: 1, Column: 8},
+				{Type: ast.TokenBreak, Value: "break", Path: "test.forst", Line: 1, Column: 14},
+				{Type: ast.TokenContinue, Value: "continue", Path: "test.forst", Line: 1, Column: 19},
+				{Type: ast.TokenFallthrough, Value: "fallthrough", Path: "test.forst", Line: 1, Column: 27},
+				{Type: ast.TokenGoto, Value: "goto", Path: "test.forst", Line: 1, Column: 37},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLexerTokens(t, tt)
+		})
+	}
+}
+
+func TestLexer_Comments(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []ast.Token
+	}{
+		{
+			name:  "line comments",
+			input: "// comment\nx // another comment",
+			expected: []ast.Token{
+				{Type: ast.TokenComment, Value: "// comment", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenIdentifier, Value: "x", Path: "test.forst", Line: 1, Column: 4},
+				{Type: ast.TokenComment, Value: "// another comment", Path: "test.forst", Line: 2, Column: 1},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "block comments",
+			input: "/* comment */ x /* multi\nline\ncomment */",
+			expected: []ast.Token{
+				{Type: ast.TokenComment, Value: "/* comment */", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenIdentifier, Value: "x", Path: "test.forst", Line: 2, Column: 1},
+				{Type: ast.TokenComment, Value: "/* multi\nline\ncomment */", Path: "test.forst", Line: 4, Column: 1},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "nested block comments",
+			input: "/* outer /* inner */ still outer */ x",
+			expected: []ast.Token{
+				{Type: ast.TokenComment, Value: "/* outer /* inner */ still outer */", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenIdentifier, Value: "x", Path: "test.forst", Line: 2, Column: 1},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLexerTokens(t, tt)
+		})
+	}
+}
+
+func TestLexer_StringLiterals(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []ast.Token
+	}{
+		{
+			name:  "double quoted strings",
+			input: `"hello" "world\n" "with \"quote\""`,
+			expected: []ast.Token{
+				{Type: ast.TokenStringLiteral, Value: `"hello"`, Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenStringLiteral, Value: `"world\n"`, Path: "test.forst", Line: 1, Column: 9},
+				{Type: ast.TokenStringLiteral, Value: `"with \"quote\""`, Path: "test.forst", Line: 1, Column: 19},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "raw strings",
+			input: "`hello` `world\n` `with \"quote\"`",
+			expected: []ast.Token{
+				{Type: ast.TokenStringLiteral, Value: "`hello`", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenStringLiteral, Value: "`world\n`", Path: "test.forst", Line: 1, Column: 9},
+				{Type: ast.TokenStringLiteral, Value: "`with \"quote\"`", Path: "test.forst", Line: 1, Column: 19},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "string with escapes",
+			input: `"\\ \n \r \t \v \f \u1234 \U00001234"`,
+			expected: []ast.Token{
+				{Type: ast.TokenStringLiteral, Value: `"\\ \n \r \t \v \f \u1234 \U00001234"`, Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLexerTokens(t, tt)
+		})
+	}
+}
+
+func TestLexer_Whitespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []ast.Token
+	}{
+		{
+			name:  "spaces and tabs",
+			input: "x  y\tz",
+			expected: []ast.Token{
+				{Type: ast.TokenIdentifier, Value: "x", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenIdentifier, Value: "y", Path: "test.forst", Line: 1, Column: 3},
+				{Type: ast.TokenIdentifier, Value: "z", Path: "test.forst", Line: 1, Column: 5},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "newlines",
+			input: "x\ny\nz",
+			expected: []ast.Token{
+				{Type: ast.TokenIdentifier, Value: "x", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenIdentifier, Value: "y", Path: "test.forst", Line: 2, Column: 1},
+				{Type: ast.TokenIdentifier, Value: "z", Path: "test.forst", Line: 3, Column: 1},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "mixed whitespace",
+			input: "x \t\ny \n\tz",
+			expected: []ast.Token{
+				{Type: ast.TokenIdentifier, Value: "x", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenIdentifier, Value: "y", Path: "test.forst", Line: 2, Column: 3},
+				{Type: ast.TokenIdentifier, Value: "z", Path: "test.forst", Line: 3, Column: 5},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLexerTokens(t, tt)
+		})
+	}
+}
+
+func TestLexer_ComplexProgram(t *testing.T) {
+	tt := struct {
+		name     string
+		input    string
+		expected []ast.Token
+	}{
+		name: "complex program",
+		input: `
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+type Point struct {
+	X, Y float64
+}
+
+func (p *Point) Distance(q *Point) float64 {
+	return math.Sqrt(math.Pow(p.X-q.X, 2) + math.Pow(p.Y-q.Y, 2))
+}
+
+func main() {
+	p1 := &Point{X: 1, Y: 2}
+	p2 := &Point{X: 4, Y: 6}
+	
+	if dist := p1.Distance(p2); dist > 5 {
+		fmt.Println("Points are far apart:", dist)
+	} else {
+		fmt.Println("Points are close:", dist)
+	}
+}
+`,
+		expected: []ast.Token{
+			{Type: ast.TokenPackage, Value: "package", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "main", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenImport, Value: "import", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenStringLiteral, Value: "\"fmt\"", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenStringLiteral, Value: "\"math\"", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenType, Value: "type", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Point", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenStruct, Value: "struct", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLBrace, Value: "{", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "X", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenComma, Value: ",", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Y", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "float64", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRBrace, Value: "}", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenFunc, Value: "func", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "p", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenStar, Value: "*", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Point", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Distance", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "q", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenStar, Value: "*", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Point", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "float64", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLBrace, Value: "{", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenReturn, Value: "return", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "math", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Sqrt", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "math", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Pow", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "p", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "X", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenMinus, Value: "-", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "q", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "X", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenComma, Value: ",", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIntLiteral, Value: "2", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenPlus, Value: "+", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "math", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Pow", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "p", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Y", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenMinus, Value: "-", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "q", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Y", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenComma, Value: ",", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIntLiteral, Value: "2", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRBrace, Value: "}", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenFunc, Value: "func", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "main", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLBrace, Value: "{", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "p1", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenColonEquals, Value: ":=", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenBitwiseAnd, Value: "&", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Point", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLBrace, Value: "{", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "X", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenColon, Value: ":", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIntLiteral, Value: "1", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenComma, Value: ",", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Y", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenColon, Value: ":", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIntLiteral, Value: "2", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRBrace, Value: "}", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "p2", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenColonEquals, Value: ":=", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenBitwiseAnd, Value: "&", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Point", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLBrace, Value: "{", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "X", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenColon, Value: ":", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIntLiteral, Value: "4", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenComma, Value: ",", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Y", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenColon, Value: ":", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIntLiteral, Value: "6", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRBrace, Value: "}", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIf, Value: "if", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "dist", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenColonEquals, Value: ":=", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "p1", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Distance", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "p2", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenSemicolon, Value: ";", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "dist", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenGreater, Value: ">", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIntLiteral, Value: "5", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLBrace, Value: "{", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "fmt", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Println", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenStringLiteral, Value: "\"Points are far apart:\"", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenComma, Value: ",", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "dist", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRBrace, Value: "}", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenElse, Value: "else", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLBrace, Value: "{", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "fmt", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenDot, Value: ".", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "Println", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenLParen, Value: "(", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenStringLiteral, Value: "\"Points are close:\"", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenComma, Value: ",", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenIdentifier, Value: "dist", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRParen, Value: ")", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRBrace, Value: "}", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenRBrace, Value: "}", Path: "test.forst", Line: 0, Column: 0},
+			{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 0, Column: 0},
+		},
+	}
+	testLexerTokens(t, tt)
+}
+
+func TestLexer_Simple(t *testing.T) {
+	tt := struct {
+		name     string
+		input    string
+		expected []ast.Token
+	}{
+		name:  "simple",
+		input: "hello world",
+		expected: []ast.Token{
+			{Type: ast.TokenIdentifier, Value: "hello", Path: "test.forst", Line: 1, Column: 1},
+			{Type: ast.TokenIdentifier, Value: "world", Path: "test.forst", Line: 1, Column: 7},
+			{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+		},
+	}
+	testLexerTokens(t, tt)
+}
+
+func TestLexer_UnsupportedTokens(t *testing.T) {
+	t.Skip("These tokens are not yet implemented in Forst")
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []ast.Token
+	}{
+		{
+			name:  "bitwise operators",
+			input: "^ << >> &^",
+			expected: []ast.Token{
+				// {Type: ast.TokenXor, Value: "^", Path: "test.forst", Line: 1, Column: 1},
+				// {Type: ast.TokenLShift, Value: "<<", Path: "test.forst", Line: 1, Column: 3},
+				// {Type: ast.TokenRShift, Value: ">>", Path: "test.forst", Line: 1, Column: 6},
+				// {Type: ast.TokenAndNot, Value: "&^", Path: "test.forst", Line: 1, Column: 9},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "compound assignment operators",
+			input: "+= -= *= /= %= &= |= ^= <<= >>= &^=",
+			expected: []ast.Token{
+				// {Type: ast.TokenPlusEq, Value: "+=", Path: "test.forst", Line: 1, Column: 1},
+				// {Type: ast.TokenMinusEq, Value: "-=", Path: "test.forst", Line: 1, Column: 4},
+				// {Type: ast.TokenStarEq, Value: "*=", Path: "test.forst", Line: 1, Column: 7},
+				// {Type: ast.TokenSlashEq, Value: "/=", Path: "test.forst", Line: 1, Column: 10},
+				// {Type: ast.TokenPercentEq, Value: "%=", Path: "test.forst", Line: 1, Column: 13},
+				// {Type: ast.TokenAndEq, Value: "&=", Path: "test.forst", Line: 1, Column: 16},
+				// {Type: ast.TokenOrEq, Value: "|=", Path: "test.forst", Line: 1, Column: 19},
+				// {Type: ast.TokenXorEq, Value: "^=", Path: "test.forst", Line: 1, Column: 22},
+				// {Type: ast.TokenLShiftEq, Value: "<<=", Path: "test.forst", Line: 1, Column: 25},
+				// {Type: ast.TokenRShiftEq, Value: ">>=", Path: "test.forst", Line: 1, Column: 29},
+				// {Type: ast.TokenAndNotEq, Value: "&^=", Path: "test.forst", Line: 1, Column: 33},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+		{
+			name:  "ellipsis",
+			input: "...",
+			expected: []ast.Token{
+				// {Type: ast.TokenEllipsis, Value: "...", Path: "test.forst", Line: 1, Column: 1},
+				{Type: ast.TokenEOF, Value: "", Path: "test.forst", Line: 2, Column: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLexerTokens(t, tt)
+		})
+	}
+}
+
+func testLexerTokens(t *testing.T, tt struct {
+	name     string
+	input    string
+	expected []ast.Token
+}) {
+	l := NewLexer([]byte(tt.input), "test.forst")
+	tokens := l.Lex()
+
+	if len(tokens) != len(tt.expected) {
+		if testing.Verbose() {
+			t.Logf("Expected tokens:")
+			for i, exp := range tt.expected {
+				t.Logf("  [%d] Type: %q, Value: %q", i, exp.Type, exp.Value)
+			}
+			t.Logf("Actual tokens:")
+			for i, tok := range tokens {
+				t.Logf("  [%d] Type: %q, Value: %q", i, tok.Type, tok.Value)
+			}
+		}
+		t.Errorf("expected %d tokens, got %d", len(tt.expected), len(tokens))
+		return
+	}
+
+	for i, exp := range tt.expected {
+		if tokens[i].Type != exp.Type {
+			t.Errorf("token[%d] - type wrong. expected=%q, got=%q",
+				i, exp.Type, tokens[i].Type)
+		}
+		if tokens[i].Value != exp.Value {
+			t.Errorf("token[%d] - value wrong. expected=%q, got=%q",
+				i, exp.Value, tokens[i].Value)
+		}
+	}
+}

--- a/forst/internal/lexer/process.go
+++ b/forst/internal/lexer/process.go
@@ -8,15 +8,42 @@ import (
 // Token processing functions
 func processStringLiteral(line []byte, startCol int, path string, lineNum int) (ast.Token, int) {
 	column := startCol
+	quoteChar := line[column]
 	column++ // Move past opening quote
-	for column < len(line) && line[column] != '"' {
+
+	// For backtick strings, we don't need to handle escapes
+	if quoteChar == '`' {
+		for column < len(line) && line[column] != '`' {
+			column++
+		}
+		if column < len(line) {
+			column++ // Move past closing backtick
+		}
+		word := string(line[startCol:column])
+		return ast.Token{
+			Path:   path,
+			Line:   lineNum,
+			Column: startCol + 1,
+			Value:  word,
+			Type:   ast.TokenStringLiteral,
+		}, column
+	}
+
+	// For double and single quoted strings, handle escapes
+	for column < len(line) {
+		if line[column] == '\\' {
+			column += 2 // Skip the escape sequence
+			continue
+		}
+		if line[column] == quoteChar {
+			column++ // Move past closing quote
+			break
+		}
 		column++
 	}
-	if column < len(line) {
-		column++ // Move past closing quote
-	}
+
 	word := string(line[startCol:column])
-	
+
 	return ast.Token{
 		Path:   path,
 		Line:   lineNum,
@@ -35,6 +62,22 @@ func processSpecialChar(line []byte, startCol int, path string, lineNum int) (as
 	}
 	word := string(line[startCol:column])
 
+	// Special handling for line comments
+	if word == "//" {
+		commentContent := "//"
+		for column < len(line) {
+			commentContent += string(line[column])
+			column++
+		}
+		return ast.Token{
+			Path:   path,
+			Line:   lineNum,
+			Column: startCol + 1,
+			Value:  commentContent,
+			Type:   ast.TokenComment,
+		}, column
+	}
+
 	token := ast.Token{
 		Path:   path,
 		Line:   lineNum,
@@ -42,12 +85,72 @@ func processSpecialChar(line []byte, startCol int, path string, lineNum int) (as
 		Value:  word,
 		Type:   GetTokenType(word),
 	}
-	
+
 	return token, column
 }
 
 func processWord(line []byte, startCol int, path string, lineNum int) (ast.Token, int) {
 	column := startCol
+	// Special handling for numbers
+	if isDigit(line[column]) {
+		hasDecimal := false
+		hasExponent := false
+		hasImaginary := false
+
+		// Check for base prefix
+		if line[column] == '0' && column+1 < len(line) {
+			if line[column+1] == 'x' || line[column+1] == 'X' {
+				column += 2
+			} else if line[column+1] == 'b' || line[column+1] == 'B' {
+				column += 2
+			} else if line[column+1] == 'o' || line[column+1] == 'O' {
+				column += 2
+			}
+		}
+
+		// Parse digits
+		for column < len(line) {
+			c := line[column]
+			if c == '.' && !hasDecimal && !hasExponent {
+				hasDecimal = true
+				column++
+				continue
+			}
+			if (c == 'e' || c == 'E') && !hasExponent {
+				hasExponent = true
+				column++
+				if column < len(line) && (line[column] == '+' || line[column] == '-') {
+					column++
+				}
+				continue
+			}
+			if c == 'i' && !hasImaginary {
+				hasImaginary = true
+				column++
+				break
+			}
+			if !isDigit(c) && !unicode.IsLetter(rune(c)) {
+				break
+			}
+			column++
+		}
+
+		word := string(line[startCol:column])
+		tokenType := ast.TokenIntLiteral
+		if hasDecimal || hasExponent || hasImaginary {
+			tokenType = ast.TokenFloatLiteral
+		}
+
+		return ast.Token{
+			Path:   path,
+			Line:   lineNum,
+			Column: startCol + 1,
+			Value:  word,
+			Type:   tokenType,
+		}, column
+	}
+
+	// Regular word processing
 	for column < len(line) && !unicode.IsSpace(rune(line[column])) && !isSpecialChar(line[column]) {
 		column++
 	}

--- a/forst/internal/lexer/tokens.go
+++ b/forst/internal/lexer/tokens.go
@@ -10,7 +10,7 @@ func GetTokenType(word string) ast.TokenIdent {
 	case "//":
 		return ast.TokenComment
 	case "func":
-		return ast.TokenFunction
+		return ast.TokenFunc
 	case "import":
 		return ast.TokenImport
 	case "package":
@@ -54,7 +54,7 @@ func GetTokenType(word string) ast.TokenIdent {
 	case "-":
 		return ast.TokenMinus
 	case "*":
-		return ast.TokenMultiply
+		return ast.TokenStar
 	case "/":
 		return ast.TokenDivide
 	case "%":
@@ -101,6 +101,8 @@ func GetTokenType(word string) ast.TokenIdent {
 		return ast.TokenElse
 	case "for":
 		return ast.TokenFor
+	case "range":
+		return ast.TokenRange
 	case "break":
 		return ast.TokenBreak
 	case "continue":
@@ -115,6 +117,8 @@ func GetTokenType(word string) ast.TokenIdent {
 		return ast.TokenFallthrough
 	case "var":
 		return ast.TokenVar
+	case "const":
+		return ast.TokenConst
 	case "map":
 		return ast.TokenMap
 	case "chan":
@@ -125,11 +129,19 @@ func GetTokenType(word string) ast.TokenIdent {
 		return ast.TokenInterface
 	case "struct":
 		return ast.TokenStruct
+	case "go":
+		return ast.TokenGo
+	case "defer":
+		return ast.TokenDefer
+	case "goto":
+		return ast.TokenGoto
 	default:
 		if isDigit(word[0]) {
-			lastChar := word[len(word)-1]
-			if lastChar == 'f' {
-				return ast.TokenFloatLiteral
+			// Check for float literals
+			for i := 0; i < len(word); i++ {
+				if word[i] == '.' || word[i] == 'e' || word[i] == 'E' || word[i] == 'i' {
+					return ast.TokenFloatLiteral
+				}
 			}
 			return ast.TokenIntLiteral
 		}

--- a/forst/internal/parser/function.go
+++ b/forst/internal/parser/function.go
@@ -127,7 +127,7 @@ func (p *Parser) parseFunctionBody() []ast.Node {
 
 // Parse a function definition
 func (p *Parser) parseFunctionDefinition() ast.FunctionNode {
-	p.expect(ast.TokenFunction)           // Expect `fn`
+	p.expect(ast.TokenFunc)               // Expect `fn`
 	name := p.expect(ast.TokenIdentifier) // Function name
 
 	p.context.Scope.functionName = name.Value

--- a/forst/internal/parser/parse.go
+++ b/forst/internal/parser/parse.go
@@ -57,7 +57,7 @@ func (p *Parser) ParseFile() ([]ast.Node, error) {
 			typeDef := p.parseTypeDef()
 			logParsedNodeWithMessage(typeDef, "Parsed type def")
 			nodes = append(nodes, *typeDef)
-		case ast.TokenFunction:
+		case ast.TokenFunc:
 			p.context.Scope = &Scope{
 				Variables: make(map[string]ast.TypeNode),
 			}

--- a/forst/internal/parser/parse_test.go
+++ b/forst/internal/parser/parse_test.go
@@ -130,7 +130,7 @@ func TestParseFile_WithFunctions(t *testing.T) {
 		{
 			name: "basic function with parameter",
 			tokens: []ast.Token{
-				{Type: ast.TokenFunction, Value: "func", Line: 1, Column: 1},
+				{Type: ast.TokenFunc, Value: "func", Line: 1, Column: 1},
 				{Type: ast.TokenIdentifier, Value: "main", Line: 1, Column: 6},
 				{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 9},
 				{Type: ast.TokenIdentifier, Value: "x", Line: 1, Column: 10},
@@ -159,7 +159,7 @@ func TestParseFile_WithFunctions(t *testing.T) {
 		{
 			name: "function with ensure statement",
 			tokens: []ast.Token{
-				{Type: ast.TokenFunction, Value: "func", Line: 1, Column: 1},
+				{Type: ast.TokenFunc, Value: "func", Line: 1, Column: 1},
 				{Type: ast.TokenIdentifier, Value: "main", Line: 1, Column: 6},
 				{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 9},
 				{Type: ast.TokenIdentifier, Value: "x", Line: 1, Column: 10},
@@ -305,7 +305,7 @@ func TestParseFile_WithTypeGuards(t *testing.T) {
 
 func TestParseFile_WithBinaryExpressionInFunction(t *testing.T) {
 	tokens := []ast.Token{
-		{Type: ast.TokenFunction, Value: "func", Line: 1, Column: 1},
+		{Type: ast.TokenFunc, Value: "func", Line: 1, Column: 1},
 		{Type: ast.TokenIdentifier, Value: "passwordStrength", Line: 1, Column: 6},
 		{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 14},
 		{Type: ast.TokenIdentifier, Value: "password", Line: 1, Column: 15},
@@ -356,7 +356,7 @@ func TestParseFile_WithMapLiterals(t *testing.T) {
 		{
 			name: "basic map literal",
 			tokens: []ast.Token{
-				{Type: ast.TokenFunction, Value: "func", Line: 1, Column: 1},
+				{Type: ast.TokenFunc, Value: "func", Line: 1, Column: 1},
 				{Type: ast.TokenIdentifier, Value: "main", Line: 1, Column: 6},
 				{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 9},
 				{Type: ast.TokenRParen, Value: ")", Line: 1, Column: 10},
@@ -416,7 +416,7 @@ func TestParseFile_WithMapLiterals(t *testing.T) {
 		{
 			name: "empty map literal",
 			tokens: []ast.Token{
-				{Type: ast.TokenFunction, Value: "func", Line: 1, Column: 1},
+				{Type: ast.TokenFunc, Value: "func", Line: 1, Column: 1},
 				{Type: ast.TokenIdentifier, Value: "main", Line: 1, Column: 6},
 				{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 9},
 				{Type: ast.TokenRParen, Value: ")", Line: 1, Column: 10},
@@ -481,7 +481,7 @@ func TestParseFile_WithReferences(t *testing.T) {
 		{
 			name: "reference to variable",
 			tokens: []ast.Token{
-				{Type: ast.TokenFunction, Value: "func", Line: 1, Column: 1},
+				{Type: ast.TokenFunc, Value: "func", Line: 1, Column: 1},
 				{Type: ast.TokenIdentifier, Value: "main", Line: 1, Column: 6},
 				{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 9},
 				{Type: ast.TokenRParen, Value: ")", Line: 1, Column: 10},
@@ -545,7 +545,7 @@ func TestParseFile_WithControlFlow(t *testing.T) {
 		{
 			name: "if statement with init",
 			tokens: []ast.Token{
-				{Type: ast.TokenFunction, Value: "func", Line: 1, Column: 1},
+				{Type: ast.TokenFunc, Value: "func", Line: 1, Column: 1},
 				{Type: ast.TokenIdentifier, Value: "main", Line: 1, Column: 6},
 				{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 9},
 				{Type: ast.TokenRParen, Value: ")", Line: 1, Column: 10},
@@ -604,7 +604,7 @@ func TestParseFile_WithControlFlow(t *testing.T) {
 		{
 			name: "if statement with else-if and else",
 			tokens: []ast.Token{
-				{Type: ast.TokenFunction, Value: "func", Line: 1, Column: 1},
+				{Type: ast.TokenFunc, Value: "func", Line: 1, Column: 1},
 				{Type: ast.TokenIdentifier, Value: "main", Line: 1, Column: 6},
 				{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 9},
 				{Type: ast.TokenRParen, Value: ")", Line: 1, Column: 10},

--- a/forst/internal/transformer/go/expression.go
+++ b/forst/internal/transformer/go/expression.go
@@ -38,7 +38,7 @@ func transformOperator(op ast.TokenIdent) token.Token {
 		return token.ADD
 	case ast.TokenMinus:
 		return token.SUB
-	case ast.TokenMultiply:
+	case ast.TokenStar:
 		return token.MUL
 	case ast.TokenDivide:
 		return token.QUO


### PR DESCRIPTION
# Lexer Improvements and Token Standardization

This PR introduces significant improvements to the lexer implementation and standardizes token handling across the Forst codebase.

## Changes

### 1. Token Type Standardization
- Renamed `TokenFunction` to `TokenFunc` for consistency with Go's syntax
- Renamed `TokenMultiply` to `TokenStar` to match common lexer conventions
- Added support for new tokens: `TokenRange`, `TokenConst`, `TokenGo`, `TokenDefer`, `TokenGoto`

### 2. String Literal Handling
- Improved string literal processing with proper handling of different quote types
- Added special handling for backtick strings without escape sequence processing
- Enhanced escape sequence handling for double and single quoted strings

### 3. Number Literal Processing
- Added comprehensive number literal parsing support
- Implemented handling for:
  - Decimal numbers
  - Hexadecimal numbers (0x prefix)
  - Binary numbers (0b prefix)
  - Octal numbers (0o prefix)
  - Floating point numbers
  - Scientific notation
  - Complex numbers (i suffix)

### 4. Comment Processing
- Added proper line comment handling
- Improved comment token generation

### 5. Test Coverage
- Added extensive test cases for all token types
- Included complex program test case
- Added tests for whitespace handling
- Added tests for unsupported tokens (marked as skipped)

## Future Work

Some token types are currently marked as unsupported and skipped in tests:
- Bitwise operators (^, <<, >>, &^)
- Compound assignment operators (+=, -=, *=, etc.)
- Ellipsis (...)