### PR TITLE
feat(compiler): Go builtins, map literals, and slice ]T parse fix

### DIFF
--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -23,6 +23,8 @@ Run example compilations with tracing enabled:
 examples/in/rfc/guard/shape_guard.ft
 examples/in/rfc/guard/basic_guard.ft
 examples/in/basic.ft
+examples/in/go_builtins.ft
+examples/in/generics.ft
 examples/in/basic_function.ft
 examples/in/ensure.ft
 
@@ -40,6 +42,7 @@ The project follows this structure:
 - `examples/in/`: Example Forst source files
   - `rfc/guard/`: Guard-related examples
   - `basic.ft`: Basic language examples
+  - `generics.ft`: Built-in parameterized types (`[]T`, `*T`, `append`/`copy`/`cap`/`range`); not user-defined generics
   - `basic_function.ft`: Function examples
   - `ensure.ft`: Ensure statement examples
 - `examples/out/`: Example expected Go files after transpilation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ Themes group work (language, interop, tooling, docs, infrastructure). We do not 
 | Methods (`func (t T) M()`) | 📋 planned | Forst is function-centric; no method declarations. |
 | `interface{ }` satisfaction / embedding | 🔬 experimental | Structural shapes and Go interop differ from Go’s interface model. |
 | Type assertions `x.(T)`, type switch | 📋 planned | Distinct from Forst’s `is` / `ensure` / narrowing. |
-| Built-in calls (`make`, `new`, `append`, `copy`, `len`, `cap`, `close`, …) | 🔬 experimental | Via **Go builtins** and transpilation; not necessarily first-class Forst syntax for every builtin. |
+| Built-in calls (`make`, `new`, `append`, `copy`, `len`, `cap`, `close`, …) | 🔬 experimental | Predeclared Go builtins used as calls are type-checked against Go rules in `forst/internal/typechecker/go_builtins.go` (`tryDispatchGoBuiltin`). **`make` / `new` with a type argument** are rejected until the expression parser accepts **Forst type syntax** in that position (e.g. `Array(Int)`, `Map(K, V)`), not Go spellings like `[]T` or `map[K]V`. |
 | Goroutines (beyond `go` call) | 🔬 experimental | `go f()` supported; scheduler/runtime is Go’s. |
 | Channels (`chan`, `<-`, `range` on channel) | 🔬 experimental | Send/receive parse in some forms; `select` and full channel ergonomics missing. |
 | `panic` / `recover` | 🔬 experimental | May appear in generated code; not first-class Forst keywords. |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -181,6 +181,18 @@ tasks:
     cmds:
       - go run ./{{.BUILD_DIR}} run -loglevel trace -report-phases -- {{.EXAMPLES_DIR}}/basic.ft
 
+  example:go-builtins:
+    desc: Compile go_builtins example (len/min/max on strings and slices)
+    dir: forst
+    cmds:
+      - go run ./{{.BUILD_DIR}} run -loglevel trace -report-phases -- {{.EXAMPLES_DIR}}/go_builtins.ft
+
+  example:generics:
+    desc: Compile generics example (built-in []T / *T, append/copy/cap/range; not user-defined type parameters)
+    dir: forst
+    cmds:
+      - go run ./{{.BUILD_DIR}} run -loglevel trace -report-phases -- {{.EXAMPLES_DIR}}/generics.ft
+
   example:function:
     desc: Compile function example
     dir: forst

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 - **`in/`** — Forst `.ft` sources used by Task targets (e.g. `task example:basic`). Paths are mirrored under **`out/`** with expected Go output for integration checks (`in` → `out`).
 
-- **`in/*.ft`** at the root of `in/` (e.g. `basic.ft`, `ensure.ft`) are the small, primary examples referenced by the Taskfile and [testing rules](../.cursor/rules/testing.mdc).
+- **`in/*.ft`** at the root of `in/` (e.g. `basic.ft`, `go_builtins.ft`, `generics.ft`, `ensure.ft`) are the small, primary examples referenced by the Taskfile and [testing rules](../.cursor/rules/testing.mdc).
 
 - **`in/imports/`** — multi-file “imports” demo (LSP merged package + `task example:imports` via `cli.ft`); see `in/imports/README.md`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,29 @@
 
 ## `in/rfc/`
 
-Design notes (Markdown), sample `.ft` files, and sometimes TypeScript or config files are grouped **by topic** (sidecar, guards, typescript-client, effects, etc.). That folder is **not only** minimal “hello world” examples: it is **RFC-style documentation + runnable snippets** kept together. No separate layout is required as long as this convention is understood.
+Design notes (Markdown), sample `.ft` files, and sometimes TypeScript or config files are grouped **by topic**. That folder is **not only** minimal “hello world” examples: it is **RFC-style documentation + runnable snippets** kept together. Each topic usually has a `README.md` index (except where noted). Implementation status in the wild is tracked separately in [ROADMAP.md](../ROADMAP.md); **stage** here describes the RFC’s *intent and maturity as documentation*, not a guarantee that every bullet is shipped.
+
+### RFC index (by topic)
+
+**Stages (how to read this table):**
+
+| Stage | Meaning |
+| ----- | ------- |
+| **Exploration** | Alternatives and tradeoffs; no single committed delivery tied to the whole RFC set. |
+| **Specification / design** | Normative contracts, architecture, or phased plans meant to guide implementation. |
+| **Planned (language)** | Aligns with [ROADMAP](../ROADMAP.md) language rows still **planned** or early; design-only until implemented. |
+| **Partially realized** | Core pieces exist in the compiler or tooling; the full RFC scope is larger than what is shipped. |
+| **Experimental (tooling)** | End-user or dev workflows (sidecar, HTTP, NPM) expected to evolve; not the core language definition. |
+
+| Topic | Index / entry point | Stage | Notes |
+| ----- | -------------------- | ----- | ----- |
+| **Effect-TS integration** | [in/rfc/effect/README.md](in/rfc/effect/README.md) | Exploration | Many documents (native effects, interop, batching, strategy); long-horizon options for Effect-like patterns. |
+| **Error system** | [in/rfc/errors/README.md](in/rfc/errors/README.md) | Specification / design | Broad architecture (hierarchy, OTel, factories); compiler has typed errors—full vision is wider than today’s emit. |
+| **ES modules / Node** | [in/rfc/esm/README.md](in/rfc/esm/README.md) | Exploration | Forst as native ESM, addons, enhanced sidecar variants. |
+| **User generics** | [in/rfc/generics/README.md](in/rfc/generics/README.md) | Specification / design · **Planned (language)** | Phased plan for user type parameters; see [00-user-generics-and-type-parameters.md](in/rfc/generics/00-user-generics-and-type-parameters.md). |
+| **Guards** | [in/rfc/guard/guard.md](in/rfc/guard/guard.md) (no folder README) | Partially realized | Shape guards and `ensure` are in the language; [anonymous_objects.md](in/rfc/guard/anonymous_objects.md), [interop.md](in/rfc/guard/interop.md) extend the story. |
+| **Sidecar & TS adoption** | [in/rfc/sidecar/00-sidecar.md](in/rfc/sidecar/00-sidecar.md), [10-decisions.md](in/rfc/sidecar/10-decisions.md) | Experimental (tooling) + specification | HTTP sidecar, NPM, tests under `sidecar/tests/`; strategic decisions doc. (Ignore `node_modules/`—third-party deps, not RFC text.) |
+| **TypeScript client** | [in/rfc/typescript-client/README.md](in/rfc/typescript-client/README.md) | Specification / design · **in progress (tooling)** | `forst generate`, dev HTTP contract, integration profiles (P0–P3 plan in [00-implementation-plan.md](in/rfc/typescript-client/00-implementation-plan.md)). |
 
 ## `client-integration/`
 

--- a/examples/in/generics.ft
+++ b/examples/in/generics.ft
@@ -1,0 +1,36 @@
+package main
+
+// Built-in parameterized types: Array = []T, Pointer = *T (and map[K]V in type positions). These use type parameters on predeclared type constructors; user-defined generics are not implemented yet — see ROADMAP.
+// Golden output: ../out/generics.go
+
+func main() {
+	// []Int: back-to-back slice short declarations, then copy / append / len / cap
+	dst := [0, 0, 0]
+	src := [1, 2, 3]
+	println(copy(dst, src))
+	xs := append(src, 4)
+	println(len(xs))
+	println(cap(xs))
+	println(copy(dst, xs))
+
+	// map[K]V: map literal; len (same key/value type parameters as Go's map[K]V)
+	scores := map[String]Int{ "a": 1, "b": 2 }
+	empty := map[String]Int{}
+	println(len(scores))
+	println(len(empty))
+
+	// Two-value range: index and value are both Int, matching Array(Int)
+	for i, v := range xs {
+		println(string(i) + string(v))
+	}
+
+	// *String
+	s := "go"
+	p := &s
+	println(*p)
+
+	// *Int
+	n := 7
+	pn := &n
+	println(*pn)
+}

--- a/examples/in/go_builtins.ft
+++ b/examples/in/go_builtins.ft
@@ -1,0 +1,13 @@
+package main
+
+// Exercises Go predeclared builtins checked by tryDispatchGoBuiltin: len on String and
+// slice literals, min/max on ordered types. Golden output: ../out/go_builtins.go
+
+func main() {
+	s: String = "ab"
+	println(len(s))
+	println(len("hi"))
+	println(len([1, 2, 3]))
+	println(min(1, 2, 3))
+	println(max(3, 4))
+}

--- a/examples/in/rfc/generics/00-user-generics-and-type-parameters.md
+++ b/examples/in/rfc/generics/00-user-generics-and-type-parameters.md
@@ -1,0 +1,223 @@
+# User generics and type parameters
+
+## Table of contents
+
+1. [Introduction](#introduction)
+2. [Purpose and benefits for the language](#purpose-and-benefits-for-the-language)
+3. [Relationship to today’s Forst](#relationship-to-todays-forst)
+4. [Alignment with project principles](#alignment-with-project-principles)
+5. [Target capabilities (staged)](#target-capabilities-staged)
+6. [Design decisions to lock early](#design-decisions-to-lock-early)
+7. [Implementation phases](#implementation-phases)
+8. [Risks and mitigations](#risks-and-mitigations)
+9. [Testing strategy](#testing-strategy)
+10. [References](#references)
+
+---
+
+## Introduction
+
+Forst is a statically typed language that transpiles to Go and targets **TypeScript-grade ergonomics** on the backend. Today, programmers can use **parametric built-in type constructors**—notably slices (`[]T`), pointers (`*T`), and maps (`map[K]V`)—and the compiler models those with `TypeParams` on internal [`TypeNode`](../../../../forst/internal/ast/type.go) representations. That is **not** the same as **user-defined** polymorphism: you cannot yet write a reusable `Box[T]` or `func identity[T](x T) T` that the typechecker understands end-to-end and that lowers cleanly to idiomatic Go.
+
+This RFC describes a **roadmap** toward **comprehensive generic support** in that user-facing sense: declared type parameters on types and functions, instantiation, explicit constraints, codegen strategy (likely Go 1.18+ generics), and **incremental** interoperability with generic APIs in imported Go code. It consolidates technical direction previously captured in internal planning; it does **not** prescribe final syntax (that remains a design decision in a later revision of this document or a short ADR).
+
+The audience is **language designers and compiler contributors** deciding what to build next, and **advanced users** who need to see how Forst intends to relate to Go’s generic ecosystem without promising a single big-bang release.
+
+---
+
+## Purpose and benefits for the language
+
+### Why this work matters
+
+1. **Abstraction without losing types**  
+   Backend code repeats the same patterns for “a value of type T”, “a container of T”, or “transform A to B” where `T`, `A`, and `B` should be arbitrary **named** types. Without generics, authors either duplicate concrete definitions or fall back to **weaker** representations (`Shape`, `interface{}`, or stringly-typed APIs). User generics let those patterns stay **fully typed** and **checkable** at compile time.
+
+2. **Closer parity with TypeScript and modern Go**  
+   TypeScript users expect generic functions and generic types for collections, utilities, and API boundaries. Go 1.18+ codebases increasingly expose **generic** stdlib APIs (`slices`, `maps`, `cmp`, …). Forst that only understands **non-generic** Go signatures will **lag** those libraries unless the language can grow generic **definitions** and, over time, **interop** for instantiated generic calls. This RFC sets expectations: Forst-first generics are the **main** goal; mapping every external generic API is an **incremental** follow-on (see [Risks and mitigations](#2-go-interop-long-tail--accepted)).
+
+3. **Safer refactors and clearer APIs**  
+   Instantiated types like `Result[Int, AppError]` (syntax illustrative) document intent better than parallel `ResultInt`, `ResultString`, … Generics reduce drift between copies and make **incompatibility** explicit (`Box[Int]` is not `Box[String]`).
+
+4. **Foundation for future features**  
+   Constraints (`comparable`, ordered types, eventual interface-like bounds) connect to **binary type expressions**, **control-flow narrowing**, and **interop** work already listed on the [roadmap](../../../../ROADMAP.md). A coherent generic **core** avoids bolting on ad hoc special cases later.
+
+5. **Honest ergonomics vs hand-written Go**  
+   Emitting **real Go generics** where appropriate keeps generated code readable and **debuggable** in mixed Go/Forst modules—aligned with Forst’s Go-backwards-compatibility story.
+
+### What success does *not* require
+
+- **Full** `go/types` coverage for every generic symbol in the universe on day one.
+- **Maximum** type inference when it conflicts with clarity (see [PHILOSOPHY.md](../../../../PHILOSOPHY.md)).
+- **Dependent types** or type-level computation beyond what this phased plan describes.
+
+---
+
+## Relationship to today’s Forst
+
+| Topic | Today | After this RFC (phased) |
+| ----- | ----- | ------------------------ |
+| [ROADMAP “Generic types”](../../../../ROADMAP.md) | Planned / not user-defined | Progress toward experimental → done with scoped notes |
+| Built-in `Array` / `Map` / `Pointer` `TypeParams` | Used for `[]T`, `map[K]V`, `*T` | Unchanged; **additional** machinery for **user** type parameters |
+| [examples/in/generics.ft](../../../../examples/in/generics.ft) | Documents **builtin** parametric types | May gain a sibling example for **user** `Box[T]`-style code when implemented |
+| [go_interop.go](../../../../forst/internal/typechecker/go_interop.go) | Maps basics, slices, pointers; many generic Go returns **unsupported** | **Incremental** extension for instantiated generics; long tail accepted |
+| Type aliases, binary types | Experimental / partial | [Roadmap](../../../../ROADMAP.md) notes interactions with generics—**integration passes** after each stabilizes |
+
+---
+
+## Alignment with project principles
+
+- **[PHILOSOPHY.md](../../../../PHILOSOPHY.md)** — Generic **constraints** should be **explicit**; type-arg **inference** only in well-defined cases where parameters are **uniquely determined**; avoid type-system side effects and unbounded metaprogramming.
+- **Go interoperability** — Prefer **honest** errors over silent widening; thin Go wrappers remain valid when interop is incomplete.
+- **Testing culture** — Each phase adds **reproducing** unit and integration tests ([project priorities](../../../../.cursor/rules/priorities.mdc)); examples under `examples/in/` when stable.
+
+---
+
+## Target capabilities (staged)
+
+| Stage | Capability | Notes |
+| ----- | ---------- | ----- |
+| A | **User generic type definitions** | e.g. nominal `type Box[T] = …` / struct-like shapes with type parameters; substitution in fields and type references. |
+| B | **Generic functions** | Type parameters on top-level `func`; instantiation by explicit or inferred type args at call sites. |
+| C | **Constraints** | Explicit bounds (`comparable`, ordered subset for `min`/`max`, future interface-like bounds); ties to roadmap “binary types” / interfaces later. |
+| D | **Interop** | `make`/`new` with Forst type syntax ([ROADMAP](../../../../ROADMAP.md)); **incremental** mapping of instantiated Go generic APIs via `go/types`—full coverage is a **long tail**, not a release blocker. |
+| E | **Tooling** | LSP hover / diagnostics for type parameters and instantiation sites. |
+
+Stages A–B unlock most **language** generics; C–D unlock **interop and stdlib**; E is ongoing.
+
+---
+
+## Design decisions to lock early
+
+1. **Surface syntax** (parser): one consistent style for type parameters and applications (e.g. Go-like `func f[T](x T)`, `Box[T]`, `f[Int](1)` vs alternatives). Touches [`forst/internal/parser/type.go`](../../../../forst/internal/parser/type.go), `function.go`, `typedef.go`.
+2. **Codegen strategy**: emit **Go 1.18+ generic Go** (`type Box[T any] struct`, `func Id[T any](x T) T`) vs **monomorphize** to concrete types only. Emission touches [`forst/internal/transformer/go/`](../../../../forst/internal/transformer/go/); repo `go.mod` already targets a modern Go toolchain.
+3. **Constraint language (minimal first)**: start with `any` / `comparable` / **ordered** (subset already mirrored in [`builtin_type_helpers.go`](../../../../forst/internal/typechecker/builtin_type_helpers.go) for `min`/`max`) before full interface constraints.
+
+---
+
+## Implementation phases
+
+### Phase 1 — AST and binding
+
+- Extend AST for **declared type parameters** (name, optional constraint) on **type definitions** and **functions**; distinguish parameter identifiers from type constructors in [`forst/internal/ast/`](../../../../forst/internal/ast/).
+- **Name resolution / scoping**: generic parameter scope for function body and type bodies (alongside existing [`register.go`](../../../../forst/internal/typechecker/register.go) / lookup paths).
+- **Tests**: parser round-trips + negative tests for invalid shadowing / arity.
+
+### Phase 2 — Typechecker: substitution and compatibility
+
+- Introduce a **generic environment** (mapping param → concrete `TypeNode`) for each instantiation.
+- Implement **substitution** on `TypeNode`, shapes, and function signatures when referencing `T` inside definitions.
+- Extend **`IsTypeCompatible` / unify** ([`typeops_test.go`](../../../../forst/internal/typechecker/typeops_test.go) already has some `TypeParams` cases) for instantiated types.
+- **Regression tests**: `Box[Int]` vs `Box[String]` incompatibility; identity of `Box[Int]` across sites.
+
+### Phase 3 — Generic types (Stage A) end-to-end
+
+- Typecheck **generic typedefs** / shapes with parameters; **instantiation** at use sites (`Box[Int]{ ... }` or equivalent).
+- **Transformer**: emit `type Name[T any] struct { ... }` (or monomorphized `Name_int`) per early design decision.
+- **Golden / integration**: extend [generics.ft](../../../../examples/in/generics.ft) or add `generic_types.ft` with a minimal `Box`-style example.
+
+### Phase 4 — Generic functions (Stage B)
+
+- Parse and store type parameter lists on **functions**; typecheck body with parameters in scope.
+- **Call resolution**: explicit `f[Int](...)` first; then **inference** only when PHILOSOPHY’s “uniquely determined” rule applies (narrow cases + clear errors).
+- Emit generic Go functions or monomorphized overloads.
+
+### Phase 5 — Constraints (Stage C)
+
+- Parse constraint clauses; enforce **assignability** to constraint (start with `any`, `comparable`, ordered builtins).
+- Connect to **future** interface/union work without blocking Phases 3–4 on full interface satisfaction.
+
+### Phase 6 — Interop (Stage D)
+
+- Extend [`go_interop.go`](../../../../forst/internal/typechecker/go_interop.go) / `goTypeToForstType` for **instantiated** generic Go types and signatures using `go/types` (**incrementally**; full stdlib coverage is **not** a gate—see risks).
+- **Expression parser** for `make`/`new` type arguments ([ROADMAP](../../../../ROADMAP.md) prerequisite).
+- Tests against **one** small real API per milestone (e.g. a single `slices` or `maps` function) to prove the pipeline; add mappings over time.
+
+### Phase 7 — Tooling and docs
+
+- LSP: hover for generic definitions and instantiations.
+- Update [ROADMAP.md](../../../../ROADMAP.md) row **Generic types** from planned → experimental/done with honest scope notes.
+- Cross-cutting: roadmap flags **type aliases + generics** and **binary type expressions + generics**—schedule integration passes when each lands.
+
+---
+
+## Risks and mitigations
+
+### 1. Structural hashing vs named generic instantiation identity
+
+**Risk:** Anonymous shapes use hash-based names today; user generics need a single canonical identity for `Box[Int]` across definitions, imports, and codegen.
+
+**Mitigations:**
+
+- Treat **instantiated named generics** as first-class: key identity by `(generic symbol, sorted type args)` in the typechecker, not by re-hashing substituted struct bodies alone.
+- Keep **structural/anonymous** types on the existing hasher path; only mix with generics where substitution is fully applied before hashing (tests that `Box[Int]` from two sites unify).
+- Document when users should prefer **named** `type Box[T] = …` over anonymous shapes parameterized by `T` to avoid duplicate structural hashes.
+
+**Examples (illustrative — final syntax TBD):**
+
+| Allowed / goal | Not supported or out of scope for identity rules |
+| ---------------- | ------------------------------------------------ |
+| Two references to **`Box[Int]`** (same named generic `Box`, same args) unify to **one** instantiated type for fields, assignments, and emit. | Relying on **two independent anonymous** shapes with the same field layout to be “the same type” without a shared named definition (structural/hash territory; generics do not merge unrelated anonymous shapes). |
+| **`type Pair[A, B] = { first: A, second: B }`** then **`Pair[Int, String]`** has stable identity keyed by `Pair` + `[Int, String]`. | Instantiation identity that **depends on declaration order** or **source file** rather than `(symbol, type args)` (the design should reject this). |
+
+### 2. Go interop (long tail — accepted)
+
+**Risk:** `go/types` exposes unbound type parameters, instantiated `Named` types, and generic signatures; mapping every future stdlib or third-party generic API is open-ended.
+
+**Stance:** **We accept the long tail.** Shipping **Forst-side** generics and emit does **not** wait on complete Go generic interop.
+
+**Mitigations:**
+
+- **Incremental allowlist:** extend `goTypeToForstType` / parameter checking per **high-value** APIs with tests, not big-bang coverage.
+- **Stable diagnostics:** explicit `unsupported Go … type` (or similar) with **actionable** messages (e.g. suggest a typed wrapper in `.go`) rather than silent wrong types.
+- **Escape hatches:** hand-written Go helpers or thin wrappers remain valid; document gaps in ROADMAP/examples.
+- **Defer edge cases:** channel/type-parameter combinations, contravariant positions, etc. behind “not yet” errors until targeted.
+
+**Examples (illustrative):**
+
+| Allowed (incremental) | Not supported until explicitly implemented / mapped |
+| --------------------- | --------------------------------------------------- |
+| Call a **non-generic** or **already-mapped** imported function; types align with today’s mapping (basics, slices, pointers, `error`). | Imported function returns **`T`** where **`T`** is still a **free type parameter** at the call boundary (e.g. `func Clone[S ~[]E](S) S` returning **`S`**) — **unsupported** until mapping exists. |
+| After a milestone maps e.g. **`slices.Index`**, call with concrete **`[]Int`** and use the **concrete** result type. | Assume **every** external generic API works without tests — long tail. |
+| **Escape hatch:** implement **`myClone(xs []int) []int`** in `.go`, import and call from Forst with a **non-generic** signature. | Silently treating unsupported generic returns as **`interface{}`** or wrong concrete type — **never**; must remain an **explicit error**. |
+| **`make` / `new`** with Forst type syntax once parser + checker support it ([ROADMAP](../../../../ROADMAP.md)). | **`make([]T, n)`** with **`T`** only known at runtime — not valid in Go; not a goal. |
+
+### 3. PHILOSOPHY vs inference ambiguity
+
+**Risk:** Over-eager type-argument inference conflicts with “explicit when unclear” and hides bugs.
+
+**Mitigations:**
+
+- Ship **explicit** instantiation syntax first (`f[Int](x)` or equivalent); add inference only for **narrow** rules (e.g. single parameter determined by argument types) with tests.
+- When inference fails, diagnostics that **name** the ambiguous parameter and suggest explicit type arguments.
+- Log/trace at **debug** for inference attempts during development ([PHILOSOPHY.md](../../../../PHILOSOPHY.md)).
+
+**Examples (illustrative — syntax TBD):**
+
+| Allowed | Not supported (reject or require explicit args) |
+| ------- | ----------------------------------------------- |
+| **Explicit** type application: **`id[Int](x)`** (or as the language defines it). | **`id(x)`** when **`x`** could instantiate **`T`** to **`Int`** or **`Float`** equally — **ambiguous**; compiler must **not** guess. |
+| Narrow inference **if** the ruleset proves **at most one** valid instantiation — only with tests and a specified algorithm. | Inference using **only** return context, **multiple** independent parameters, or **constraints** not in the solver yet. |
+| Clear error: *cannot infer `T`; try `f[Int](…)`*. | Silent choice of **`Int`** because it was “first” internally. |
+
+---
+
+## Testing strategy
+
+- **Unit tests** at each layer: parser → typechecker substitution → transformer emit → `go test` on emitted snippets.
+- **Integration:** `task example:*` or dedicated `examples/in/` once syntax is stable.
+- Prefer **narrow** tests per inference rule; avoid drive-by refactors.
+
+---
+
+## References
+
+- [ROADMAP.md](../../../../ROADMAP.md) — feature status table.
+- [PHILOSOPHY.md](../../../../PHILOSOPHY.md) — inference and explicitness.
+- [examples/README.md](../../../../examples/README.md) — RFC layout conventions under `examples/in/rfc/`.
+- Internal surfaces: [`ast.TypeNode`](../../../../forst/internal/ast/type.go), [`go_interop.go`](../../../../forst/internal/typechecker/go_interop.go), [`transformer/go`](../../../../forst/internal/transformer/go/).
+
+---
+
+## Document status
+
+**Draft RFC — design and phasing only.** Syntax examples are **illustrative**; implementation tasks are **not** started by this document. Revise this file as decisions (syntax, monomorphization vs Go generics emit) are locked.

--- a/examples/in/rfc/generics/README.md
+++ b/examples/in/rfc/generics/README.md
@@ -1,0 +1,13 @@
+# User generics and type parameters (RFC)
+
+This folder specifies a **phased design** for user-defined generic types and functions in Forst: declared type parameters, instantiation, constraints, Go codegen, and incremental Go interop. It is a **design and roadmap** document only—implementation follows separately.
+
+## Documents
+
+- **[00-user-generics-and-type-parameters.md](./00-user-generics-and-type-parameters.md)** — Full RFC: motivation, benefits, current baseline, staged capabilities, design decisions, implementation phases, risks and mitigations (with allowed / not-supported examples), and testing strategy.
+
+## See also
+
+- [ROADMAP.md](../../../../ROADMAP.md) — language feature status (Generic types are currently **planned**).
+- [PHILOSOPHY.md](../../../../PHILOSOPHY.md) — inference and explicitness principles that constrain generic inference.
+- [examples/in/generics.ft](../../../../examples/in/generics.ft) — today’s **built-in** parametric types (`[]T`, `*T`, `map[K]V`), not user polymorphism.

--- a/forst/internal/parser/array_literal_type_suffix_test.go
+++ b/forst/internal/parser/array_literal_type_suffix_test.go
@@ -1,0 +1,45 @@
+package parser
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/lexer"
+)
+
+func TestParseFile_arrayLiteralTypeSuffixNotAfterNewline(t *testing.T) {
+	// Regression: `]` at end of line must not consume the next statement's identifier as `]T`.
+	src := `package main
+
+func main() {
+	ys := [0, 0, 0]
+	xs := [1, 2, 3]
+	println(len(xs))
+}
+`
+	logger := ast.SetupTestLogger(nil)
+	toks := lexer.New([]byte(src), "t.ft", logger).Lex()
+	p := New(toks, "t.ft", logger)
+	_, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+}
+
+func TestParseFile_arrayLiteralOptionalTypeSameLine(t *testing.T) {
+	// `]T` on the same line as `]` is still a valid element-type suffix (user-defined name).
+	src := `package main
+
+func main() {
+	x := [1, 2]T
+	println(len(x))
+}
+`
+	logger := ast.SetupTestLogger(nil)
+	toks := lexer.New([]byte(src), "t.ft", logger).Lex()
+	p := New(toks, "t.ft", logger)
+	_, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+}

--- a/forst/internal/parser/literal.go
+++ b/forst/internal/parser/literal.go
@@ -69,15 +69,18 @@ func (p *Parser) parseLiteral() ast.LiteralNode {
 				p.advance() // Consume comma
 			}
 		}
-		p.expect(ast.TokenRBracket)
+		rbrack := p.expect(ast.TokenRBracket)
 
 		var arrayType ast.TypeNode
-		if p.current().Type == ast.TokenIdentifier {
-			// Parse array type annotation
+		next := p.current()
+		// Optional `[elem...]T` suffix: only when `T` is on the same line as `]`. Otherwise a
+		// closing `]` at end of line would consume the next statement's identifier (e.g. `xs` in
+		// `ys := [...]\n  xs := [...]`).
+		if next.Type == ast.TokenIdentifier && next.Line == rbrack.Line {
 			arrayType = ast.TypeNode{
-				Ident: ast.TypeIdent(p.current().Value),
+				Ident: ast.TypeIdent(next.Value),
 			}
-			p.advance() // Consume type identifier
+			p.advance()
 		} else {
 			arrayType = ast.TypeNode{Ident: ast.TypeImplicit}
 		}

--- a/forst/internal/transformer/go/expression.go
+++ b/forst/internal/transformer/go/expression.go
@@ -172,6 +172,34 @@ func (t *Transformer) transformExpression(expr ast.ExpressionNode) (goast.Expr, 
 			Type: &goast.ArrayType{Elt: eltGo},
 			Elts: elts,
 		}, nil
+	case ast.MapLiteralNode:
+		if e.Type.Ident != ast.TypeMap || len(e.Type.TypeParams) != 2 {
+			return nil, fmt.Errorf("map literal: invalid type %v", e.Type)
+		}
+		keyGo, err := t.transformType(e.Type.TypeParams[0])
+		if err != nil {
+			return nil, err
+		}
+		valGo, err := t.transformType(e.Type.TypeParams[1])
+		if err != nil {
+			return nil, err
+		}
+		elts := make([]goast.Expr, 0, len(e.Entries))
+		for _, ent := range e.Entries {
+			kx, err := t.transformExpression(ent.Key)
+			if err != nil {
+				return nil, err
+			}
+			vx, err := t.transformExpression(ent.Value)
+			if err != nil {
+				return nil, err
+			}
+			elts = append(elts, &goast.KeyValueExpr{Key: kx, Value: vx})
+		}
+		return &goast.CompositeLit{
+			Type: &goast.MapType{Key: keyGo, Value: valGo},
+			Elts: elts,
+		}, nil
 	case ast.UnaryExpressionNode:
 		op, err := t.transformOperator(e.Operator)
 		if err != nil {

--- a/forst/internal/transformer/go/pipeline_integration_test.go
+++ b/forst/internal/transformer/go/pipeline_integration_test.go
@@ -202,6 +202,37 @@ func main() {
 `,
 			needles: []string{`defer work()`, `go work()`, `func main`},
 		},
+		{
+			name: "builtin_len_string",
+			src: `package main
+
+func main() {
+	println(len("hi"))
+}
+`,
+			needles: []string{`package main`, `len("hi")`, `println`},
+		},
+		{
+			name: "builtin_len_array_literal",
+			src: `package main
+
+func main() {
+	println(len([1, 2, 3]))
+}
+`,
+			needles: []string{`len(`, `func main`},
+		},
+		{
+			name: "builtin_min_max_literals",
+			src: `package main
+
+func main() {
+	println(min(1, 2, 3))
+	println(max(3, 4))
+}
+`,
+			needles: []string{`min(`, `max(`, `func main`},
+		},
 	}
 
 	for _, tt := range tests {

--- a/forst/internal/transformer/go/type.go
+++ b/forst/internal/transformer/go/type.go
@@ -32,6 +32,28 @@ func (t *Transformer) transformType(n ast.TypeNode) (goast.Expr, error) {
 			return nil, fmt.Errorf("failed to transform pointer base type: %s", err)
 		}
 		return &goast.StarExpr{X: baseType}, nil
+	case ast.TypeArray:
+		if len(n.TypeParams) < 1 {
+			return nil, fmt.Errorf("array type must have element type parameter")
+		}
+		elt, err := t.transformType(n.TypeParams[0])
+		if err != nil {
+			return nil, err
+		}
+		return &goast.ArrayType{Elt: elt}, nil
+	case ast.TypeMap:
+		if len(n.TypeParams) < 2 {
+			return nil, fmt.Errorf("map type must have key and value type parameters")
+		}
+		keyT, err := t.transformType(n.TypeParams[0])
+		if err != nil {
+			return nil, err
+		}
+		valT, err := t.transformType(n.TypeParams[1])
+		if err != nil {
+			return nil, err
+		}
+		return &goast.MapType{Key: keyT, Value: valT}, nil
 	default:
 		// Always use the unified type aliasing function from the typechecker for all non-builtin, non-special types
 		name, err := t.TypeChecker.GetAliasedTypeName(n, typechecker.GetAliasedTypeNameOptions{AllowStructuralAlias: false})

--- a/forst/internal/typechecker/builtin_type_helpers.go
+++ b/forst/internal/typechecker/builtin_type_helpers.go
@@ -1,0 +1,84 @@
+package typechecker
+
+import "forst/internal/ast"
+
+// sliceElementType returns the element type of a slice/array TypeNode (Array(T)).
+func sliceElementType(t ast.TypeNode) (ast.TypeNode, bool) {
+	if t.Ident == ast.TypeArray && len(t.TypeParams) >= 1 {
+		return t.TypeParams[0], true
+	}
+	return ast.TypeNode{}, false
+}
+
+// mapKeyValueTypes returns key and value types for Map(K, V).
+func mapKeyValueTypes(t ast.TypeNode) (key, val ast.TypeNode, ok bool) {
+	if t.Ident != ast.TypeMap || len(t.TypeParams) < 2 {
+		return ast.TypeNode{}, ast.TypeNode{}, false
+	}
+	return t.TypeParams[0], t.TypeParams[1], true
+}
+
+// lenOperandAllowed mirrors Go's len: string, array, slice, map, pointer to array,
+// and channel when modeled. Forst does not model channel types yet; pointer-to-slice
+// uses the same Array(T) representation as a slice, so we allow Pointer(Array(T)).
+func lenOperandAllowed(t ast.TypeNode) bool {
+	switch t.Ident {
+	case ast.TypeString, ast.TypeMap:
+		return true
+	case ast.TypeArray:
+		return true
+	case ast.TypePointer:
+		if len(t.TypeParams) != 1 {
+			return false
+		}
+		return t.TypeParams[0].Ident == ast.TypeArray
+	default:
+		return false
+	}
+}
+
+// capOperandAllowed mirrors Go's cap: slice, array, channel. Channel is not modeled.
+func capOperandAllowed(t ast.TypeNode) bool {
+	switch t.Ident {
+	case ast.TypeArray:
+		return true
+	case ast.TypePointer:
+		if len(t.TypeParams) != 1 {
+			return false
+		}
+		return t.TypeParams[0].Ident == ast.TypeArray
+	default:
+		return false
+	}
+}
+
+// clearOperandAllowed: Go 1.21+ clear on map or slice.
+func clearOperandAllowed(t ast.TypeNode) bool {
+	return t.Ident == ast.TypeMap || t.Ident == ast.TypeArray
+}
+
+// builtinTypesIdenticalOrdered checks structural identity for min/max (same ordered type).
+func builtinTypesIdenticalOrdered(a, b ast.TypeNode) bool {
+	if a.Ident != b.Ident {
+		return false
+	}
+	if len(a.TypeParams) != len(b.TypeParams) {
+		return false
+	}
+	for i := range a.TypeParams {
+		if !builtinTypesIdenticalOrdered(a.TypeParams[i], b.TypeParams[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isOrderedBuiltinType is the subset of cmp.Ordered we model without full generics.
+func isOrderedBuiltinType(t ast.TypeNode) bool {
+	switch t.Ident {
+	case ast.TypeInt, ast.TypeFloat, ast.TypeString:
+		return true
+	default:
+		return false
+	}
+}

--- a/forst/internal/typechecker/builtin_type_helpers_test.go
+++ b/forst/internal/typechecker/builtin_type_helpers_test.go
@@ -1,0 +1,60 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestBuiltinHelpers_lenOperandAllowed(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  ast.TypeNode
+		want bool
+	}{
+		{"string", ast.NewBuiltinType(ast.TypeString), true},
+		{"map", ast.NewMapType(ast.NewBuiltinType(ast.TypeString), ast.NewBuiltinType(ast.TypeInt)), true},
+		{"slice", ast.NewArrayType(ast.NewBuiltinType(ast.TypeInt)), true},
+		{"pointer_to_slice", ast.NewPointerType(ast.NewArrayType(ast.NewBuiltinType(ast.TypeBool))), true},
+		{"int", ast.NewBuiltinType(ast.TypeInt), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lenOperandAllowed(tt.typ); got != tt.want {
+				t.Fatalf("lenOperandAllowed(%v) = %v, want %v", tt.typ, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuiltinHelpers_capOperandAllowed(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  ast.TypeNode
+		want bool
+	}{
+		{"slice", ast.NewArrayType(ast.NewBuiltinType(ast.TypeInt)), true},
+		{"pointer_to_slice", ast.NewPointerType(ast.NewArrayType(ast.NewBuiltinType(ast.TypeBool))), true},
+		{"string", ast.NewBuiltinType(ast.TypeString), false},
+		{"map", ast.NewMapType(ast.NewBuiltinType(ast.TypeString), ast.NewBuiltinType(ast.TypeInt)), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := capOperandAllowed(tt.typ); got != tt.want {
+				t.Fatalf("capOperandAllowed(%v) = %v, want %v", tt.typ, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuiltinHelpers_builtinTypesIdenticalOrdered(t *testing.T) {
+	a := ast.NewArrayType(ast.NewBuiltinType(ast.TypeInt))
+	b := ast.NewArrayType(ast.NewBuiltinType(ast.TypeInt))
+	c := ast.NewArrayType(ast.NewBuiltinType(ast.TypeString))
+	if !builtinTypesIdenticalOrdered(a, b) {
+		t.Fatal("expected identical")
+	}
+	if builtinTypesIdenticalOrdered(a, c) {
+		t.Fatal("expected not identical")
+	}
+}

--- a/forst/internal/typechecker/go_builtins.go
+++ b/forst/internal/typechecker/go_builtins.go
@@ -6,6 +6,17 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
+// BuiltinCheckKind says how checkBuiltinFunctionCall validates a builtin.
+type BuiltinCheckKind uint8
+
+const (
+	// BuiltinCheckGeneric uses ParamTypes, arity, and IsTypeCompatible (stdlib entries, string() conversion).
+	BuiltinCheckGeneric BuiltinCheckKind = iota
+	// BuiltinCheckDispatch: rules live in tryDispatchGoBuiltin + helpers; ParamTypes are placeholders
+	// for arity/LSP only — never used with IsTypeCompatible for these entries.
+	BuiltinCheckDispatch
+)
+
 // BuiltinFunction represents a built-in function with its type signature
 type BuiltinFunction struct {
 	Name           string
@@ -14,25 +25,31 @@ type BuiltinFunction struct {
 	ParamTypes     []ast.TypeNode
 	IsVarArgs      bool
 	AcceptSubtypes bool // Whether to accept subtypes of parameter types
+	CheckKind      BuiltinCheckKind
+	// HoverSignature is optional markdown for hover when CheckKind is BuiltinCheckDispatch (otherwise ParamTypes are shown).
+	HoverSignature string
 }
 
 // BuiltinFunctions maps function names to their type signatures
 var BuiltinFunctions = map[string]BuiltinFunction{
-	// Built-in functions that don't require a package
+	// Predeclared Go builtins (no package): type-checking is implemented in tryDispatchGoBuiltin, not ParamTypes.
 	"len": {
 		Name:           "len",
-		Package:        "", // No package required
+		Package:        "",
 		ReturnType:     ast.TypeNode{Ident: ast.TypeInt},
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // Base type
-		AcceptSubtypes: true,                                    // Accept subtypes like Password
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
+		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
+		HoverSignature: "predeclared `len` via tryDispatchGoBuiltin (operand: string, slice, map, …)",
 	},
 	"println": {
 		Name:           "println",
-		Package:        "", // No package required
+		Package:        "",
 		ReturnType:     ast.TypeNode{Ident: ast.TypeVoid},
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // Base type
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}},
 		IsVarArgs:      true,
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	// Go predeclared string(): conversion (e.g. code point to UTF-8 string)
 	"string": {
@@ -44,119 +61,135 @@ var BuiltinFunctions = map[string]BuiltinFunction{
 	},
 	"print": {
 		Name:           "print",
-		Package:        "", // No package required
+		Package:        "",
 		ReturnType:     ast.TypeNode{Ident: ast.TypeVoid},
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // Base type
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}},
 		IsVarArgs:      true,
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"cap": {
 		Name:           "cap",
-		Package:        "", // No package required
+		Package:        "",
 		ReturnType:     ast.TypeNode{Ident: ast.TypeInt},
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // Base type
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"append": {
 		Name:           "append",
-		Package:        "",                                      // No package required
-		ReturnType:     ast.TypeNode{Ident: ast.TypeString},     // Returns same type as input
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // Base type
+		Package:        "",
+		ReturnType:     ast.TypeNode{Ident: ast.TypeObject},
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		IsVarArgs:      true,
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"make": {
 		Name:           "make",
-		Package:        "",                                      // No package required
-		ReturnType:     ast.TypeNode{Ident: ast.TypeString},     // Returns same type as input
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // Base type
+		Package:        "",
+		ReturnType:     ast.TypeNode{Ident: ast.TypeObject},
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		IsVarArgs:      true,
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"new": {
 		Name:           "new",
-		Package:        "",                                      // No package required
-		ReturnType:     ast.TypeNode{Ident: ast.TypeString},     // Returns pointer to type
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // Base type
+		Package:        "",
+		ReturnType:     ast.TypeNode{Ident: ast.TypeObject},
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"clear": {
 		Name:           "clear",
-		Package:        "", // No package required
+		Package:        "",
 		ReturnType:     ast.TypeNode{Ident: ast.TypeVoid},
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // container to clear
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"complex": {
 		Name:           "complex",
-		Package:        "",                                                               // No package required
-		ReturnType:     ast.TypeNode{Ident: ast.TypeString},                              // Returns complex number
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}, {Ident: ast.TypeString}}, // real, imag parts
+		Package:        "",
+		ReturnType:     ast.TypeNode{Ident: ast.TypeObject},
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeFloat}, {Ident: ast.TypeFloat}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"real": {
 		Name:           "real",
-		Package:        "",                                      // No package required
-		ReturnType:     ast.TypeNode{Ident: ast.TypeString},     // Returns real part
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // complex number
+		Package:        "",
+		ReturnType:     ast.TypeNode{Ident: ast.TypeFloat},
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"imag": {
 		Name:           "imag",
-		Package:        "",                                      // No package required
-		ReturnType:     ast.TypeNode{Ident: ast.TypeString},     // Returns imaginary part
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // complex number
+		Package:        "",
+		ReturnType:     ast.TypeNode{Ident: ast.TypeFloat},
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"delete": {
 		Name:           "delete",
-		Package:        "", // No package required
+		Package:        "",
 		ReturnType:     ast.TypeNode{Ident: ast.TypeVoid},
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}, {Ident: ast.TypeString}}, // map, key
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}, {Ident: ast.TypeObject}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"close": {
 		Name:           "close",
-		Package:        "", // No package required
+		Package:        "",
 		ReturnType:     ast.TypeNode{Ident: ast.TypeVoid},
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // channel
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"min": {
 		Name:           "min",
-		Package:        "",                                      // No package required
-		ReturnType:     ast.TypeNode{Ident: ast.TypeString},     // Returns smallest value
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // values to compare
+		Package:        "",
+		ReturnType:     ast.TypeNode{Ident: ast.TypeObject},
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		IsVarArgs:      true,
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"max": {
 		Name:           "max",
-		Package:        "",                                      // No package required
-		ReturnType:     ast.TypeNode{Ident: ast.TypeString},     // Returns largest value
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // values to compare
+		Package:        "",
+		ReturnType:     ast.TypeNode{Ident: ast.TypeObject},
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		IsVarArgs:      true,
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"panic": {
 		Name:           "panic",
-		Package:        "", // No package required
+		Package:        "",
 		ReturnType:     ast.TypeNode{Ident: ast.TypeVoid},
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}}, // panic value
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"recover": {
 		Name:           "recover",
-		Package:        "",                                  // No package required
-		ReturnType:     ast.TypeNode{Ident: ast.TypeString}, // Returns panic value
+		Package:        "",
+		ReturnType:     ast.TypeNode{Ident: ast.TypeObject},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 	"copy": {
 		Name:           "copy",
-		Package:        "", // No package required
+		Package:        "",
 		ReturnType:     ast.TypeNode{Ident: ast.TypeInt},
-		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeString}, {Ident: ast.TypeString}}, // dst, src
+		ParamTypes:     []ast.TypeNode{{Ident: ast.TypeObject}, {Ident: ast.TypeObject}},
 		AcceptSubtypes: true,
+		CheckKind:      BuiltinCheckDispatch,
 	},
 
 	// fmt package functions
@@ -376,6 +409,16 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 		return true
 	}
 
+	// Assigning to TypeObject mirrors Go assignability to interface{} / any (empty interface).
+	if expected.Ident == ast.TypeObject && actual.Ident != ast.TypeVoid {
+		tc.log.WithFields(logrus.Fields{
+			"actual":   actual.Ident,
+			"expected": expected.Ident,
+			"function": "IsTypeCompatible",
+		}).Debug("Actual type assignable to TypeObject")
+		return true
+	}
+
 	// Check if actual type is an alias of expected type
 	actualDef, actualExists := tc.Defs[actual.Ident]
 	if actualExists {
@@ -546,6 +589,20 @@ func (tc *TypeChecker) checkBuiltinFunctionCall(fn BuiltinFunction, args []ast.E
 		}
 	}
 
+	// Go predeclared builtins (empty package): semantics are implemented in tryDispatchGoBuiltin, not ParamTypes.
+	if fn.Package == "" && fn.Name != "string" {
+		ret, ok, err := tc.tryDispatchGoBuiltin(fn, args, argSpans, callSpan)
+		if ok {
+			return ret, err
+		}
+		if err != nil {
+			return nil, err
+		}
+		if fn.CheckKind == BuiltinCheckDispatch {
+			return nil, diagnosticf(callSpan, "builtin-call", "internal: missing tryDispatchGoBuiltin case for %q", fn.Name)
+		}
+	}
+
 	// Check argument count
 	if !fn.IsVarArgs && len(args) != len(fn.ParamTypes) {
 		tc.log.WithFields(logrus.Fields{
@@ -601,4 +658,252 @@ func (tc *TypeChecker) checkBuiltinFunctionCall(fn BuiltinFunction, args []ast.E
 	}
 
 	return []ast.TypeNode{fn.ReturnType}, nil
+}
+
+func (tc *TypeChecker) inferBuiltinArgType(args []ast.ExpressionNode, i int, argSpans []ast.SourceSpan, callSpan ast.SourceSpan) (ast.TypeNode, error) {
+	if i < 0 || i >= len(args) {
+		return ast.TypeNode{}, diagnosticf(callSpan, "builtin-call", "internal: missing argument %d", i+1)
+	}
+	sp := spanForCallArg(argSpans, i, args, callSpan)
+	ts, err := tc.inferExpressionType(args[i])
+	if err != nil {
+		return ast.TypeNode{}, err
+	}
+	if len(ts) != 1 {
+		return ast.TypeNode{}, diagnosticf(sp, "builtin-call", "argument %d must have a single type", i+1)
+	}
+	return ts[0], nil
+}
+
+// tryDispatchGoBuiltin applies Go-aligned rules for predeclared builtins (Package "").
+// If it returns handled=false, the caller falls back to generic ParamTypes checking.
+func (tc *TypeChecker) tryDispatchGoBuiltin(fn BuiltinFunction, args []ast.ExpressionNode, argSpans []ast.SourceSpan, callSpan ast.SourceSpan) ([]ast.TypeNode, bool, error) {
+	intT := ast.NewBuiltinType(ast.TypeInt)
+	voidT := ast.NewBuiltinType(ast.TypeVoid)
+	objT := ast.NewBuiltinType(ast.TypeObject)
+	floatT := ast.NewBuiltinType(ast.TypeFloat)
+
+	switch fn.Name {
+	case "len":
+		if len(args) != 1 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "len() expects 1 argument, got %d", len(args))
+		}
+		t, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		if !lenOperandAllowed(t) {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "len() invalid operand type %s", t.Ident)
+		}
+		return []ast.TypeNode{intT}, true, nil
+
+	case "cap":
+		if len(args) != 1 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "cap() expects 1 argument, got %d", len(args))
+		}
+		t, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		if !capOperandAllowed(t) {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "cap() invalid operand type %s", t.Ident)
+		}
+		return []ast.TypeNode{intT}, true, nil
+
+	case "append":
+		if len(args) < 2 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "append() expects at least 2 arguments, got %d", len(args))
+		}
+		sliceT, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		if sliceT.Ident != ast.TypeArray {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "append() first argument must be a slice, got %s", sliceT.Ident)
+		}
+		elem, ok := sliceElementType(sliceT)
+		if !ok {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "append() slice must have an element type")
+		}
+		for i := 1; i < len(args); i++ {
+			at, err := tc.inferBuiltinArgType(args, i, argSpans, callSpan)
+			if err != nil {
+				return nil, true, err
+			}
+			if !tc.IsTypeCompatible(at, elem) {
+				sp := spanForCallArg(argSpans, i, args, callSpan)
+				return nil, true, diagnosticf(sp, "builtin-call", "append() argument %d must be assignable to slice element %s, got %s",
+					i+1, elem.Ident, at.Ident)
+			}
+		}
+		return []ast.TypeNode{sliceT}, true, nil
+
+	case "copy":
+		if len(args) != 2 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "copy() expects 2 arguments, got %d", len(args))
+		}
+		dstT, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		srcT, err := tc.inferBuiltinArgType(args, 1, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		if dstT.Ident == ast.TypeArray && len(dstT.TypeParams) == 1 && dstT.TypeParams[0].Ident == ast.TypeInt && srcT.Ident == ast.TypeString {
+			return []ast.TypeNode{intT}, true, nil
+		}
+		if dstT.Ident != ast.TypeArray || srcT.Ident != ast.TypeArray {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "copy() expects two slices, or []Int with String (Go copy to []byte)")
+		}
+		de, ok1 := sliceElementType(dstT)
+		se, ok2 := sliceElementType(srcT)
+		if !ok1 || !ok2 {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "copy() could not read slice element types")
+		}
+		if !builtinTypesIdenticalOrdered(de, se) {
+			sp := spanForCallArg(argSpans, 1, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "copy() slice element types must match")
+		}
+		return []ast.TypeNode{intT}, true, nil
+
+	case "delete":
+		if len(args) != 2 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "delete() expects 2 arguments, got %d", len(args))
+		}
+		mT, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		keyT, err := tc.inferBuiltinArgType(args, 1, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		kFormal, _, ok := mapKeyValueTypes(mT)
+		if !ok {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "delete() first argument must be a map, got %s", mT.Ident)
+		}
+		if !tc.IsTypeCompatible(keyT, kFormal) {
+			sp := spanForCallArg(argSpans, 1, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "delete() key type incompatible with map key %s", kFormal.Ident)
+		}
+		return []ast.TypeNode{voidT}, true, nil
+
+	case "close":
+		if len(args) != 1 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "close() expects 1 argument, got %d", len(args))
+		}
+		if _, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan); err != nil {
+			return nil, true, err
+		}
+		return []ast.TypeNode{voidT}, true, nil
+
+	case "clear":
+		if len(args) != 1 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "clear() expects 1 argument, got %d", len(args))
+		}
+		t, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		if !clearOperandAllowed(t) {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "clear() expects a map or slice, got %s", t.Ident)
+		}
+		return []ast.TypeNode{voidT}, true, nil
+
+	case "min", "max":
+		if len(args) < 1 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "%s() expects at least 1 argument", fn.Name)
+		}
+		first, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		if !isOrderedBuiltinType(first) {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "%s() expects ordered types (Int, Float, String), got %s", fn.Name, first.Ident)
+		}
+		for i := 1; i < len(args); i++ {
+			at, err := tc.inferBuiltinArgType(args, i, argSpans, callSpan)
+			if err != nil {
+				return nil, true, err
+			}
+			if !builtinTypesIdenticalOrdered(first, at) {
+				sp := spanForCallArg(argSpans, i, args, callSpan)
+				return nil, true, diagnosticf(sp, "builtin-call", "%s() arguments must have the same type", fn.Name)
+			}
+		}
+		return []ast.TypeNode{first}, true, nil
+
+	case "complex":
+		if len(args) != 2 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "complex() expects 2 arguments, got %d", len(args))
+		}
+		a, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		b, err := tc.inferBuiltinArgType(args, 1, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		if a.Ident != ast.TypeFloat || b.Ident != ast.TypeFloat {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "complex() expects Float arguments, got %s and %s", a.Ident, b.Ident)
+		}
+		return []ast.TypeNode{objT}, true, nil
+
+	case "real", "imag":
+		if len(args) != 1 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "%s() expects 1 argument, got %d", fn.Name, len(args))
+		}
+		t, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan)
+		if err != nil {
+			return nil, true, err
+		}
+		// Forst has no complex128 TypeIdent; complex() is typed as Object.
+		if t.Ident != ast.TypeObject {
+			sp := spanForCallArg(argSpans, 0, args, callSpan)
+			return nil, true, diagnosticf(sp, "builtin-call", "%s() expects a complex value, got %s", fn.Name, t.Ident)
+		}
+		return []ast.TypeNode{floatT}, true, nil
+
+	case "panic":
+		if len(args) != 1 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "panic() expects 1 argument, got %d", len(args))
+		}
+		if _, err := tc.inferBuiltinArgType(args, 0, argSpans, callSpan); err != nil {
+			return nil, true, err
+		}
+		return []ast.TypeNode{voidT}, true, nil
+
+	case "print", "println":
+		for i := range args {
+			if _, err := tc.inferBuiltinArgType(args, i, argSpans, callSpan); err != nil {
+				return nil, true, err
+			}
+		}
+		return []ast.TypeNode{voidT}, true, nil
+
+	case "recover":
+		if len(args) != 0 {
+			return nil, true, diagnosticf(callSpan, "builtin-call", "recover() expects 0 arguments, got %d", len(args))
+		}
+		return []ast.TypeNode{objT}, true, nil
+
+	case "make", "new":
+		return nil, true, diagnosticf(callSpan, "builtin-call",
+			"%s() with a type argument is not supported yet: use Forst type syntax (e.g. Array(Int)) when the parser accepts types in call position, or use a small Go helper via import", fn.Name)
+
+	default:
+		return nil, false, nil
+	}
 }

--- a/forst/internal/typechecker/go_builtins_test.go
+++ b/forst/internal/typechecker/go_builtins_test.go
@@ -147,6 +147,25 @@ func TestCheckBuiltinFunctionCall_stringInt(t *testing.T) {
 	}
 }
 
+func TestIsTypeCompatible_concreteAssignableToTypeObject(t *testing.T) {
+	tc := New(logrus.New(), false)
+	if !tc.IsTypeCompatible(ast.NewBuiltinType(ast.TypeString), ast.NewBuiltinType(ast.TypeObject)) {
+		t.Fatal("String should be assignable where TypeObject is expected (empty-interface-like)")
+	}
+	if tc.IsTypeCompatible(ast.NewBuiltinType(ast.TypeVoid), ast.NewBuiltinType(ast.TypeObject)) {
+		t.Fatal("Void should not assign to TypeObject")
+	}
+}
+
+func TestBuiltinFunction_lenIsDispatchKind(t *testing.T) {
+	if BuiltinFunctions["len"].CheckKind != BuiltinCheckDispatch {
+		t.Fatalf("len should use BuiltinCheckDispatch, got %v", BuiltinFunctions["len"].CheckKind)
+	}
+	if BuiltinFunctions["string"].CheckKind != BuiltinCheckGeneric {
+		t.Fatalf("string() should use BuiltinCheckGeneric, got %v", BuiltinFunctions["string"].CheckKind)
+	}
+}
+
 func TestCheckBuiltinFunctionCall_stringRejectsNonInt(t *testing.T) {
 	tc := New(logrus.New(), false)
 	fn := BuiltinFunctions["string"]
@@ -154,4 +173,155 @@ func TestCheckBuiltinFunctionCall_stringRejectsNonInt(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for string() of string")
 	}
+}
+
+func TestCheckBuiltinFunctionCall_goPredeclared(t *testing.T) {
+	tc := New(logrus.New(), false)
+	tc.CurrentScope().RegisterSymbol(ast.Identifier("m"), []ast.TypeNode{
+		ast.NewMapType(ast.NewBuiltinType(ast.TypeString), ast.NewBuiltinType(ast.TypeInt)),
+	}, SymbolVariable)
+
+	t.Run("len string ok", func(t *testing.T) {
+		fn := BuiltinFunctions["len"]
+		types, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{ast.StringLiteralNode{Value: "ab"}}, nil, ast.SourceSpan{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(types) != 1 || types[0].Ident != ast.TypeInt {
+			t.Fatalf("got %+v", types)
+		}
+	})
+
+	t.Run("len string variable", func(t *testing.T) {
+		tc2 := New(logrus.New(), false)
+		tc2.CurrentScope().RegisterSymbol(ast.Identifier("s"), []ast.TypeNode{ast.NewBuiltinType(ast.TypeString)}, SymbolVariable)
+		fn := BuiltinFunctions["len"]
+		types, err := tc2.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{ast.VariableNode{Ident: ast.Ident{ID: "s"}}}, nil, ast.SourceSpan{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(types) != 1 || types[0].Ident != ast.TypeInt {
+			t.Fatalf("got %+v", types)
+		}
+	})
+
+	t.Run("len int fails", func(t *testing.T) {
+		fn := BuiltinFunctions["len"]
+		_, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{ast.IntLiteralNode{Value: 1}}, nil, ast.SourceSpan{})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("append slice", func(t *testing.T) {
+		fn := BuiltinFunctions["append"]
+		types, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{
+			ast.ArrayLiteralNode{Value: []ast.LiteralNode{ast.IntLiteralNode{Value: 1}}},
+			ast.IntLiteralNode{Value: 2},
+		}, nil, ast.SourceSpan{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(types) != 1 || types[0].Ident != ast.TypeArray {
+			t.Fatalf("got %+v", types)
+		}
+	})
+
+	t.Run("delete map", func(t *testing.T) {
+		fn := BuiltinFunctions["delete"]
+		_, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{
+			ast.VariableNode{Ident: ast.Ident{ID: "m"}},
+			ast.StringLiteralNode{Value: "k"},
+		}, nil, ast.SourceSpan{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("min int", func(t *testing.T) {
+		fn := BuiltinFunctions["min"]
+		types, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{
+			ast.IntLiteralNode{Value: 3},
+			ast.IntLiteralNode{Value: 1},
+		}, nil, ast.SourceSpan{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(types) != 1 || types[0].Ident != ast.TypeInt {
+			t.Fatalf("got %+v", types)
+		}
+	})
+
+	t.Run("min mixed types fails", func(t *testing.T) {
+		fn := BuiltinFunctions["min"]
+		_, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{
+			ast.IntLiteralNode{Value: 1},
+			ast.FloatLiteralNode{Value: 2},
+		}, nil, ast.SourceSpan{})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("complex", func(t *testing.T) {
+		fn := BuiltinFunctions["complex"]
+		types, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{
+			ast.FloatLiteralNode{Value: 1},
+			ast.FloatLiteralNode{Value: 0},
+		}, nil, ast.SourceSpan{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(types) != 1 || types[0].Ident != ast.TypeObject {
+			t.Fatalf("got %+v", types)
+		}
+	})
+
+	t.Run("real of complex", func(t *testing.T) {
+		complexCall := ast.FunctionCallNode{
+			Function: ast.Ident{ID: "complex"},
+			Arguments: []ast.ExpressionNode{
+				ast.FloatLiteralNode{Value: 3},
+				ast.FloatLiteralNode{Value: 4},
+			},
+		}
+		fn := BuiltinFunctions["real"]
+		types, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{complexCall}, nil, ast.SourceSpan{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(types) != 1 || types[0].Ident != ast.TypeFloat {
+			t.Fatalf("got %+v", types)
+		}
+	})
+
+	t.Run("recover", func(t *testing.T) {
+		fn := BuiltinFunctions["recover"]
+		types, err := tc.checkBuiltinFunctionCall(fn, nil, nil, ast.SourceSpan{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(types) != 1 || types[0].Ident != ast.TypeObject {
+			t.Fatalf("got %+v", types)
+		}
+	})
+
+	t.Run("make unsupported", func(t *testing.T) {
+		fn := BuiltinFunctions["make"]
+		_, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{ast.StringLiteralNode{Value: "x"}}, nil, ast.SourceSpan{})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("println mixed", func(t *testing.T) {
+		fn := BuiltinFunctions["println"]
+		_, err := tc.checkBuiltinFunctionCall(fn, []ast.ExpressionNode{
+			ast.StringLiteralNode{Value: "a"},
+			ast.IntLiteralNode{Value: 2},
+		}, nil, ast.SourceSpan{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/forst/internal/typechecker/go_hover.go
+++ b/forst/internal/typechecker/go_hover.go
@@ -67,7 +67,9 @@ func (tc *TypeChecker) GoHoverMarkdown(pkgLocal, symbol string) (string, bool) {
 	qual := pkgLocal + "." + symbol
 	if bfn, ok := BuiltinFunctions[qual]; ok {
 		b.WriteString("\n\n**Forst (builtin table)** ")
-		if len(bfn.ParamTypes) > 0 {
+		if bfn.HoverSignature != "" {
+			b.WriteString(bfn.HoverSignature + " → ")
+		} else if len(bfn.ParamTypes) > 0 {
 			parts := make([]string, len(bfn.ParamTypes))
 			for i, p := range bfn.ParamTypes {
 				parts[i] = tc.FormatTypeNodeDisplay(p)

--- a/forst/internal/typechecker/infer_expression.go
+++ b/forst/internal/typechecker/infer_expression.go
@@ -287,6 +287,36 @@ func (tc *TypeChecker) inferExpressionType(expr ast.Node) ([]ast.TypeNode, error
 		// Return a special marker (empty slice) to indicate untyped nil; context must resolve
 		return nil, nil
 
+	case ast.MapLiteralNode:
+		if e.Type.Ident != ast.TypeMap || len(e.Type.TypeParams) != 2 {
+			return nil, fmt.Errorf("map literal: invalid type %v", e.Type)
+		}
+		wantK, wantV := e.Type.TypeParams[0], e.Type.TypeParams[1]
+		for i, ent := range e.Entries {
+			kt, err := tc.inferExpressionType(ent.Key)
+			if err != nil {
+				return nil, fmt.Errorf("map literal entry %d key: %w", i, err)
+			}
+			if len(kt) != 1 {
+				return nil, fmt.Errorf("map literal entry %d key: expected one type", i)
+			}
+			if !tc.IsTypeCompatible(kt[0], wantK) {
+				return nil, fmt.Errorf("map literal entry %d key: want %s, got %s", i, wantK.Ident, kt[0].Ident)
+			}
+			vt, err := tc.inferExpressionType(ent.Value)
+			if err != nil {
+				return nil, fmt.Errorf("map literal entry %d value: %w", i, err)
+			}
+			if len(vt) != 1 {
+				return nil, fmt.Errorf("map literal entry %d value: expected one type", i)
+			}
+			if !tc.IsTypeCompatible(vt[0], wantV) {
+				return nil, fmt.Errorf("map literal entry %d value: want %s, got %s", i, wantV.Ident, vt[0].Ident)
+			}
+		}
+		tc.storeInferredType(e, []ast.TypeNode{e.Type})
+		return []ast.TypeNode{e.Type}, nil
+
 	default:
 		tc.log.Tracef("Unhandled expression type: %T", expr)
 		return nil, fmt.Errorf("cannot infer type for expression: %T", expr)

--- a/forst/internal/typechecker/infer_expression_test.go
+++ b/forst/internal/typechecker/infer_expression_test.go
@@ -127,3 +127,53 @@ func TestInferExpressionType_ArrayLiteralNode_emptyDefaultsToIntElem(t *testing.
 		t.Fatalf("got %+v", types)
 	}
 }
+
+func TestInferExpressionType_MapLiteralNode_stringInt(t *testing.T) {
+	tc := New(logrus.New(), false)
+	m := ast.MapLiteralNode{
+		Type: ast.TypeNode{
+			Ident: ast.TypeMap,
+			TypeParams: []ast.TypeNode{
+				{Ident: ast.TypeString},
+				{Ident: ast.TypeInt},
+			},
+		},
+		Entries: []ast.MapEntryNode{
+			{
+				Key:   ast.StringLiteralNode{Value: "a"},
+				Value: ast.IntLiteralNode{Value: 1},
+			},
+		},
+	}
+	types, err := tc.inferExpressionType(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(types) != 1 || types[0].Ident != ast.TypeMap || len(types[0].TypeParams) != 2 ||
+		types[0].TypeParams[0].Ident != ast.TypeString || types[0].TypeParams[1].Ident != ast.TypeInt {
+		t.Fatalf("got %+v", types)
+	}
+}
+
+func TestInferExpressionType_MapLiteralNode_keyTypeMismatch(t *testing.T) {
+	tc := New(logrus.New(), false)
+	m := ast.MapLiteralNode{
+		Type: ast.TypeNode{
+			Ident: ast.TypeMap,
+			TypeParams: []ast.TypeNode{
+				{Ident: ast.TypeString},
+				{Ident: ast.TypeInt},
+			},
+		},
+		Entries: []ast.MapEntryNode{
+			{
+				Key:   ast.IntLiteralNode{Value: 1},
+				Value: ast.IntLiteralNode{Value: 2},
+			},
+		},
+	}
+	_, err := tc.inferExpressionType(m)
+	if err == nil {
+		t.Fatal("expected key type error")
+	}
+}


### PR DESCRIPTION
- Route predeclared calls through tryDispatchGoBuiltin with Go-aligned rules; add builtin_type_helpers (len/cap operands, min/max ordering, slice/map helpers).
- Type-check and emit map literals; lower Array/Map in transformType for composite literals.
- Only treat `[…]T` as an element-type suffix when T is on the same line as `]`, so back-to-back `name := […]` lines parse.
- Add examples go_builtins.ft and generics.ft, Task targets, and README/testing/ROADMAP notes; expand tests and pipeline integration cases.

Example:

```forst
scores := map[String]Int{ "a": 1, "b": 2 }
println(len(scores))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Built-in functions (len, append, min, max, delete, copy, cap, clear, complex, real, imag) now properly type-checked and validated
  * Map literals with parameterized types now supported (e.g., `map[String]Int`)
  * Array and slice handling with optional type annotations

* **Bug Fixes**
  * Array literal type suffix parsing now correctly respects newlines, preventing incorrect token consumption

* **Documentation**
  * Added example programs demonstrating built-in parameterized types and functions
  * Expanded examples documentation with RFC structure for future user-defined generics

* **Tests**
  * Comprehensive test coverage for built-in function validation and type checking
  * New tests for array literal parsing edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->