### PR TITLE
feat(lsp): add document symbols, references, and workspace symbol search

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,7 +84,7 @@ Themes group work (language, interop, tooling, docs, infrastructure). Priority a
 
 ## Tooling & developer experience
 
-**LSP (`forst lsp`):** The server exposes **JSON-RPC over HTTP** (`POST /` on the listener port), not stdio—editors need a small bridge (the in-repo VS Code extension does this). **`initialize`** returns a wide **ServerCapabilities** set (hover, completion, diagnostics, definition/references, symbols, formatting, code actions, code lens, folding, plus **experimental** debug flags). Behavior below is what **`handleLSPMethod`** in `forst/cmd/forst/lsp/` actually implements vs advertises; **go to definition** is implemented for same-file top-level names (see `definition.go`).
+**LSP (`forst lsp`):** The server exposes **JSON-RPC over HTTP** (`POST /` on the listener port), not stdio—editors need a small bridge (the in-repo VS Code extension does this). **`initialize`** returns a wide **ServerCapabilities** set (hover, completion, diagnostics, definition/references, symbols, formatting, code actions, code lens, folding, plus **experimental** debug flags). Behavior below is what **`handleLSPMethod`** in `forst/cmd/forst/lsp/` actually implements vs advertises. **Navigation:** same-file **go to definition**, **find references**, **document symbol**, and **workspace symbol** (open buffers only) for top-level functions, user types, and type guards—shared pipeline in `analyze.go`, `definition.go`, `references.go`, `symbols.go`.
 
 | Feature | Status | Notes |
 | --- | --- | --- |
@@ -94,18 +94,18 @@ Themes group work (language, interop, tooling, docs, infrastructure). Priority a
 | LSP: text document sync | done | `didOpen` / `didChange` / `didClose`: in-memory `openDocuments` per URI; `didChange` stores the **last** `contentChanges` entry’s `text` as the full buffer and recompiles. Drives diagnostics on each update. |
 | LSP: diagnostics | done | `compileForstFile`: lexer → parser → typechecker; builds `LSPDiagnostic` ranges from compiler errors. `didOpen` / `didChange` / `didClose` responses include `PublishDiagnosticsParams`; `sendDiagnosticsNotification` supports push-style clients. |
 | LSP: hover (`textDocument/hover`) | in progress | **Implemented:** resolve token at LSP position, parse + typecheck when possible; hovers for **identifiers** (function signatures with optional leading `//` / `/* */` doc lines, type definitions, inferred variable types), **keywords** (short quick-info). **Skipped:** literals (by design). **Limits:** if parse fails, hover often returns nothing (errors show in diagnostics). |
-| LSP: completion (`textDocument/completion`) | prototype | Returns **all** Forst keywords from `lexer.Keywords` as keyword items—**not** filtered by position or scope, **no** semantic or identifier completion. Capabilities advertise `resolveProvider: true` but there is **no** `completionItem/resolve` handler (unknown methods return JSON-RPC errors). |
+| LSP: completion (`textDocument/completion`) | prototype | Returns **all** Forst keywords from `lexer.Keywords` as keyword items—**not** filtered by position or scope, **no** semantic or identifier completion. `completionProvider.resolveProvider` is **false** until `completionItem/resolve` exists. |
 | LSP: go to definition | done | **`textDocument/definition`** resolves identifiers in the open buffer to defining tokens in the **same file**: top-level **`func`**, **`type`** (incl. shape/alias defs), and top-level **`is (…) Name`** type guards (brace depth avoids `ensure … is …`). Variables/parameters not yet. Implementation: `cmd/forst/lsp/definition.go`. |
-| LSP: find references | prototype | `textDocument/references` returns an **empty** array (TODO). |
-| LSP: document symbols | prototype | `textDocument/documentSymbol` returns **[]** (TODO). |
-| LSP: workspace symbol | prototype | `workspace/symbol` returns **[]** (TODO). |
+| LSP: find references | done | **`textDocument/references`**: same-file identifier occurrences for symbols that match **go-to-definition** rules (top-level **func**, **type**, **type guard**). **`includeDeclaration`** respected. Locals/cross-file not yet. `references.go`. |
+| LSP: document symbols | done | **`textDocument/documentSymbol`**: flat **`SymbolInformation`** for top-level **func**, **type** (skips `T_*` hash idents), **type guard**. Parse failure → `[]`. `symbols.go`. |
+| LSP: workspace symbol | done | **`workspace/symbol`**: searches **open** `.ft` buffers (`openDocuments` / didOpen sync only); substring match on symbol name (case-insensitive). No disk-wide index yet. `symbols.go` / `hover_completion.go`. |
 | LSP: formatting | prototype | `textDocument/formatting` returns **`null`** (no formatter yet). |
 | LSP: code actions, code lens, folding | prototype | `textDocument/codeAction` / `codeLens` / `foldingRange` return **empty** arrays (or no-op); capabilities still advertised in `initialize`. |
 | LSP: custom compiler / debug methods | prototype | `textDocument/debugInfo`, `textDocument/compilerState`, `textDocument/phaseDetails`—structured compiler state for tooling/LLM workflows (`server.go`); not general end-user editor parity. |
 | LSP: protocol & client quirks | prototype | **HTTP** transport is non-standard for LSP; stdio clients won’t work without an adapter. Methods not handled by the switch (e.g. some client notifications) get **-32601 Method not found**. |
 | Error messages (line numbers, suggestions) | prototype | Incremental improvements; parity not the only priority. |
 | More real-world examples | prototype | Some examples exist; broader set still wanted. |
-| VS Code extension | prototype | In-repo **`packages/vscode-forst`**: `.ft` language + grammar, HTTP LSP client, and language providers; **F12 / go to definition** works for same-file definitions the server resolves. **Marketplace** / discoverability still open. |
+| VS Code extension | prototype | In-repo **`packages/vscode-forst`**: `.ft` language + grammar, HTTP LSP client, and language providers; **outline**, **go to definition**, **find references**, **workspace symbol** (open files) when the server resolves symbols. **Marketplace** / discoverability still open. |
 
 ---
 

--- a/forst/cmd/forst/lsp/analyze.go
+++ b/forst/cmd/forst/lsp/analyze.go
@@ -1,0 +1,94 @@
+package lsp
+
+import (
+	"os"
+	"runtime"
+	"strings"
+
+	"forst/internal/ast"
+	"forst/internal/lexer"
+	"forst/internal/parser"
+	"forst/internal/typechecker"
+
+	"github.com/sirupsen/logrus"
+)
+
+// forstDocumentContext holds lex/parse/typecheck results for one .ft document URI.
+type forstDocumentContext struct {
+	URI      string
+	FilePath string
+	Content  string
+	FileID   string
+	Tokens   []ast.Token
+	Nodes    []ast.Node
+	ParseErr error
+	TC       *typechecker.TypeChecker
+	CheckErr error
+}
+
+// analyzeForstDocument loads buffer text, lexes, parses, and typechecks.
+// Returns ok false if the URI is not a loadable .ft file or the compiler debugger is unavailable.
+// On parse failure, ParseErr is set and TC is nil; Tokens is still populated.
+func (s *LSPServer) analyzeForstDocument(uri string) (ctx *forstDocumentContext, ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.log.WithFields(logrus.Fields{
+				"function": "analyzeForstDocument",
+				"panic":    r,
+			}).Debug("analyzeForstDocument panic recovered")
+			ctx = nil
+			ok = false
+		}
+	}()
+
+	filePath := strings.TrimPrefix(uri, "file://")
+	if runtime.GOOS == "windows" {
+		filePath = strings.TrimPrefix(filePath, "/")
+	}
+	if !strings.HasSuffix(filePath, ".ft") {
+		return nil, false
+	}
+
+	s.documentMu.RLock()
+	content, haveOpen := s.openDocuments[uri]
+	s.documentMu.RUnlock()
+	if !haveOpen || content == "" {
+		b, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, false
+		}
+		content = string(b)
+	}
+
+	cd, dbgOK := s.debugger.(*CompilerDebugger)
+	if !dbgOK {
+		return nil, false
+	}
+	packageStore := cd.packageStore
+	fileID := packageStore.RegisterFile(filePath, extractPackagePath(filePath))
+	fid := string(fileID)
+	lex := lexer.New([]byte(content), fid, s.log)
+	tokens := lex.Lex()
+
+	psr := parser.New(tokens, fid, s.log)
+	nodes, parseErr := psr.ParseFile()
+
+	ctx = &forstDocumentContext{
+		URI:      uri,
+		FilePath: filePath,
+		Content:  content,
+		FileID:   fid,
+		Tokens:   tokens,
+		ParseErr: parseErr,
+	}
+	if parseErr != nil {
+		return ctx, true
+	}
+
+	tc := typechecker.New(s.log, false)
+	checkErr := tc.CheckTypes(nodes)
+	ctx.Nodes = nodes
+	ctx.TC = tc
+	ctx.CheckErr = checkErr
+	return ctx, true
+}

--- a/forst/cmd/forst/lsp/definition.go
+++ b/forst/cmd/forst/lsp/definition.go
@@ -2,14 +2,10 @@ package lsp
 
 import (
 	"encoding/json"
-	"os"
-	"runtime"
 	"strings"
 	"unicode/utf8"
 
 	"forst/internal/ast"
-	"forst/internal/lexer"
-	"forst/internal/parser"
 	"forst/internal/typechecker"
 
 	"github.com/sirupsen/logrus"
@@ -63,77 +59,47 @@ func (s *LSPServer) findDefinitionForPosition(uri string, position LSPPosition) 
 		}
 	}()
 
-	filePath := strings.TrimPrefix(uri, "file://")
-	if runtime.GOOS == "windows" {
-		filePath = strings.TrimPrefix(filePath, "/")
-	}
-	if !strings.HasSuffix(filePath, ".ft") {
+	ctx, ok := s.analyzeForstDocument(uri)
+	if !ok || ctx == nil || ctx.ParseErr != nil || ctx.TC == nil {
 		return nil
 	}
-
-	s.documentMu.RLock()
-	content, haveOpen := s.openDocuments[uri]
-	s.documentMu.RUnlock()
-	if !haveOpen || content == "" {
-		b, err := os.ReadFile(filePath)
-		if err != nil {
-			return nil
-		}
-		content = string(b)
-	}
-
-	cd, ok := s.debugger.(*CompilerDebugger)
-	if !ok {
-		return nil
-	}
-	packageStore := cd.packageStore
-	fileID := packageStore.RegisterFile(filePath, extractPackagePath(filePath))
-	lex := lexer.New([]byte(content), string(fileID), s.log)
-	tokens := lex.Lex()
+	tokens := ctx.Tokens
 	tok := tokenAtLSPPosition(tokens, position)
 	if tok == nil || tok.Type != ast.TokenIdentifier {
 		return nil
 	}
-
-	psr := parser.New(tokens, string(fileID), s.log)
-	astNodes, err := psr.ParseFile()
-	if err != nil {
+	defTok := definingTokenForNavigableSymbol(ctx.TC, tokens, tok)
+	if defTok == nil {
 		return nil
 	}
+	return lspLocationPtrFromToken(uri, defTok)
+}
 
-	tc := typechecker.New(s.log, false)
-	_ = tc.CheckTypes(astNodes)
-
+// definingTokenForNavigableSymbol returns the defining identifier token for a top-level function,
+// user type, or type guard when the cursor token refers to that name (same rules as go-to-definition).
+func definingTokenForNavigableSymbol(tc *typechecker.TypeChecker, tokens []ast.Token, tok *ast.Token) *ast.Token {
+	if tok == nil || tok.Type != ast.TokenIdentifier {
+		return nil
+	}
 	id := ast.Identifier(tok.Value)
-
 	if _, ok := tc.Functions[id]; ok {
-		if defTok := findFuncNameToken(tokens, string(id)); defTok != nil {
-			return lspLocationPtrFromToken(uri, defTok)
-		}
-		return nil
+		return findFuncNameToken(tokens, string(id))
 	}
-
 	if strings.HasPrefix(tok.Value, "T_") {
 		return nil
 	}
-
 	def, ok := tc.Defs[ast.TypeIdent(tok.Value)]
 	if !ok {
 		return nil
 	}
-
 	switch def.(type) {
 	case ast.TypeDefNode:
-		if defTok := findTypeNameToken(tokens, tok.Value); defTok != nil {
-			return lspLocationPtrFromToken(uri, defTok)
-		}
+		return findTypeNameToken(tokens, tok.Value)
 	case *ast.TypeGuardNode:
-		if defTok := findTypeGuardNameToken(tokens, tok.Value); defTok != nil {
-			return lspLocationPtrFromToken(uri, defTok)
-		}
+		return findTypeGuardNameToken(tokens, tok.Value)
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 func lspLocationPtrFromToken(uri string, t *ast.Token) *LSPLocation {

--- a/forst/cmd/forst/lsp/document.go
+++ b/forst/cmd/forst/lsp/document.go
@@ -50,8 +50,8 @@ func (s *LSPServer) handleDidOpen(request LSPRequest) LSPServerResponse {
 		JSONRPC: "2.0",
 		ID:      request.ID,
 		Result: PublishDiagnosticsParams{
-			URI:           params.TextDocument.URI,
-			Diagnostics:   diagnostics,
+			URI:         params.TextDocument.URI,
+			Diagnostics: diagnostics,
 		},
 	}
 }
@@ -107,8 +107,8 @@ func (s *LSPServer) handleDidChange(request LSPRequest) LSPServerResponse {
 		JSONRPC: "2.0",
 		ID:      request.ID,
 		Result: PublishDiagnosticsParams{
-			URI:           params.TextDocument.URI,
-			Diagnostics:   diagnostics,
+			URI:         params.TextDocument.URI,
+			Diagnostics: diagnostics,
 		},
 	}
 }
@@ -148,8 +148,8 @@ func (s *LSPServer) handleDidClose(request LSPRequest) LSPServerResponse {
 		JSONRPC: "2.0",
 		ID:      request.ID,
 		Result: PublishDiagnosticsParams{
-			URI:           params.TextDocument.URI,
-			Diagnostics:   []LSPDiagnostic{},
+			URI:         params.TextDocument.URI,
+			Diagnostics: []LSPDiagnostic{},
 		},
 	}
 }
@@ -203,52 +203,4 @@ func (s *LSPServer) processForstFile(uri, content string) []LSPDiagnostic {
 	// Compile the file and get diagnostics
 	debugger := s.debugger.GetDebugger(PhaseParser, filePath)
 	return s.compileForstFile(filePath, content, debugger)
-}
-
-// handleReferences handles the textDocument/references method
-func (s *LSPServer) handleReferences(request LSPRequest) LSPServerResponse {
-	// Parse position from params
-	var params map[string]interface{}
-	if err := json.Unmarshal(request.Params, &params); err != nil {
-		return LSPServerResponse{
-			JSONRPC: "2.0",
-			ID:      request.ID,
-			Error: &LSPError{
-				Code:    -32602,
-				Message: "Invalid params",
-			},
-		}
-	}
-
-	// For now, return empty array (no references found)
-	// TODO: Implement actual reference lookup
-	return LSPServerResponse{
-		JSONRPC: "2.0",
-		ID:      request.ID,
-		Result:  []interface{}{},
-	}
-}
-
-// handleDocumentSymbol handles the textDocument/documentSymbol method
-func (s *LSPServer) handleDocumentSymbol(request LSPRequest) LSPServerResponse {
-	// Parse text document from params
-	var params map[string]interface{}
-	if err := json.Unmarshal(request.Params, &params); err != nil {
-		return LSPServerResponse{
-			JSONRPC: "2.0",
-			ID:      request.ID,
-			Error: &LSPError{
-				Code:    -32602,
-				Message: "Invalid params",
-			},
-		}
-	}
-
-	// For now, return empty array (no symbols found)
-	// TODO: Implement actual symbol extraction
-	return LSPServerResponse{
-		JSONRPC: "2.0",
-		ID:      request.ID,
-		Result:  []interface{}{},
-	}
 }

--- a/forst/cmd/forst/lsp/hover_completion.go
+++ b/forst/cmd/forst/lsp/hover_completion.go
@@ -3,14 +3,12 @@ package lsp
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 	"unicode/utf8"
 
 	"forst/internal/ast"
 	"forst/internal/lexer"
-	"forst/internal/parser"
 	"forst/internal/typechecker"
 
 	"github.com/sirupsen/logrus"
@@ -86,28 +84,18 @@ func (s *LSPServer) handleCompletion(request LSPRequest) LSPServerResponse {
 
 // findHoverForPosition finds hover information for a given position.
 func (s *LSPServer) findHoverForPosition(uri string, position LSPPosition) *LSPHover {
-	filePath := strings.TrimPrefix(uri, "file://")
-	if runtime.GOOS == "windows" {
-		filePath = strings.TrimPrefix(filePath, "/")
-	}
-
-	if !strings.HasSuffix(filePath, ".ft") {
+	ctx, ok := s.analyzeForstDocument(uri)
+	if !ok || ctx == nil {
 		return nil
 	}
-
-	s.documentMu.RLock()
-	content, haveOpen := s.openDocuments[uri]
-	s.documentMu.RUnlock()
-
-	if !haveOpen || content == "" {
-		b, err := os.ReadFile(filePath)
-		if err != nil {
-			return nil
-		}
-		content = string(b)
+	tok := tokenAtLSPPosition(ctx.Tokens, position)
+	if tok == nil {
+		return nil
 	}
-
-	return s.hoverMarkdownForContent(filePath, content, position)
+	if ctx.ParseErr != nil || ctx.TC == nil {
+		return nil
+	}
+	return s.hoverFromAnalyzedContext(ctx, tok)
 }
 
 func basicHoverMarkdown(text string) *LSPHover {
@@ -119,39 +107,19 @@ func basicHoverMarkdown(text string) *LSPHover {
 	}
 }
 
-func (s *LSPServer) hoverMarkdownForContent(filePath, content string, position LSPPosition) *LSPHover {
+func (s *LSPServer) hoverFromAnalyzedContext(ctx *forstDocumentContext, tok *ast.Token) *LSPHover {
 	defer func() {
 		if r := recover(); r != nil {
 			s.log.WithFields(logrus.Fields{
-				"function": "hoverMarkdownForContent",
+				"function": "hoverFromAnalyzedContext",
 				"panic":    r,
 			}).Debug("hover panic recovered")
 		}
 	}()
 
-	cd, ok := s.debugger.(*CompilerDebugger)
-	if !ok {
-		return nil
-	}
-	packageStore := cd.packageStore
-	fileID := packageStore.RegisterFile(filePath, extractPackagePath(filePath))
-	lex := lexer.New([]byte(content), string(fileID), s.log)
-	tokens := lex.Lex()
-	tok := tokenAtLSPPosition(tokens, position)
-	if tok == nil {
-		return nil
-	}
-
-	psr := parser.New(tokens, string(fileID), s.log)
-	astNodes, err := psr.ParseFile()
-	if err != nil {
-		// Diagnostics carry parse errors; hover stays quiet (matches typical TS / LSP behavior).
-		return nil
-	}
-
-	tc := typechecker.New(s.log, false)
-	if err := tc.CheckTypes(astNodes); err != nil {
-		// Still show quick info for the symbol when inferable; full error is in Problems.
+	tc := ctx.TC
+	tokens := ctx.Tokens
+	if ctx.CheckErr != nil {
 		text := hoverTextForToken(tc, tokens, tok)
 		if text == "" {
 			return nil
@@ -363,26 +331,51 @@ func (s *LSPServer) getCompletionsForPosition(uri string, position LSPPosition) 
 	return completions
 }
 
-// handleWorkspaceSymbol handles the workspace/symbol method
+// handleWorkspaceSymbol handles workspace/symbol over open .ft buffers (didOpen/didChange sync only).
 func (s *LSPServer) handleWorkspaceSymbol(request LSPRequest) LSPServerResponse {
-	// Parse query from params
-	var params map[string]interface{}
+	var params struct {
+		Query string `json:"query"`
+	}
 	if err := json.Unmarshal(request.Params, &params); err != nil {
 		return LSPServerResponse{
 			JSONRPC: "2.0",
 			ID:      request.ID,
 			Error: &LSPError{
-				Code:    -32602,
-				Message: "Invalid params",
+				Code:    -32700,
+				Message: "Parse error",
 			},
 		}
 	}
 
-	// For now, return empty array (no workspace symbols found)
-	// TODO: Implement actual workspace symbol search
+	q := strings.ToLower(strings.TrimSpace(params.Query))
+
+	s.documentMu.RLock()
+	uris := make([]string, 0, len(s.openDocuments))
+	for u := range s.openDocuments {
+		uris = append(uris, u)
+	}
+	s.documentMu.RUnlock()
+
+	var out []LspSymbolInformation
+	for _, uri := range uris {
+		if !strings.HasPrefix(uri, "file://") || !strings.HasSuffix(uri, ".ft") {
+			continue
+		}
+		ctx, ok := s.analyzeForstDocument(uri)
+		if !ok || ctx == nil || ctx.ParseErr != nil || ctx.Nodes == nil {
+			continue
+		}
+		for _, sym := range symbolsFromParsedDocument(uri, ctx.Tokens, ctx.Nodes) {
+			if q != "" && !strings.Contains(strings.ToLower(sym.Name), q) {
+				continue
+			}
+			out = append(out, sym)
+		}
+	}
+
 	return LSPServerResponse{
 		JSONRPC: "2.0",
 		ID:      request.ID,
-		Result:  []interface{}{},
+		Result:  out,
 	}
 }

--- a/forst/cmd/forst/lsp/initialize.go
+++ b/forst/cmd/forst/lsp/initialize.go
@@ -9,7 +9,7 @@ func (s *LSPServer) handleInitialize(request LSPRequest) LSPServerResponse {
 		},
 		"completionProvider": map[string]interface{}{
 			"triggerCharacters": []string{".", ":", "(", " "},
-			"resolveProvider":   true,
+			"resolveProvider":   false,
 		},
 		"hoverProvider": true,
 		"diagnosticProvider": map[string]interface{}{

--- a/forst/cmd/forst/lsp/navigation_test.go
+++ b/forst/cmd/forst/lsp/navigation_test.go
@@ -1,0 +1,173 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestSymbolsFromParsedDocument_funcAndType(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	s := NewLSPServer("8080", log)
+	dir := t.TempDir()
+	ftPath := filepath.Join(dir, "sym.ft")
+	const src = `package main
+
+type Row = {
+  x: Int
+}
+
+func bump(): Int {
+  return 1
+}
+`
+	if err := os.WriteFile(ftPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri := "file://" + ftPath
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	ctx, ok := s.analyzeForstDocument(uri)
+	if !ok || ctx == nil || ctx.ParseErr != nil {
+		t.Fatalf("analyze: ok=%v parseErr=%v", ok, ctx.ParseErr)
+	}
+	syms := symbolsFromParsedDocument(uri, ctx.Tokens, ctx.Nodes)
+	if len(syms) != 2 {
+		t.Fatalf("want 2 symbols, got %d %#v", len(syms), syms)
+	}
+	names := map[string]int{}
+	for _, s := range syms {
+		names[s.Name] = s.Kind
+	}
+	if names["Row"] != lspSymbolKindStruct {
+		t.Fatalf("Row kind: %v", names["Row"])
+	}
+	if names["bump"] != lspSymbolKindFunction {
+		t.Fatalf("bump kind: %v", names["bump"])
+	}
+}
+
+func TestHandleDocumentSymbol_JSON(t *testing.T) {
+	t.Parallel()
+	s := NewLSPServer("8080", logrus.New())
+	dir := t.TempDir()
+	ftPath := filepath.Join(dir, "doc.ft")
+	const src = `package main
+
+func alpha(): Int { return 0 }
+`
+	if err := os.WriteFile(ftPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri := "file://" + ftPath
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	resp := s.handleDocumentSymbol(LSPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "textDocument/documentSymbol",
+		Params:  mustJSONParams(t, map[string]interface{}{"textDocument": map[string]interface{}{"uri": uri}}),
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %+v", resp.Error)
+	}
+	raw, ok := resp.Result.([]LspSymbolInformation)
+	if !ok {
+		t.Fatalf("result type %T", resp.Result)
+	}
+	if len(raw) != 1 || raw[0].Name != "alpha" {
+		t.Fatalf("got %#v", raw)
+	}
+}
+
+func TestHandleReferences_excludesDeclaration(t *testing.T) {
+	t.Parallel()
+	s := NewLSPServer("8080", logrus.New())
+	dir := t.TempDir()
+	ftPath := filepath.Join(dir, "ref.ft")
+	const src = `package main
+
+func bump(): Int {
+  return 1
+}
+
+func main() {
+  bump()
+}
+`
+	if err := os.WriteFile(ftPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri := "file://" + ftPath
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	params := map[string]interface{}{
+		"textDocument": map[string]interface{}{"uri": uri},
+		"position":     map[string]interface{}{"line": 7, "character": 2},
+		"context":      map[string]interface{}{"includeDeclaration": false},
+	}
+	resp := s.handleReferences(LSPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "textDocument/references",
+		Params:  mustJSONParams(t, params),
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %+v", resp.Error)
+	}
+	locs, ok := resp.Result.([]LSPLocation)
+	if !ok {
+		t.Fatalf("result type %T", resp.Result)
+	}
+	if len(locs) != 1 {
+		t.Fatalf("want 1 ref (call site only), got %d", len(locs))
+	}
+	if locs[0].Range.Start.Line != 7 {
+		t.Fatalf("expected call on line 8 (0-based 7), got %+v", locs[0].Range.Start)
+	}
+}
+
+func TestHandleWorkspaceSymbol_filtersQuery(t *testing.T) {
+	t.Parallel()
+	s := NewLSPServer("8080", logrus.New())
+	dir := t.TempDir()
+	ftPath := filepath.Join(dir, "ws.ft")
+	const src = `package main
+
+func fooBar(): Int { return 0 }
+func other(): Int { return 1 }
+`
+	if err := os.WriteFile(ftPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri := "file://" + ftPath
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	resp := s.handleWorkspaceSymbol(LSPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "workspace/symbol",
+		Params:  mustJSONParams(t, map[string]interface{}{"query": "bar"}),
+	})
+	if resp.Error != nil {
+		t.Fatalf("error: %+v", resp.Error)
+	}
+	syms, ok := resp.Result.([]LspSymbolInformation)
+	if !ok {
+		t.Fatalf("result type %T", resp.Result)
+	}
+	if len(syms) != 1 || syms[0].Name != "fooBar" {
+		t.Fatalf("got %#v", syms)
+	}
+}

--- a/forst/cmd/forst/lsp/references.go
+++ b/forst/cmd/forst/lsp/references.go
@@ -1,0 +1,83 @@
+package lsp
+
+import (
+	"encoding/json"
+
+	"forst/internal/ast"
+)
+
+// handleReferences implements textDocument/references for same-file identifier occurrences
+// of top-level functions, user types, and type guards (same resolution as go-to-definition).
+func (s *LSPServer) handleReferences(request LSPRequest) LSPServerResponse {
+	var params struct {
+		TextDocument struct {
+			URI string `json:"uri"`
+		} `json:"textDocument"`
+		Position LSPPosition `json:"position"`
+		Context  struct {
+			IncludeDeclaration bool `json:"includeDeclaration"`
+		} `json:"context"`
+	}
+	if err := json.Unmarshal(request.Params, &params); err != nil {
+		return LSPServerResponse{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Error: &LSPError{
+				Code:    -32700,
+				Message: "Parse error",
+			},
+		}
+	}
+
+	locs := s.findReferencesForPosition(
+		params.TextDocument.URI,
+		params.Position,
+		params.Context.IncludeDeclaration,
+	)
+	if locs == nil {
+		locs = []LSPLocation{}
+	}
+	return LSPServerResponse{
+		JSONRPC: "2.0",
+		ID:      request.ID,
+		Result:  locs,
+	}
+}
+
+func (s *LSPServer) findReferencesForPosition(uri string, position LSPPosition, includeDecl bool) []LSPLocation {
+	ctx, ok := s.analyzeForstDocument(uri)
+	if !ok || ctx == nil || ctx.ParseErr != nil || ctx.TC == nil {
+		return nil
+	}
+	tok := tokenAtLSPPosition(ctx.Tokens, position)
+	if tok == nil || tok.Type != ast.TokenIdentifier {
+		return nil
+	}
+	defTok := definingTokenForNavigableSymbol(ctx.TC, ctx.Tokens, tok)
+	if defTok == nil {
+		return nil
+	}
+	return collectIdentifierReferences(uri, ctx.Tokens, tok.Value, defTok, includeDecl)
+}
+
+func collectIdentifierReferences(uri string, tokens []ast.Token, name string, defTok *ast.Token, includeDecl bool) []LSPLocation {
+	var out []LSPLocation
+	for i := range tokens {
+		t := &tokens[i]
+		if t.Type != ast.TokenIdentifier || t.Value != name {
+			continue
+		}
+		if !includeDecl && tokenSamePosition(t, defTok) {
+			continue
+		}
+		out = append(out, lspLocationFromToken(uri, t))
+	}
+	return out
+}
+
+func tokenSamePosition(a, b *ast.Token) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Line == b.Line && a.Column == b.Column
+}

--- a/forst/cmd/forst/lsp/symbols.go
+++ b/forst/cmd/forst/lsp/symbols.go
@@ -1,0 +1,104 @@
+package lsp
+
+import (
+	"encoding/json"
+	"strings"
+
+	"forst/internal/ast"
+
+	"github.com/sirupsen/logrus"
+)
+
+// LSP SymbolKind subset (see LSP spec).
+const (
+	lspSymbolKindFunction = 12
+	lspSymbolKindStruct   = 23
+	lspSymbolKindMethod   = 6
+)
+
+// LspSymbolInformation is the wire shape for documentSymbol (flat) and workspace/symbol.
+type LspSymbolInformation struct {
+	Name          string      `json:"name"`
+	Kind          int         `json:"kind"`
+	Location      LSPLocation `json:"location"`
+	ContainerName string      `json:"containerName,omitempty"`
+}
+
+// handleDocumentSymbol implements textDocument/documentSymbol for top-level declarations.
+func (s *LSPServer) handleDocumentSymbol(request LSPRequest) LSPServerResponse {
+	var params struct {
+		TextDocument struct {
+			URI string `json:"uri"`
+		} `json:"textDocument"`
+	}
+	if err := json.Unmarshal(request.Params, &params); err != nil {
+		return LSPServerResponse{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Error: &LSPError{
+				Code:    -32700,
+				Message: "Parse error",
+			},
+		}
+	}
+
+	uri := params.TextDocument.URI
+	ctx, ok := s.analyzeForstDocument(uri)
+	if !ok || ctx == nil || ctx.ParseErr != nil || ctx.Nodes == nil {
+		s.log.WithFields(logrus.Fields{
+			"function": "handleDocumentSymbol",
+			"uri":      uri,
+		}).Debug("documentSymbol: no parsed document")
+		return LSPServerResponse{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Result:  []LspSymbolInformation{},
+		}
+	}
+
+	syms := symbolsFromParsedDocument(uri, ctx.Tokens, ctx.Nodes)
+	return LSPServerResponse{
+		JSONRPC: "2.0",
+		ID:      request.ID,
+		Result:  syms,
+	}
+}
+
+func symbolsFromParsedDocument(uri string, tokens []ast.Token, nodes []ast.Node) []LspSymbolInformation {
+	var out []LspSymbolInformation
+	for _, n := range nodes {
+		switch v := n.(type) {
+		case ast.FunctionNode:
+			name := string(v.Ident.ID)
+			if t := findFuncNameToken(tokens, name); t != nil {
+				out = append(out, LspSymbolInformation{
+					Name:     name,
+					Kind:     lspSymbolKindFunction,
+					Location: lspLocationFromToken(uri, t),
+				})
+			}
+		case ast.TypeDefNode:
+			name := string(v.Ident)
+			if strings.HasPrefix(name, "T_") {
+				continue
+			}
+			if t := findTypeNameToken(tokens, name); t != nil {
+				out = append(out, LspSymbolInformation{
+					Name:     name,
+					Kind:     lspSymbolKindStruct,
+					Location: lspLocationFromToken(uri, t),
+				})
+			}
+		case *ast.TypeGuardNode:
+			name := string(v.Ident)
+			if t := findTypeGuardNameToken(tokens, name); t != nil {
+				out = append(out, LspSymbolInformation{
+					Name:     name,
+					Kind:     lspSymbolKindMethod,
+					Location: lspLocationFromToken(uri, t),
+				})
+			}
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Introduce analyzeForstDocument/forstDocumentContext and route definition + hover through it. Implement textDocument/documentSymbol, textDocument/references (same file, same rules as go-to-definition), and workspace/symbol over open .ft buffers with query filter. Extract definingTokenForNavigableSymbol; set completion resolveProvider to false until resolve is implemented. Add navigation tests; update ROADMAP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added language server support for finding symbol references across files
  * Added document outline via symbol listing
  * Added workspace-wide symbol search for open buffers

* **Bug Fixes**
  * Fixed completion provider capability advertisement

* **Tests**
  * Added navigation feature tests

* **Documentation**
  * Updated roadmap to reflect LSP navigation capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->