### PR TITLE
chore: Increase test coverage for CLI code

### DIFF
--- a/forst/cmd/forst/args_test.go
+++ b/forst/cmd/forst/args_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		want     ProgramArgs
+		wantHelp bool
+	}{
+		{
+			name: "run command with file",
+			args: []string{"forst", "run", "test.ft"},
+			want: ProgramArgs{
+				command:  "run",
+				filePath: "test.ft",
+			},
+			wantHelp: false,
+		},
+		{
+			name: "build command with file",
+			args: []string{"forst", "build", "test.ft"},
+			want: ProgramArgs{
+				command:  "build",
+				filePath: "test.ft",
+			},
+			wantHelp: false,
+		},
+		{
+			name: "run with debug flag",
+			args: []string{"forst", "run", "-debug", "test.ft"},
+			want: ProgramArgs{
+				command:  "run",
+				filePath: "test.ft",
+				debug:    true,
+			},
+			wantHelp: false,
+		},
+		{
+			name: "run with watch and output",
+			args: []string{"forst", "run", "-watch", "-o", "output.go", "test.ft"},
+			want: ProgramArgs{
+				command:    "run",
+				filePath:   "test.ft",
+				watch:      true,
+				outputPath: "output.go",
+			},
+			wantHelp: false,
+		},
+		{
+			name:     "help flag",
+			args:     []string{"forst", "--help"},
+			want:     ProgramArgs{},
+			wantHelp: true,
+		},
+		{
+			name:     "invalid command",
+			args:     []string{"forst", "invalid", "test.ft"},
+			want:     ProgramArgs{},
+			wantHelp: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original args and restore after test
+			origArgs := os.Args
+			defer func() { os.Args = origArgs }()
+
+			os.Args = tt.args
+
+			if tt.wantHelp {
+				// Help flag should cause os.Exit(0)
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected ParseArgs() to exit with status 0 for help flag")
+					}
+				}()
+			}
+
+			got := ParseArgs()
+
+			// Compare fields
+			if got.command != tt.want.command {
+				t.Errorf("ParseArgs().command = %v, want %v", got.command, tt.want.command)
+			}
+			if got.filePath != tt.want.filePath {
+				t.Errorf("ParseArgs().filePath = %v, want %v", got.filePath, tt.want.filePath)
+			}
+			if got.debug != tt.want.debug {
+				t.Errorf("ParseArgs().debug = %v, want %v", got.debug, tt.want.debug)
+			}
+			if got.watch != tt.want.watch {
+				t.Errorf("ParseArgs().watch = %v, want %v", got.watch, tt.want.watch)
+			}
+			if got.outputPath != tt.want.outputPath {
+				t.Errorf("ParseArgs().outputPath = %v, want %v", got.outputPath, tt.want.outputPath)
+			}
+		})
+	}
+}
+
+func TestInvalidArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "no arguments",
+			args: []string{"forst"},
+		},
+		{
+			name: "no file specified",
+			args: []string{"forst", "run"},
+		},
+		{
+			name: "build with watch",
+			args: []string{"forst", "build", "-watch", "test.ft"},
+		},
+		{
+			name: "watch without output",
+			args: []string{"forst", "run", "-watch", "test.ft"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original args and restore after test
+			origArgs := os.Args
+			defer func() { os.Args = origArgs }()
+
+			os.Args = tt.args
+			got := ParseArgs()
+
+			if got != (ProgramArgs{}) {
+				t.Errorf("ParseArgs() = %v, want empty ProgramArgs for invalid args", got)
+			}
+		})
+	}
+}

--- a/forst/cmd/forst/debug_test.go
+++ b/forst/cmd/forst/debug_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"forst/internal/ast"
+	"forst/internal/typechecker"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TestHook is a custom hook to capture log entries
+type TestHook struct {
+	entries []*logrus.Entry
+}
+
+func (h *TestHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *TestHook) Fire(entry *logrus.Entry) error {
+	h.entries = append(h.entries, entry)
+	return nil
+}
+
+func (h *TestHook) Reset() {
+	h.entries = nil
+}
+
+func (h *TestHook) ContainsMessage(msg string) bool {
+	for _, entry := range h.entries {
+		// Check the message field
+		if strings.Contains(entry.Message, msg) {
+			return true
+		}
+		// Check all fields
+		for k, v := range entry.Data {
+			if strings.Contains(k, msg) || strings.Contains(fmt.Sprint(v), msg) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var testHook = &TestHook{}
+
+func init() {
+	// Set log level to debug for testing
+	logrus.SetLevel(logrus.DebugLevel)
+	// Add our test hook
+	logrus.AddHook(testHook)
+}
+
+func TestLogMemUsage(t *testing.T) {
+	testHook.Reset()
+
+	// Create a program with memory reporting enabled
+	program := &Program{
+		Args: ProgramArgs{
+			reportMemoryUsage: true,
+		},
+	}
+
+	// Get initial memory stats
+	before := runtime.MemStats{}
+	runtime.ReadMemStats(&before)
+
+	// Allocate some memory
+	_ = make([]byte, 1024*1024) // 1MB allocation
+
+	// Get memory stats after allocation
+	after := runtime.MemStats{}
+	runtime.ReadMemStats(&after)
+
+	// Test memory usage logging
+	program.logMemUsage("test_phase", before, after)
+
+	// Verify that memory usage was logged
+	if !testHook.ContainsMessage("test_phase") {
+		t.Error("Expected memory usage log to contain 'test_phase'")
+	}
+	if !testHook.ContainsMessage("allocatedBytes") {
+		t.Error("Expected memory usage log to contain 'allocatedBytes'")
+	}
+}
+
+func TestDebugPrintTokens(t *testing.T) {
+	testHook.Reset()
+
+	// Create a program with debug enabled
+	program := &Program{
+		Args: ProgramArgs{
+			debug: true,
+		},
+	}
+
+	// Create test tokens
+	tokens := []ast.Token{
+		{
+			Type:   ast.TokenIdentifier,
+			Value:  "test",
+			Path:   "test.ft",
+			Line:   1,
+			Column: 1,
+		},
+		{
+			Type:   ast.TokenIntLiteral,
+			Value:  "42",
+			Path:   "test.ft",
+			Line:   1,
+			Column: 6,
+		},
+	}
+
+	// Test token printing
+	program.debugPrintTokens(tokens)
+
+	// Verify that tokens were logged
+	if !testHook.ContainsMessage("IDENTIFIER") {
+		t.Error("Expected token log to contain 'IDENTIFIER'")
+	}
+	if !testHook.ContainsMessage("INT_LITERAL") {
+		t.Error("Expected token log to contain 'INT_LITERAL'")
+	}
+}
+
+func TestDebugPrintForstAST(t *testing.T) {
+	testHook.Reset()
+
+	// Create a program with debug enabled
+	program := &Program{
+		Args: ProgramArgs{
+			debug: true,
+		},
+	}
+
+	// Create test AST nodes
+	nodes := []ast.Node{
+		ast.PackageNode{Ident: ast.Ident{ID: "main"}},
+		ast.ImportNode{Path: "fmt"},
+		ast.FunctionNode{
+			Ident:       ast.Ident{ID: "main"},
+			ReturnTypes: []ast.TypeNode{{Ident: ast.TypeVoid}},
+			Body:        []ast.Node{},
+		},
+	}
+
+	// Test AST printing
+	program.debugPrintForstAST(nodes)
+
+	// Verify that AST nodes were logged
+	if !testHook.ContainsMessage("Package declaration") {
+		t.Error("Expected AST log to contain 'Package declaration'")
+	}
+	if !testHook.ContainsMessage("Import") {
+		t.Error("Expected AST log to contain 'Import'")
+	}
+}
+
+func TestDebugPrintTypeInfo(t *testing.T) {
+	testHook.Reset()
+
+	// Create a program with debug enabled
+	program := &Program{
+		Args: ProgramArgs{
+			debug: true,
+		},
+	}
+
+	// Create a type checker with some test data
+	tc := typechecker.New()
+	tc.Functions["main"] = typechecker.FunctionSignature{
+		Ident: ast.Ident{ID: "main"},
+		Parameters: []typechecker.ParameterSignature{
+			{
+				Ident: ast.Ident{ID: "x"},
+				Type:  ast.TypeNode{Ident: ast.TypeInt},
+			},
+		},
+		ReturnTypes: []ast.TypeNode{
+			{Ident: ast.TypeVoid},
+		},
+	}
+
+	tc.Defs["x"] = ast.TypeDefNode{
+		Ident: ast.TypeIdent("x"),
+		Expr:  ast.TypeDefAssertionExpr{},
+	}
+
+	// Test type info printing
+	program.debugPrintTypeInfo(tc)
+
+	// Verify that type info was logged
+	if !testHook.ContainsMessage("function signature") {
+		t.Error("Expected type info log to contain 'function signature'")
+	}
+	if !testHook.ContainsMessage("definition") {
+		t.Error("Expected type info log to contain 'definition'")
+	}
+}

--- a/forst/cmd/forst/program_test.go
+++ b/forst/cmd/forst/program_test.go
@@ -53,7 +53,13 @@ func TestTempOutputFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createTempOutputFile() error = %v", err)
 	}
-	defer os.RemoveAll(filepath.Dir(outputPath))
+
+	defer func() {
+		err := os.RemoveAll(filepath.Dir(outputPath))
+		if err != nil {
+			t.Errorf("Failed to remove temporary output file: %v", err)
+		}
+	}()
 
 	// Verify the file exists
 	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
@@ -78,7 +84,13 @@ func TestRunGoProgram(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test program: %v", err)
 	}
-	defer os.RemoveAll(filepath.Dir(outputPath))
+
+	defer func() {
+		err := os.RemoveAll(filepath.Dir(outputPath))
+		if err != nil {
+			t.Errorf("Failed to remove temporary output file: %v", err)
+		}
+	}()
 
 	// Test running the program
 	err = runGoProgram(outputPath)

--- a/forst/cmd/forst/program_test.go
+++ b/forst/cmd/forst/program_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProgramCompilation(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		wantErr  bool
+	}{
+		{
+			name:     "valid basic program",
+			filePath: "../../../examples/in/basic.ft",
+			wantErr:  false,
+		},
+		{
+			name:     "non-existent file",
+			filePath: "nonexistent.ft",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program := &Program{
+				Args: ProgramArgs{
+					command:  "run",
+					filePath: tt.filePath,
+				},
+			}
+
+			code, err := program.compileFile()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Program.compileFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && code == nil {
+				t.Error("Program.compileFile() returned nil code for successful compilation")
+			}
+		})
+	}
+}
+
+func TestTempOutputFile(t *testing.T) {
+	testCode := "package main\n\nfunc main() {\n\tprintln(\"Hello, World!\")\n}"
+
+	outputPath, err := createTempOutputFile(testCode)
+	if err != nil {
+		t.Fatalf("createTempOutputFile() error = %v", err)
+	}
+	defer os.RemoveAll(filepath.Dir(outputPath))
+
+	// Verify the file exists
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Error("createTempOutputFile() did not create the output file")
+	}
+
+	// Verify the content
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read created file: %v", err)
+	}
+
+	if string(content) != testCode {
+		t.Errorf("createTempOutputFile() content = %v, want %v", string(content), testCode)
+	}
+}
+
+func TestRunGoProgram(t *testing.T) {
+	// Create a temporary test program
+	testCode := "package main\n\nfunc main() {\n\tprintln(\"Hello, World!\")\n}"
+	outputPath, err := createTempOutputFile(testCode)
+	if err != nil {
+		t.Fatalf("Failed to create test program: %v", err)
+	}
+	defer os.RemoveAll(filepath.Dir(outputPath))
+
+	// Test running the program
+	err = runGoProgram(outputPath)
+	if err != nil {
+		t.Errorf("runGoProgram() error = %v", err)
+	}
+}


### PR DESCRIPTION
# Split CLI Tests into Separate Files

This PR improves test organization by splitting the CLI tests into separate files based on functionality. Each test file now focuses on a specific component of the CLI:

## Changes

- Created `args_test.go` for command-line argument parsing tests
- Created `debug_test.go` for debug functionality tests
- Created `program_test.go` for core program functionality tests