### PR TITLE
feat(lsp): add hover dictionaries for built-in types and guards

### DIFF
--- a/forst/cmd/forst/lsp/hover_completion.go
+++ b/forst/cmd/forst/lsp/hover_completion.go
@@ -338,14 +338,17 @@ func hoverTextForToken(tc *typechecker.TypeChecker, tokens []ast.Token, tok *ast
 		if types, ok := tc.InferredTypesForVariableNode(vn); ok && len(types) > 0 {
 			return variableHoverMarkdownWithGuardDocs(tc, tokens, merge, tok, types)
 		}
+		if md := hoverdoc.BuiltinTypeMarkdown(tok.Value); md != "" {
+			return md
+		}
 		return ""
 	}
 
-	if literalHover(tok) {
-		return ""
-	}
 	if kw := keywordHover(tok); kw != "" {
 		return kw
+	}
+	if literalHover(tok) {
+		return ""
 	}
 	return ""
 }
@@ -668,28 +671,44 @@ func typeDefHoverMarkdown(tokens []ast.Token, merge *packageMergeInfo, def ast.N
 		}
 		return doc + "\n\n" + block
 	case ast.TypeGuardNode:
-		return typeGuardHoverStub(&d)
+		return typeGuardHoverMarkdown(tokens, merge, &d)
 	case *ast.TypeGuardNode:
-		return typeGuardHoverStub(d)
+		return typeGuardHoverMarkdown(tokens, merge, d)
 	default:
 		return ""
 	}
 }
 
-func typeGuardHoverStub(g *ast.TypeGuardNode) string {
+func typeGuardHoverMarkdown(tokens []ast.Token, merge *packageMergeInfo, g *ast.TypeGuardNode) string {
 	if g == nil {
 		return ""
 	}
-	// registerTypeGuard stores *TypeGuardNode in Defs; full signature formatting is optional follow-up.
-	return fmt.Sprintf("```forst\nis ... %s\n```", string(g.Ident))
+	name := string(g.Ident)
+	doc := leadingCommentDocBeforeTypeGuard(tokens, name)
+	if doc == "" && merge != nil {
+		for _, u := range merge.MemberURIs {
+			tks := merge.TokensByURI[u]
+			if doc = leadingCommentDocBeforeTypeGuard(tks, name); doc != "" {
+				break
+			}
+		}
+	}
+	body, err := printer.FormatTypeGuardNode(printer.DefaultConfig(), *g)
+	if err != nil || strings.TrimSpace(body) == "" {
+		body = fmt.Sprintf("is ... %s\n", name)
+	}
+	block := "**Type guard**\n\n```forst\n" + body + "```"
+	if doc == "" {
+		return block
+	}
+	return doc + "\n\n" + block
 }
 
-// literalHover reports whether the token is a literal. We intentionally omit hover text for
-// literals (aligned with TypeScript: no noisy hovers on `42`, `"hi"`, etc.).
+// literalHover reports whether the token is a numeric or string literal. Boolean and nil
+// tokens are documented via keywordHover instead.
 func literalHover(tok *ast.Token) bool {
 	switch tok.Type {
-	case ast.TokenIntLiteral, ast.TokenFloatLiteral, ast.TokenStringLiteral,
-		ast.TokenTrue, ast.TokenFalse, ast.TokenNil:
+	case ast.TokenIntLiteral, ast.TokenFloatLiteral, ast.TokenStringLiteral:
 		return true
 	default:
 		return false

--- a/forst/cmd/forst/lsp/hover_completion.go
+++ b/forst/cmd/forst/lsp/hover_completion.go
@@ -9,6 +9,7 @@ import (
 	"forst/internal/ast"
 	"forst/internal/goload"
 	"forst/internal/printer"
+	"forst/internal/hoverdoc"
 	"forst/internal/typechecker"
 
 	"github.com/sirupsen/logrus"
@@ -278,10 +279,13 @@ func variableHoverMarkdownWithGuardDocs(tc *typechecker.TypeChecker, tokens []as
 			}
 		}
 		doc := leadingCommentDocBeforeTypeGuard(docTokens, g)
-		if doc == "" {
+		if doc != "" {
+			docBlocks = append(docBlocks, fmt.Sprintf("**%s**\n\n%s", g, doc))
 			continue
 		}
-		docBlocks = append(docBlocks, fmt.Sprintf("**%s**\n\n%s", g, doc))
+		if fb := hoverdoc.GuardMarkdown(g); fb != "" {
+			docBlocks = append(docBlocks, fb)
+		}
 	}
 	if len(docBlocks) == 0 {
 		return body
@@ -324,6 +328,9 @@ func hoverTextForToken(tc *typechecker.TypeChecker, tokens []ast.Token, tok *ast
 		}
 		if def, ok := tc.Defs[ast.TypeIdent(tok.Value)]; ok {
 			return typeDefHoverMarkdown(tokens, merge, def)
+		}
+		if doc := guardIdentifierHoverMarkdown(tokens, tok); doc != "" {
+			return doc
 		}
 		vn := ast.VariableNode{
 			Ident: ast.Ident{ID: id, Span: ast.SpanFromToken(*tok)},
@@ -689,39 +696,26 @@ func literalHover(tok *ast.Token) bool {
 	}
 }
 
-// keywordHover returns a single-line quick info string (keyword in backticks), similar to
-// built-in TypeScript keyword hovers — no tutorial paragraphs.
+// keywordHover returns markdown for documented keywords and built-in type tokens (see
+// internal/hoverdoc).
 func keywordHover(tok *ast.Token) string {
-	switch tok.Type {
-	case ast.TokenFunc:
-		return "`func`"
-	case ast.TokenType:
-		return "`type`"
-	case ast.TokenReturn:
-		return "`return`"
-	case ast.TokenEnsure:
-		return "`ensure`"
-	case ast.TokenImport:
-		return "`import`"
-	case ast.TokenPackage:
-		return "`package`"
-	case ast.TokenInt:
-		return "`Int`"
-	case ast.TokenFloat:
-		return "`Float`"
-	case ast.TokenString:
-		return "`String`"
-	case ast.TokenBool:
-		return "`Bool`"
-	case ast.TokenVoid:
-		return "`Void`"
-	case ast.TokenArray:
-		return "`Array`"
-	case ast.TokenStruct:
-		return "`struct`"
-	default:
+	if tok == nil {
 		return ""
 	}
+	return hoverdoc.MarkdownForKeywordToken(tok.Type)
+}
+
+// guardIdentifierHoverMarkdown returns built-in guard documentation when the identifier appears
+// immediately after `is` (e.g. ensure x is Min(1), if x is Ok()).
+func guardIdentifierHoverMarkdown(tokens []ast.Token, tok *ast.Token) string {
+	if tok == nil || tok.Type != ast.TokenIdentifier {
+		return ""
+	}
+	i := tokenSliceIndex(tokens, tok)
+	if i < 1 || tokens[i-1].Type != ast.TokenIs {
+		return ""
+	}
+	return hoverdoc.GuardMarkdown(tok.Value)
 }
 
 // leadingCommentDocBeforeFunc returns plain text from // or /* */ comments that appear in the

--- a/forst/cmd/forst/lsp/hover_completion_test.go
+++ b/forst/cmd/forst/lsp/hover_completion_test.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -793,4 +794,214 @@ func f(): String {
 		t.Fatalf("doc should appear above the forst code block; got %q", val)
 	}
 	_ = ctx
+}
+
+func TestHandleHover_invalidParamsReturnsParseError(t *testing.T) {
+	t.Parallel()
+	s := NewLSPServer("8080", logrus.New())
+	resp := s.handleHover(LSPRequest{
+		JSONRPC: "2.0",
+		ID:      42,
+		Params:  json.RawMessage(`not-json`),
+	})
+	if resp.Error == nil {
+		t.Fatal("expected JSON-RPC error for invalid params")
+	}
+	if resp.Error.Code != -32700 {
+		t.Fatalf("want code -32700, got %d msg %q", resp.Error.Code, resp.Error.Message)
+	}
+	if resp.ID != 42 {
+		t.Fatalf("echo id: got %v", resp.ID)
+	}
+}
+
+func TestHandleCompletion_invalidParamsReturnsParseError(t *testing.T) {
+	t.Parallel()
+	s := NewLSPServer("8080", logrus.New())
+	resp := s.handleCompletion(LSPRequest{
+		JSONRPC: "2.0",
+		ID:      7,
+		Params:  json.RawMessage(`{`),
+	})
+	if resp.Error == nil {
+		t.Fatal("expected JSON-RPC error for invalid params")
+	}
+	if resp.Error.Code != -32700 {
+		t.Fatalf("want code -32700, got %d", resp.Error.Code)
+	}
+}
+
+func TestLexicalHoverMarkdown_trueFalseNil(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		tok  ast.TokenIdent
+		want string
+	}{
+		{ast.TokenTrue, "true"},
+		{ast.TokenFalse, "false"},
+		{ast.TokenNil, "nil"},
+	}
+	for _, tc := range cases {
+		tok := ast.Token{Type: tc.tok, Value: tc.want}
+		s := lexicalHoverMarkdown(&tok)
+		if s == "" || !strings.Contains(s, tc.want) {
+			t.Fatalf("%v: got %q", tc.tok, s)
+		}
+	}
+}
+
+func TestFindHover_crossFileTypeLeadingComment(t *testing.T) {
+	t.Parallel()
+	s := NewLSPServer("8080", logrus.New())
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "widget.ft")
+	bPath := filepath.Join(dir, "use.ft")
+	const srcA = `package main
+
+// Widget wraps an identifier
+type Widget = {
+  id: Int
+}
+`
+	const srcB = `package main
+
+func wid(w: Widget): Int {
+  return w.id
+}
+`
+	if err := os.WriteFile(aPath, []byte(srcA), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(srcB), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uriA := mustFileURI(t, aPath)
+	uriB := mustFileURI(t, bPath)
+	s.documentMu.Lock()
+	s.openDocuments[uriA] = srcA
+	s.openDocuments[uriB] = srcB
+	s.documentMu.Unlock()
+
+	pos := lspPositionOfIdentifier(srcB, "Widget")
+	h := s.findHoverForPosition(uriB, pos)
+	if h == nil {
+		t.Fatal("expected hover on Widget in peer file")
+	}
+	val := h.Contents.Value
+	if !strings.Contains(val, "Widget wraps an identifier") {
+		t.Fatalf("expected merged // doc from defining file, got %q", val)
+	}
+	if !strings.Contains(val, "type Widget") && !strings.Contains(val, "Widget") {
+		t.Fatalf("expected type definition in hover: %q", val)
+	}
+}
+
+func TestFindHoverForPosition_noTokenReturnsNil(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ft := filepath.Join(dir, "short.ft")
+	const src = "package main\n"
+	if err := os.WriteFile(ft, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri := mustFileURI(t, ft)
+	s := NewLSPServer("8080", logrus.New())
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+	// Line 10 has no tokens in this one-line file.
+	if h := s.findHoverForPosition(uri, LSPPosition{Line: 10, Character: 0}); h != nil {
+		t.Fatalf("expected nil hover when no token at position, got %#v", h)
+	}
+}
+
+func TestFindHover_userTypeNameShadowsBuiltinTupleDoc(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ft := filepath.Join(dir, "shadow_tuple.ft")
+	const src = `package main
+
+type Tuple = Int
+
+func f(): Tuple {
+  return 0
+}
+`
+	if err := os.WriteFile(ft, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri := mustFileURI(t, ft)
+	s := NewLSPServer("8080", logrus.New())
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	line := "func f(): Tuple {"
+	ix := strings.Index(line, "Tuple")
+	if ix < 0 {
+		t.Fatal("fixture")
+	}
+	li := 0
+	for i, l := range strings.Split(src, "\n") {
+		if strings.Contains(l, "func f():") {
+			li = i
+			break
+		}
+	}
+	h := s.findHoverForPosition(uri, LSPPosition{Line: li, Character: ix})
+	if h == nil {
+		t.Fatal("nil hover on Tuple return type")
+	}
+	val := h.Contents.Value
+	// User-defined alias must win over built-in Tuple FFI hover.
+	if !strings.Contains(val, "type Tuple") {
+		t.Fatalf("expected user type hover, got %q", val)
+	}
+	if strings.Contains(val, "FFI") || strings.Contains(val, "multi-value") {
+		t.Fatalf("did not expect built-in Tuple blurb, got %q", val)
+	}
+}
+
+func TestFindHover_variableHoverIncludesBuiltinGuardDocWhenNoSourceComment(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ft := filepath.Join(dir, "guard_fallback_hover.ft")
+	const src = `package main
+
+func f(s: String): Void {
+  ensure s is Min(3)
+  _ = s
+}
+`
+	if err := os.WriteFile(ft, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri := mustFileURI(t, ft)
+	s := NewLSPServer("8080", logrus.New())
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	lines := strings.Split(src, "\n")
+	var hoverLine, charOff int
+	for i, line := range lines {
+		if strings.Contains(line, "_ = s") {
+			hoverLine = i
+			charOff = strings.Index(line, "s")
+			break
+		}
+	}
+	if charOff < 0 {
+		t.Fatal("could not find s in _ = s")
+	}
+	prefix := string([]rune(lines[hoverLine])[:charOff])
+	h := s.findHoverForPosition(uri, LSPPosition{Line: hoverLine, Character: utf8.RuneCountInString(prefix)})
+	if h == nil {
+		t.Fatal("nil hover on s after ensure")
+	}
+	val := h.Contents.Value
+	// Built-in Min guard doc (hoverdoc) should appear when there is no // above the guard.
+	if !strings.Contains(val, "Min") || !strings.Contains(val, "minimum") {
+		t.Fatalf("expected built-in Min guard documentation in hover, got %q", val)
+	}
 }

--- a/forst/cmd/forst/lsp/hover_completion_test.go
+++ b/forst/cmd/forst/lsp/hover_completion_test.go
@@ -34,7 +34,7 @@ func TestTokenSliceIndex_pointerOrValueMatch(t *testing.T) {
 func TestTypeDefHoverMarkdown_typeGuard(t *testing.T) {
 	t.Parallel()
 	v := ast.TypeGuardNode{Ident: ast.Identifier("Strong")}
-	if md := typeDefHoverMarkdown(nil, nil, v); !strings.Contains(md, "Strong") || !strings.Contains(md, "is") {
+	if md := typeDefHoverMarkdown(nil, nil, v); !strings.Contains(md, "Strong") || !strings.Contains(md, "is") || !strings.Contains(md, "Type guard") {
 		t.Fatalf("value TypeGuardNode: got %q", md)
 	}
 	if md := typeDefHoverMarkdown(nil, nil, &v); !strings.Contains(md, "Strong") {
@@ -272,6 +272,24 @@ func TestHoverTextForToken_builtinGuardAfterIs(t *testing.T) {
 	}
 	tok := &tokens[2]
 	if s := hoverTextForToken(tc, tokens, tok, nil); !strings.Contains(s, "Min") || !strings.Contains(s, "guard") {
+		t.Fatalf("got %q", s)
+	}
+}
+
+func TestHoverTextForToken_builtinTypeNameIdentifier(t *testing.T) {
+	t.Parallel()
+	tc := typechecker.New(logrus.New(), false)
+	tok := &ast.Token{Type: ast.TokenIdentifier, Value: "Tuple", Line: 1, Column: 1}
+	if s := hoverTextForToken(tc, nil, tok, nil); !strings.Contains(s, "Tuple") || !strings.Contains(s, "built-in type") {
+		t.Fatalf("got %q", s)
+	}
+}
+
+func TestHoverTextForToken_nilKeyword(t *testing.T) {
+	t.Parallel()
+	tc := typechecker.New(logrus.New(), false)
+	tok := &ast.Token{Type: ast.TokenNil, Value: "nil", Line: 1, Column: 1}
+	if s := hoverTextForToken(tc, nil, tok, nil); !strings.Contains(s, "nil") || !strings.Contains(s, "zero value") {
 		t.Fatalf("got %q", s)
 	}
 }

--- a/forst/cmd/forst/lsp/hover_completion_test.go
+++ b/forst/cmd/forst/lsp/hover_completion_test.go
@@ -256,7 +256,22 @@ func TestHoverTextForToken_keyword(t *testing.T) {
 	t.Parallel()
 	tc := typechecker.New(logrus.New(), false)
 	tok := &ast.Token{Type: ast.TokenFunc, Value: "func"}
-	if s := hoverTextForToken(tc, nil, tok, nil); s != "`func`" {
+	s := hoverTextForToken(tc, nil, tok, nil)
+	if !strings.Contains(s, "**`func`**") || !strings.Contains(s, "Declares") {
+		t.Fatalf("got %q", s)
+	}
+}
+
+func TestHoverTextForToken_builtinGuardAfterIs(t *testing.T) {
+	t.Parallel()
+	tc := typechecker.New(logrus.New(), false)
+	tokens := []ast.Token{
+		{Type: ast.TokenIdentifier, Value: "x", Line: 1, Column: 1},
+		{Type: ast.TokenIs, Value: "is", Line: 1, Column: 3},
+		{Type: ast.TokenIdentifier, Value: "Min", Line: 1, Column: 6},
+	}
+	tok := &tokens[2]
+	if s := hoverTextForToken(tc, tokens, tok, nil); !strings.Contains(s, "Min") || !strings.Contains(s, "guard") {
 		t.Fatalf("got %q", s)
 	}
 }
@@ -281,7 +296,7 @@ func TestHoverTextForToken_intLiteralReturnsEmpty(t *testing.T) {
 
 func TestLexicalHoverMarkdown_keywordAndIdentifier(t *testing.T) {
 	t.Parallel()
-	if s := lexicalHoverMarkdown(&ast.Token{Type: ast.TokenFunc, Value: "func"}); s != "`func`" {
+	if s := lexicalHoverMarkdown(&ast.Token{Type: ast.TokenFunc, Value: "func"}); !strings.Contains(s, "**`func`**") {
 		t.Fatalf("keyword: got %q", s)
 	}
 	id := &ast.Token{Type: ast.TokenIdentifier, Value: "foo"}
@@ -315,7 +330,7 @@ func TestFindHoverForPosition_parseError_keywordHover(t *testing.T) {
 
 	// Line 0: `package` keyword
 	hPkg := s.findHoverForPosition(uri, LSPPosition{Line: 0, Character: 2})
-	if hPkg == nil || hPkg.Contents.Value != "`package`" {
+	if hPkg == nil || !strings.Contains(hPkg.Contents.Value, "**`package`**") {
 		if hPkg == nil {
 			t.Fatal("expected keyword hover on package when parse fails")
 		}

--- a/forst/internal/hoverdoc/builtins.go
+++ b/forst/internal/hoverdoc/builtins.go
@@ -31,6 +31,13 @@ func BuiltinTypeMarkdown(displayName string) string {
 	return builtinTypeDocs[displayName]
 }
 
+// IsBuiltinTypeSurfaceName reports whether name is a documented built-in type spelling (e.g. "Int",
+// "Result"). Used when the name appears as an identifier (e.g. in `Array(Result)`).
+func IsBuiltinTypeSurfaceName(name string) bool {
+	_, ok := builtinTypeDocs[name]
+	return ok
+}
+
 // MarkdownForKeywordToken returns markdown for lexer keyword tokens that correspond to built-in
 // types or language keywords documented for hovers. Unknown tokens yield "".
 func MarkdownForKeywordToken(t ast.TokenIdent) string {
@@ -52,21 +59,267 @@ func MarkdownForKeywordToken(t ast.TokenIdent) string {
 	case ast.TokenStruct:
 		return BuiltinTypeMarkdown(NameStruct)
 	case ast.TokenFunc:
-		return keywordDoc("func", "Declares a function. Parameters and return types use `name: Type` syntax.")
+		return keywordDoc("func", strings.Join([]string{
+			"Declares a function. Parameters look like `name: Type`; the return type comes after the closing `)` before `{`.",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"func greet(name: String): String {",
+				"  return \"Hello, \" + name",
+				"}",
+			),
+		}, "\n"))
 	case ast.TokenType:
-		return keywordDoc("type", "Introduces a type alias, shape type, or type guard.")
+		return keywordDoc("type", strings.Join([]string{
+			"Introduces a name for a shape, alias, nominal error, or type guard. Shapes use `{ field: Type }` syntax.",
+			"",
+			"**Examples**",
+			"",
+			forstBlock(
+				"type User = {",
+				"  id: Int",
+				"  name: String",
+				"}",
+			),
+		}, "\n"))
 	case ast.TokenReturn:
-		return keywordDoc("return", "Returns a value from the current function. The expression must match the function's return type.")
+		return keywordDoc("return", strings.Join([]string{
+			"Exits the function and sends a value (or values) back to the caller. The expression must match the declared return type.",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"func double(x: Int): Int {",
+				"  return x * 2",
+				"}",
+			),
+		}, "\n"))
 	case ast.TokenImport:
-		return keywordDoc("import", "Imports a Go package (`import \"path\"`). Qualified names use the local identifier from the import.")
+		return keywordDoc("import", strings.Join([]string{
+			"Loads a Go package so you can call it with `localName.Symbol` (for example `fmt.Println`).",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				`import "fmt"`,
+				"",
+				"func main(): Void {",
+				"  fmt.Println(\"hi\")",
+				"}",
+			),
+		}, "\n"))
 	case ast.TokenPackage:
-		return keywordDoc("package", "Sets the Go package clause for the file (e.g. `package main`).")
+		return keywordDoc("package", strings.Join([]string{
+			"First line of a file: declares which Go package this file belongs to (usually `main` for programs).",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"package main",
+				"",
+				"func main(): Void { }",
+			),
+		}, "\n"))
 	case ast.TokenEnsure:
-		return keywordDoc("ensure", "Asserts a condition at this point in control flow. If the check fails, the program exits via the failure path (e.g. `log.Fatal`). Combine with `is` and built-in or user-defined guards to narrow types for following statements.")
+		return keywordDoc("ensure", strings.Join([]string{
+			"Runtime check: if the condition fails, execution stops on the failure path (for example `log.Fatal`). When the check passes, types can narrow for the rest of the function.",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"func use(s: String): Void {",
+				"  ensure s is Min(1)",
+				"  // here `s` is known non-empty for the compiler",
+				"}",
+			),
+		}, "\n"))
 	case ast.TokenIs:
-		return keywordDoc("is", "Used in `if subject is …` and `ensure … is …` to apply type guards, assertions, and built-in constraints (e.g. `Min`, `Ok`).")
+		return keywordDoc("is", strings.Join([]string{
+			"Introduces a guard or assertion on the left-hand side. Used in `if x is …` (branch narrowing) and `ensure … is …` (must hold here).",
+			"",
+			"**Examples**",
+			"",
+			forstBlock(
+				"if v is Ok() {",
+				"  // success branch",
+				"}",
+				"",
+				"ensure n is Max(100)",
+			),
+		}, "\n"))
 	case ast.TokenOr:
-		return keywordDoc("or", "Logical OR (`||`). Short-circuits: the right side is evaluated only if the left is false.")
+		return keywordDoc("or", strings.Join([]string{
+			"Word `or` between conditions (where the grammar allows). For plain boolean OR inside expressions, `||` is typical.",
+			"",
+			"**Note:** `||` is documented separately; both short-circuit.",
+		}, "\n"))
+	case ast.TokenIf:
+		return keywordDoc("if", strings.Join([]string{
+			"Runs a block when the condition is true. With `subject is …`, the typechecker narrows types inside the then-branch.",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"if x is Err() {",
+				"  // handle failure",
+				"}",
+			),
+		}, "\n"))
+	case ast.TokenElseIf:
+		return keywordDoc("else if", strings.Join([]string{
+			"Tries another condition after a failed `if`. Only one branch runs—the first that matches.",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"if x is Ok() { }",
+				"else if x is Err() { }",
+			),
+		}, "\n"))
+	case ast.TokenElse:
+		return keywordDoc("else", strings.Join([]string{
+			"Optional final branch when no `if` / `else if` matched.",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"if cond { }",
+				"else { }",
+			),
+		}, "\n"))
+	case ast.TokenFor:
+		return keywordDoc("for", strings.Join([]string{
+			"C-style loops, `while`-style loops, or paired with `range` to iterate.",
+			"",
+			"**Examples**",
+			"",
+			forstBlock(
+				"for i := 0; i < n; i++ { }",
+				"for cond { }",
+				"for i, v := range items { }",
+			),
+		}, "\n"))
+	case ast.TokenRange:
+		return keywordDoc("range", strings.Join([]string{
+			"Used with `for` to walk a slice, string, or map—similar to Go.",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"for i, ch := range s {",
+				"  _ = i",
+				"  _ = ch",
+				"}",
+			),
+		}, "\n"))
+	case ast.TokenBreak:
+		return keywordDoc("break", strings.Join([]string{
+			"Leaves the innermost `for` or `switch` immediately.",
+		}, "\n"))
+	case ast.TokenContinue:
+		return keywordDoc("continue", strings.Join([]string{
+			"Skips to the next iteration of the innermost `for` loop.",
+		}, "\n"))
+	case ast.TokenSwitch:
+		return keywordDoc("switch", strings.Join([]string{
+			"Chooses one arm by comparing a value against `case` labels; optional `default` if nothing matched.",
+		}, "\n"))
+	case ast.TokenCase:
+		return keywordDoc("case", strings.Join([]string{
+			"Labels one arm of a `switch`. Compared in order until a match.",
+		}, "\n"))
+	case ast.TokenDefault:
+		return keywordDoc("default", strings.Join([]string{
+			"Runs when no `case` in this `switch` matched.",
+		}, "\n"))
+	case ast.TokenFallthrough:
+		return keywordDoc("fallthrough", strings.Join([]string{
+			"Continues into the *next* `case` body (Go semantics). Rare; use only when you intend fall-through.",
+		}, "\n"))
+	case ast.TokenVar:
+		return keywordDoc("var", strings.Join([]string{
+			"Go-style variable declaration for interop. In idiomatic Forst, prefer `name := expr` or typed bindings where the language supports them.",
+		}, "\n"))
+	case ast.TokenConst:
+		return keywordDoc("const", strings.Join([]string{
+			"Declares a compile-time constant (Go interop).",
+		}, "\n"))
+	case ast.TokenChan:
+		return keywordDoc("chan", strings.Join([]string{
+			"Channel types for concurrent code that lowers to Go `chan`.",
+			"",
+			"**Example**",
+			"",
+			forstBlock("ch: chan Int"),
+		}, "\n"))
+	case ast.TokenInterface:
+		return keywordDoc("interface", strings.Join([]string{
+			"Declares a Go `interface{ ... }` type for FFI.",
+		}, "\n"))
+	case ast.TokenGo:
+		return keywordDoc("go", strings.Join([]string{
+			"Starts a goroutine: `go someCall()` → Go `go` statement.",
+		}, "\n"))
+	case ast.TokenDefer:
+		return keywordDoc("defer", strings.Join([]string{
+			"Schedules a call to run when the surrounding function returns—same idea as Go `defer`.",
+		}, "\n"))
+	case ast.TokenGoto:
+		return keywordDoc("goto", strings.Join([]string{
+			"Jumps to a label (Go `goto`). Uncommon; prefer structured control flow.",
+		}, "\n"))
+	case ast.TokenArrow:
+		return keywordDoc("<-", strings.Join([]string{
+			"Channel send/receive operator in Go-shaped code (`ch <- v`, `v := <-ch`).",
+		}, "\n"))
+	case ast.TokenError:
+		return keywordDoc("error", strings.Join([]string{
+			"Starts a **nominal error** type: a named error with a payload shape. Values implement the built-in `Error` interface.",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"error NotFound {",
+				"  path: String",
+				"}",
+			),
+		}, "\n"))
+	case ast.TokenLogicalAnd:
+		return keywordDoc("&&", strings.Join([]string{
+			"Logical AND. If the left side is false, the right side is **not** evaluated.",
+			"",
+			"**Example:** `ok && ok.doWork()`",
+		}, "\n"))
+	case ast.TokenLogicalOr:
+		return keywordDoc("||", strings.Join([]string{
+			"Logical OR. If the left side is true, the right side is **not** evaluated.",
+			"",
+			"**Example:** `x == nil || x.f()`",
+		}, "\n"))
+	case ast.TokenLogicalNot:
+		return keywordDoc("!", strings.Join([]string{
+			"Inverts a boolean. Often used with `ensure`: `ensure !err { ... }` runs the block when `err` is falsy (for example nil error).",
+		}, "\n"))
+	case ast.TokenNil:
+		return keywordDoc("nil", strings.Join([]string{
+			"The **zero value** for pointers, slices, maps, channels, functions, and interface-shaped values such as `Error`.",
+			"",
+			"**Example**",
+			"",
+			forstBlock(
+				"var p: Pointer(String)",
+				"p = nil",
+			),
+		}, "\n"))
+	case ast.TokenTrue:
+		return keywordDoc("true", strings.Join([]string{
+			"Boolean literal **true**.",
+		}, "\n"))
+	case ast.TokenFalse:
+		return keywordDoc("false", strings.Join([]string{
+			"Boolean literal **false**.",
+		}, "\n"))
 	default:
 		return ""
 	}
@@ -87,32 +340,131 @@ func typeDoc(title, body string) string {
 
 // builtinTypeDocs holds LSP hover text for built-in Forst types. Keys match Forst spellings.
 var builtinTypeDocs = map[string]string{
-	NameInt: typeDoc(NameInt,
-		"Signed integer. In generated Go code this maps to `int`."),
-	NameFloat: typeDoc(NameFloat,
-		"IEEE floating-point number. In generated Go code this maps to `float64`."),
-	NameString: typeDoc(NameString,
-		"UTF-8 string. In generated Go code this maps to `string`. Supports guards such as `Min`, `Max`, `HasPrefix`, and `Contains` in assertions."),
-	NameBool: typeDoc(NameBool,
-		"Boolean. In generated Go code this maps to `bool`. Assertions may use `True` or `False` guards."),
-	NameVoid: typeDoc(NameVoid,
-		"Return type for functions that do not return a value. In generated Go code this omits a result or uses `()` as appropriate."),
-	NameArray: typeDoc(NameArray,
-		"Fixed or slice-like sequence `Array(T)`. In generated Go code this maps to a Go slice `[]T`. Length-related guards use `len` in the same way as for strings."),
-	NameMap: typeDoc(NameMap,
-		"Associative map `Map(K, V)`. In generated Go code this maps to `map[K]V`."),
-	NameStruct: typeDoc(NameStruct,
-		"Anonymous struct type in Go interop positions. Prefer `type Name = { ... }` for named shapes in Forst."),
-	NameError: typeDoc(NameError,
-		"The error interface. In generated Go code this maps to Go's `error`. Methods such as `Error()` resolve to Go's `error.Error` when hovering qualified calls."),
-	NamePointer: typeDoc(NamePointer,
-		"Pointer type `Pointer(T)` (`*T` in Go). Assertions may use `Nil` or `Present` to describe nullability."),
-	NameShape: typeDoc(NameShape,
-		"Structural object type with fields. Often written as `type Name = { field: Type, ... }`. Structural types may receive hash-based names in generated Go."),
-	NameResult: typeDoc(NameResult,
-		"Discriminated result `Result(OkType, ErrType)` with error-kinded failure. Use `if x is Ok()` / `Err()` (or `ensure` variants) to narrow the success or failure side."),
-	NameTuple: typeDoc(NameTuple,
-		"Product type for multiple values (FFI / multi-value interop). Maps to a struct or multiple returns depending on context."),
-	NameObject: typeDoc(NameObject,
-		"Loose object / dynamic interop placeholder. Prefer explicit shapes or maps for static typing."),
+	NameInt: typeDoc(NameInt, strings.Join([]string{
+		"Whole numbers. Generated Go code uses `int`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock(
+			"func inc(x: Int): Int {",
+			"  return x + 1",
+			"}",
+		),
+		"",
+		"**Guards:** `Min`, `Max`, `LessThan`, `GreaterThan` in `ensure` / `if … is …`.",
+	}, "\n")),
+	NameFloat: typeDoc(NameFloat, strings.Join([]string{
+		"Floating-point numbers. Lowers to Go `float64`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock(
+			"func half(x: Float): Float {",
+			"  return x / 2",
+			"}",
+		),
+	}, "\n")),
+	NameString: typeDoc(NameString, strings.Join([]string{
+		"UTF-8 text. Lowers to Go `string`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock(`s: String = "hello"`),
+		"",
+		"**Common guards:** `Min` / `Max` (length), `HasPrefix`, `Contains`, `NotEmpty`.",
+	}, "\n")),
+	NameBool: typeDoc(NameBool, strings.Join([]string{
+		"Boolean flag. Lowers to Go `bool`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("ok: Bool = true"),
+		"",
+		"**Guards:** `True`, `False`.",
+	}, "\n")),
+	NameVoid: typeDoc(NameVoid, strings.Join([]string{
+		"Means “no return value” (like Go functions with no results).",
+		"",
+		"**Example**",
+		"",
+		forstBlock(
+			"func logMsg(s: String): Void {",
+			"  // side effects only",
+			"}",
+		),
+	}, "\n")),
+	NameArray: typeDoc(NameArray, strings.Join([]string{
+		"Ordered sequence `Array(T)`—lowers to a Go slice `[]T`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("xs: Array(Int) = [1, 2, 3]"),
+		"",
+		"**Guards:** length checks behave like `String` (`Min`, `Max`, `NotEmpty`).",
+	}, "\n")),
+	NameMap: typeDoc(NameMap, strings.Join([]string{
+		"Key/value map `Map(Key, Value)` → Go `map[Key]Value`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("scores: Map(String, Int)"),
+	}, "\n")),
+	NameStruct: typeDoc(NameStruct, strings.Join([]string{
+		"Anonymous struct in Go interop. For app types, prefer a named shape: `type Row = { … }`.",
+	}, "\n")),
+	NameError: typeDoc(NameError, strings.Join([]string{
+		"The built-in error interface (Go `error`). Call `.Error()` for the message when hovering works through the Go bridge.",
+		"",
+		"**Example**",
+		"",
+		forstBlock(
+			"func mayFail(): Error {",
+			"  return nil",
+			"}",
+		),
+	}, "\n")),
+	NamePointer: typeDoc(NamePointer, strings.Join([]string{
+		"Optional reference `Pointer(T)` → Go `*T`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("p: Pointer(String)"),
+		"",
+		"**Guards:** `Nil` (must be nil) or `Present` (must be non-nil).",
+	}, "\n")),
+	NameShape: typeDoc(NameShape, strings.Join([]string{
+		"Record / object type with named fields. Often written as `type Name = { field: Type }`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock(
+			"type Point = {",
+			"  x: Int",
+			"  y: Int",
+			"}",
+		),
+	}, "\n")),
+	NameResult: typeDoc(NameResult, strings.Join([]string{
+		"Success-or-failure value `Result(Ok, Err)` with failure error-kinded. Narrow with `Ok` / `Err` in `if` or `ensure`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock(
+			"func parse(): Result(Int, Error) { }",
+			"",
+			"if r is Ok() {",
+			"  // use success value",
+			"}",
+		),
+	}, "\n")),
+	NameTuple: typeDoc(NameTuple, strings.Join([]string{
+		"Fixed product of types, mainly for FFI and multi-value interop.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("Tuple(Int, String)"),
+	}, "\n")),
+	NameObject: typeDoc(NameObject, strings.Join([]string{
+		"Loose object interop slot. Prefer `Shape` or `Map` when you want precise static typing.",
+	}, "\n")),
 }

--- a/forst/internal/hoverdoc/builtins.go
+++ b/forst/internal/hoverdoc/builtins.go
@@ -1,0 +1,118 @@
+package hoverdoc
+
+import (
+	"fmt"
+	"strings"
+
+	"forst/internal/ast"
+)
+
+// Builtin type names as written in Forst (capitalized keywords and related spellings).
+const (
+	NameInt     = "Int"
+	NameFloat   = "Float"
+	NameString  = "String"
+	NameBool    = "Bool"
+	NameVoid    = "Void"
+	NameArray   = "Array"
+	NameMap     = "Map"
+	NameStruct  = "struct"
+	NameError   = "Error"
+	NamePointer = "Pointer"
+	NameShape   = "Shape"
+	NameResult  = "Result"
+	NameTuple   = "Tuple"
+	NameObject  = "Object"
+)
+
+// BuiltinTypeMarkdown returns user-facing markdown for a built-in Forst type, keyed by its
+// surface spelling (e.g. "Int", "Result"). Unknown names yield an empty string.
+func BuiltinTypeMarkdown(displayName string) string {
+	return builtinTypeDocs[displayName]
+}
+
+// MarkdownForKeywordToken returns markdown for lexer keyword tokens that correspond to built-in
+// types or language keywords documented for hovers. Unknown tokens yield "".
+func MarkdownForKeywordToken(t ast.TokenIdent) string {
+	switch t {
+	case ast.TokenInt:
+		return BuiltinTypeMarkdown(NameInt)
+	case ast.TokenFloat:
+		return BuiltinTypeMarkdown(NameFloat)
+	case ast.TokenString:
+		return BuiltinTypeMarkdown(NameString)
+	case ast.TokenBool:
+		return BuiltinTypeMarkdown(NameBool)
+	case ast.TokenVoid:
+		return BuiltinTypeMarkdown(NameVoid)
+	case ast.TokenArray:
+		return BuiltinTypeMarkdown(NameArray)
+	case ast.TokenMap:
+		return BuiltinTypeMarkdown(NameMap)
+	case ast.TokenStruct:
+		return BuiltinTypeMarkdown(NameStruct)
+	case ast.TokenFunc:
+		return keywordDoc("func", "Declares a function. Parameters and return types use `name: Type` syntax.")
+	case ast.TokenType:
+		return keywordDoc("type", "Introduces a type alias, shape type, or type guard.")
+	case ast.TokenReturn:
+		return keywordDoc("return", "Returns a value from the current function. The expression must match the function's return type.")
+	case ast.TokenImport:
+		return keywordDoc("import", "Imports a Go package (`import \"path\"`). Qualified names use the local identifier from the import.")
+	case ast.TokenPackage:
+		return keywordDoc("package", "Sets the Go package clause for the file (e.g. `package main`).")
+	case ast.TokenEnsure:
+		return keywordDoc("ensure", "Asserts a condition at this point in control flow. If the check fails, the program exits via the failure path (e.g. `log.Fatal`). Combine with `is` and built-in or user-defined guards to narrow types for following statements.")
+	case ast.TokenIs:
+		return keywordDoc("is", "Used in `if subject is …` and `ensure … is …` to apply type guards, assertions, and built-in constraints (e.g. `Min`, `Ok`).")
+	case ast.TokenOr:
+		return keywordDoc("or", "Logical OR (`||`). Short-circuits: the right side is evaluated only if the left is false.")
+	default:
+		return ""
+	}
+}
+
+func keywordDoc(title, body string) string {
+	var b strings.Builder
+	b.WriteString("**`")
+	b.WriteString(title)
+	b.WriteString("`**\n\n")
+	b.WriteString(body)
+	return b.String()
+}
+
+func typeDoc(title, body string) string {
+	return fmt.Sprintf("**`%s`** (built-in type)\n\n%s", title, body)
+}
+
+// builtinTypeDocs holds LSP hover text for built-in Forst types. Keys match Forst spellings.
+var builtinTypeDocs = map[string]string{
+	NameInt: typeDoc(NameInt,
+		"Signed integer. In generated Go code this maps to `int`."),
+	NameFloat: typeDoc(NameFloat,
+		"IEEE floating-point number. In generated Go code this maps to `float64`."),
+	NameString: typeDoc(NameString,
+		"UTF-8 string. In generated Go code this maps to `string`. Supports guards such as `Min`, `Max`, `HasPrefix`, and `Contains` in assertions."),
+	NameBool: typeDoc(NameBool,
+		"Boolean. In generated Go code this maps to `bool`. Assertions may use `True` or `False` guards."),
+	NameVoid: typeDoc(NameVoid,
+		"Return type for functions that do not return a value. In generated Go code this omits a result or uses `()` as appropriate."),
+	NameArray: typeDoc(NameArray,
+		"Fixed or slice-like sequence `Array(T)`. In generated Go code this maps to a Go slice `[]T`. Length-related guards use `len` in the same way as for strings."),
+	NameMap: typeDoc(NameMap,
+		"Associative map `Map(K, V)`. In generated Go code this maps to `map[K]V`."),
+	NameStruct: typeDoc(NameStruct,
+		"Anonymous struct type in Go interop positions. Prefer `type Name = { ... }` for named shapes in Forst."),
+	NameError: typeDoc(NameError,
+		"The error interface. In generated Go code this maps to Go's `error`. Methods such as `Error()` resolve to Go's `error.Error` when hovering qualified calls."),
+	NamePointer: typeDoc(NamePointer,
+		"Pointer type `Pointer(T)` (`*T` in Go). Assertions may use `Nil` or `Present` to describe nullability."),
+	NameShape: typeDoc(NameShape,
+		"Structural object type with fields. Often written as `type Name = { field: Type, ... }`. Structural types may receive hash-based names in generated Go."),
+	NameResult: typeDoc(NameResult,
+		"Discriminated result `Result(OkType, ErrType)` with error-kinded failure. Use `if x is Ok()` / `Err()` (or `ensure` variants) to narrow the success or failure side."),
+	NameTuple: typeDoc(NameTuple,
+		"Product type for multiple values (FFI / multi-value interop). Maps to a struct or multiple returns depending on context."),
+	NameObject: typeDoc(NameObject,
+		"Loose object / dynamic interop placeholder. Prefer explicit shapes or maps for static typing."),
+}

--- a/forst/internal/hoverdoc/docfmt.go
+++ b/forst/internal/hoverdoc/docfmt.go
@@ -1,0 +1,12 @@
+// Package hoverdoc holds user-facing markdown for LSP hovers (built-in types, guards, keywords).
+package hoverdoc
+
+import "strings"
+
+// forstBlock returns a markdown fenced code block labeled for Forst.
+func forstBlock(lines ...string) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	return "```forst\n" + strings.Join(lines, "\n") + "\n```"
+}

--- a/forst/internal/hoverdoc/guards.go
+++ b/forst/internal/hoverdoc/guards.go
@@ -1,0 +1,88 @@
+package hoverdoc
+
+import (
+	"strings"
+
+	"forst/internal/ast"
+)
+
+// Built-in assertion / guard names (ensure and if … is …) plus Result discriminators.
+const (
+	GuardMin          = "Min"
+	GuardMax          = "Max"
+	GuardLessThan     = "LessThan"
+	GuardGreaterThan  = "GreaterThan"
+	GuardHasPrefix     = "HasPrefix"
+	GuardContains      = "Contains"
+	GuardTrue          = "True"
+	GuardFalse         = "False"
+	GuardNil           = "Nil"
+	GuardPresent       = "Present"
+	GuardNotEmpty      = "NotEmpty"
+	GuardValid         = "Valid"
+	GuardValue         = ast.ValueConstraint // "Value"
+	GuardMatch         = "Match"
+	GuardOk            = "Ok"
+	GuardErr           = "Err"
+)
+
+// BuiltinGuardNames lists every name with an entry in guardDocs (for tests and tooling).
+var BuiltinGuardNames = []string{
+	GuardMin, GuardMax, GuardLessThan, GuardGreaterThan,
+	GuardHasPrefix, GuardContains,
+	GuardTrue, GuardFalse,
+	GuardNil, GuardPresent,
+	GuardNotEmpty, GuardValid,
+	GuardValue, GuardMatch,
+	GuardOk, GuardErr,
+}
+
+// GuardMarkdown returns markdown describing a built-in guard or Result discriminator, or ""
+// if the name is not a documented built-in (user-defined type guards are intentionally omitted).
+func GuardMarkdown(name string) string {
+	return guardDocs[name]
+}
+
+func guardDoc(title, body string) string {
+	var b strings.Builder
+	b.WriteString("**`")
+	b.WriteString(title)
+	b.WriteString("`** (guard)\n\n")
+	b.WriteString(body)
+	return b.String()
+}
+
+var guardDocs = map[string]string{
+	GuardMin: guardDoc(GuardMin,
+		"Lower bound. For strings and arrays, compares `len(value)` to the integer argument; for `Int` and `Float`, compares the numeric value. Used in `ensure x is Min(n)` or `if x is Min(n)`."),
+	GuardMax: guardDoc(GuardMax,
+		"Upper bound. For strings and arrays, compares `len(value)` to the integer argument; for `Int` and `Float`, compares the numeric value."),
+	GuardLessThan: guardDoc(GuardLessThan,
+		"For integers and floats, requires `value < n` (implemented with `>=` on the right-hand literal in generated checks)."),
+	GuardGreaterThan: guardDoc(GuardGreaterThan,
+		"For integers and floats, requires `value > n` (implemented with `<=` on the right-hand literal in generated checks)."),
+	GuardHasPrefix: guardDoc(GuardHasPrefix,
+		"For strings, requires `strings.HasPrefix(value, prefix)` to hold for the given string literal argument."),
+	GuardContains: guardDoc(GuardContains,
+		"For strings, requires `strings.Contains(value, substr)` to hold for the given string literal argument."),
+	GuardTrue: guardDoc(GuardTrue,
+		"For booleans, requires the value to be `true`."),
+	GuardFalse: guardDoc(GuardFalse,
+		"For booleans, requires the value to be `false`."),
+	GuardNil: guardDoc(GuardNil,
+		"For pointers and `Error`, requires the value to be nil (or an untyped nil in Go terms)."),
+	GuardPresent: guardDoc(GuardPresent,
+		"For pointers and `Error`, requires the value to be non-nil (`!= nil`)."),
+	GuardNotEmpty: guardDoc(GuardNotEmpty,
+		"For strings and arrays, requires non-zero length (`len != 0`)."),
+	GuardValid: guardDoc(GuardValid,
+		"Placeholder hook for validation. The compiler may emit a conservative check; prefer explicit predicates or user-defined type guards for real validation."),
+	GuardValue: guardDoc(GuardValue,
+		"Refines a type to a single compile-time value (dependent-style literal typing)."),
+	GuardMatch: guardDoc(GuardMatch,
+		"Structural matching against a shape or pattern in assertions (see type checker rules for the surrounding type)."),
+	GuardOk: guardDoc(GuardOk,
+		"For `Result(S, F)`, narrows to the success payload. In `if x is Ok()` the then-branch sees `S`; `ensure x is Ok()` narrows following statements."),
+	GuardErr: guardDoc(GuardErr,
+		"For `Result(S, F)`, narrows to the failure side. In `if x is Err()` the then-branch sees the failure type (typically error-kinded)."),
+}

--- a/forst/internal/hoverdoc/guards.go
+++ b/forst/internal/hoverdoc/guards.go
@@ -8,10 +8,10 @@ import (
 
 // Built-in assertion / guard names (ensure and if … is …) plus Result discriminators.
 const (
-	GuardMin          = "Min"
-	GuardMax          = "Max"
-	GuardLessThan     = "LessThan"
-	GuardGreaterThan  = "GreaterThan"
+	GuardMin           = "Min"
+	GuardMax           = "Max"
+	GuardLessThan      = "LessThan"
+	GuardGreaterThan   = "GreaterThan"
 	GuardHasPrefix     = "HasPrefix"
 	GuardContains      = "Contains"
 	GuardTrue          = "True"
@@ -53,36 +53,119 @@ func guardDoc(title, body string) string {
 }
 
 var guardDocs = map[string]string{
-	GuardMin: guardDoc(GuardMin,
-		"Lower bound. For strings and arrays, compares `len(value)` to the integer argument; for `Int` and `Float`, compares the numeric value. Used in `ensure x is Min(n)` or `if x is Min(n)`."),
-	GuardMax: guardDoc(GuardMax,
-		"Upper bound. For strings and arrays, compares `len(value)` to the integer argument; for `Int` and `Float`, compares the numeric value."),
-	GuardLessThan: guardDoc(GuardLessThan,
-		"For integers and floats, requires `value < n` (implemented with `>=` on the right-hand literal in generated checks)."),
-	GuardGreaterThan: guardDoc(GuardGreaterThan,
-		"For integers and floats, requires `value > n` (implemented with `<=` on the right-hand literal in generated checks)."),
-	GuardHasPrefix: guardDoc(GuardHasPrefix,
-		"For strings, requires `strings.HasPrefix(value, prefix)` to hold for the given string literal argument."),
-	GuardContains: guardDoc(GuardContains,
-		"For strings, requires `strings.Contains(value, substr)` to hold for the given string literal argument."),
-	GuardTrue: guardDoc(GuardTrue,
-		"For booleans, requires the value to be `true`."),
-	GuardFalse: guardDoc(GuardFalse,
-		"For booleans, requires the value to be `false`."),
-	GuardNil: guardDoc(GuardNil,
-		"For pointers and `Error`, requires the value to be nil (or an untyped nil in Go terms)."),
-	GuardPresent: guardDoc(GuardPresent,
-		"For pointers and `Error`, requires the value to be non-nil (`!= nil`)."),
-	GuardNotEmpty: guardDoc(GuardNotEmpty,
-		"For strings and arrays, requires non-zero length (`len != 0`)."),
-	GuardValid: guardDoc(GuardValid,
-		"Placeholder hook for validation. The compiler may emit a conservative check; prefer explicit predicates or user-defined type guards for real validation."),
-	GuardValue: guardDoc(GuardValue,
-		"Refines a type to a single compile-time value (dependent-style literal typing)."),
-	GuardMatch: guardDoc(GuardMatch,
-		"Structural matching against a shape or pattern in assertions (see type checker rules for the surrounding type)."),
-	GuardOk: guardDoc(GuardOk,
-		"For `Result(S, F)`, narrows to the success payload. In `if x is Ok()` the then-branch sees `S`; `ensure x is Ok()` narrows following statements."),
-	GuardErr: guardDoc(GuardErr,
-		"For `Result(S, F)`, narrows to the failure side. In `if x is Err()` the then-branch sees the failure type (typically error-kinded)."),
+	GuardMin: guardDoc(GuardMin, strings.Join([]string{
+		"Requires a **minimum**: for `String` and `Array`, compares `len` to the integer argument; for `Int` / `Float`, compares the numeric value.",
+		"",
+		"**Example**",
+		"",
+		forstBlock(
+			"ensure name is Min(1)",
+			"ensure scores is Min(0)",
+		),
+	}, "\n")),
+	GuardMax: guardDoc(GuardMax, strings.Join([]string{
+		"Requires a **maximum** (same length vs value rules as `Min`).",
+		"",
+		"**Example**",
+		"",
+		forstBlock("ensure label is Max(80)"),
+	}, "\n")),
+	GuardLessThan: guardDoc(GuardLessThan, strings.Join([]string{
+		"For `Int` / `Float`, requires the value to stay **strictly below** the given number (the compiler emits the matching comparison).",
+		"",
+		"**Example**",
+		"",
+		forstBlock("ensure n is LessThan(100)"),
+	}, "\n")),
+	GuardGreaterThan: guardDoc(GuardGreaterThan, strings.Join([]string{
+		"For `Int` / `Float`, requires the value to stay **strictly above** the given number.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("ensure n is GreaterThan(0)"),
+	}, "\n")),
+	GuardHasPrefix: guardDoc(GuardHasPrefix, strings.Join([]string{
+		"For `String`, requires the value to start with the given **string literal** (lowers to `strings.HasPrefix`).",
+		"",
+		"**Example**",
+		"",
+		forstBlock(`ensure url is HasPrefix("https://")`),
+	}, "\n")),
+	GuardContains: guardDoc(GuardContains, strings.Join([]string{
+		"For `String`, requires the substring to appear (`strings.Contains`).",
+		"",
+		"**Example**",
+		"",
+		forstBlock(`ensure msg is Contains("error")`),
+	}, "\n")),
+	GuardTrue: guardDoc(GuardTrue, strings.Join([]string{
+		"For `Bool`, requires the value to be **true**.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("ensure ok is True()"),
+	}, "\n")),
+	GuardFalse: guardDoc(GuardFalse, strings.Join([]string{
+		"For `Bool`, requires the value to be **false**.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("ensure done is False()"),
+	}, "\n")),
+	GuardNil: guardDoc(GuardNil, strings.Join([]string{
+		"For pointers and `Error`, requires **nil**.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("ensure err is Nil()"),
+	}, "\n")),
+	GuardPresent: guardDoc(GuardPresent, strings.Join([]string{
+		"For pointers and `Error`, requires **non-nil** (`!= nil`).",
+		"",
+		"**Example**",
+		"",
+		forstBlock("ensure err is Present()"),
+	}, "\n")),
+	GuardNotEmpty: guardDoc(GuardNotEmpty, strings.Join([]string{
+		"For `String` and `Array`, requires `len != 0`.",
+		"",
+		"**Example**",
+		"",
+		forstBlock("ensure line is NotEmpty()"),
+	}, "\n")),
+	GuardValid: guardDoc(GuardValid, strings.Join([]string{
+		"Reserved hook for custom validation. The compiler may emit a placeholder check—use explicit guards or a user-defined type guard for real rules.",
+	}, "\n")),
+	GuardValue: guardDoc(GuardValue, strings.Join([]string{
+		"Refines a type to a **single compile-time value** (literal typing).",
+		"",
+		"**Example**",
+		"",
+		forstBlock("// appears in assertion-style types as Value(...)"),
+	}, "\n")),
+	GuardMatch: guardDoc(GuardMatch, strings.Join([]string{
+		"Structural match against a shape or pattern inside an assertion—see the surrounding type for what is compared.",
+	}, "\n")),
+	GuardOk: guardDoc(GuardOk, strings.Join([]string{
+		"For `Result(S, F)`, picks the **success** side. In `if x is Ok()` the then-branch sees `S`; after `ensure x is Ok()`, later code is narrowed.",
+		"",
+		"**Example**",
+		"",
+		forstBlock(
+			"if r is Ok() {",
+			"  // r is the success payload here",
+			"}",
+		),
+	}, "\n")),
+	GuardErr: guardDoc(GuardErr, strings.Join([]string{
+		"For `Result(S, F)`, picks the **failure** side (often error-like).",
+		"",
+		"**Example**",
+		"",
+		forstBlock(
+			"if r is Err() {",
+			"  // handle failure",
+			"}",
+		),
+	}, "\n")),
 }

--- a/forst/internal/hoverdoc/hoverdoc_test.go
+++ b/forst/internal/hoverdoc/hoverdoc_test.go
@@ -1,0 +1,57 @@
+package hoverdoc
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestBuiltinTypeDocs_nonempty(t *testing.T) {
+	t.Parallel()
+	keys := []string{
+		NameInt, NameFloat, NameString, NameBool, NameVoid,
+		NameArray, NameMap, NameStruct,
+		NameError, NamePointer, NameShape, NameResult, NameTuple, NameObject,
+	}
+	for _, k := range keys {
+		if s := BuiltinTypeMarkdown(k); s == "" || !strings.Contains(s, k) {
+			t.Fatalf("BuiltinTypeMarkdown(%q): empty or missing name: %q", k, s)
+		}
+	}
+}
+
+func TestMarkdownForKeywordToken_typesAndKeywords(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		tok  ast.TokenIdent
+		want string
+	}{
+		{ast.TokenInt, NameInt},
+		{ast.TokenMap, NameMap},
+		{ast.TokenEnsure, "ensure"},
+		{ast.TokenIs, "is"},
+	}
+	for _, tc := range cases {
+		got := MarkdownForKeywordToken(tc.tok)
+		if got == "" || !strings.Contains(got, tc.want) {
+			t.Fatalf("MarkdownForKeywordToken(%v): got %q, want substring %q", tc.tok, got, tc.want)
+		}
+	}
+}
+
+func TestGuardMarkdown_allBuiltinNames(t *testing.T) {
+	t.Parallel()
+	for _, name := range BuiltinGuardNames {
+		if s := GuardMarkdown(name); s == "" || !strings.Contains(s, name) {
+			t.Fatalf("GuardMarkdown(%q): %q", name, s)
+		}
+	}
+}
+
+func TestGuardMarkdown_unknown(t *testing.T) {
+	t.Parallel()
+	if GuardMarkdown("NotABuiltinGuard") != "" {
+		t.Fatal("expected empty for unknown guard")
+	}
+}

--- a/forst/internal/hoverdoc/hoverdoc_test.go
+++ b/forst/internal/hoverdoc/hoverdoc_test.go
@@ -55,3 +55,30 @@ func TestGuardMarkdown_unknown(t *testing.T) {
 		t.Fatal("expected empty for unknown guard")
 	}
 }
+
+func TestIsBuiltinTypeSurfaceName(t *testing.T) {
+	t.Parallel()
+	if !IsBuiltinTypeSurfaceName(NameResult) || IsBuiltinTypeSurfaceName("NotBuiltin") {
+		t.Fatal("IsBuiltinTypeSurfaceName mismatch")
+	}
+}
+
+func TestForstBlock(t *testing.T) {
+	t.Parallel()
+	s := forstBlock("a", "b")
+	if !strings.Contains(s, "```forst") || !strings.Contains(s, "a\nb") {
+		t.Fatalf("got %q", s)
+	}
+}
+
+func TestMarkdownForKeywordToken_controlFlowAndLiterals(t *testing.T) {
+	t.Parallel()
+	cases := []ast.TokenIdent{
+		ast.TokenIf, ast.TokenFor, ast.TokenNil, ast.TokenTrue, ast.TokenError,
+	}
+	for _, tok := range cases {
+		if s := MarkdownForKeywordToken(tok); s == "" {
+			t.Fatalf("empty for %v", tok)
+		}
+	}
+}

--- a/forst/internal/printer/printer.go
+++ b/forst/internal/printer/printer.go
@@ -56,6 +56,16 @@ func FormatTypeDefNode(cfg Config, def ast.TypeDefNode) (string, error) {
 	return p.printTypeDef(def)
 }
 
+// FormatTypeGuardNode pretty-prints a type guard declaration (e.g. LSP hover).
+func FormatTypeGuardNode(cfg Config, g ast.TypeGuardNode) (string, error) {
+	if cfg.Indent == "" {
+		cfg.Indent = "\t"
+	}
+	var p printer
+	p.cfg = cfg
+	return p.printTypeGuard(g)
+}
+
 type printer struct {
 	cfg    Config
 	depth  int

--- a/forst/internal/printer/typeprint_test.go
+++ b/forst/internal/printer/typeprint_test.go
@@ -181,3 +181,24 @@ func TestPrintType_typeShape_withAssertion(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+func TestFormatTypeGuardNode_roundTrip(t *testing.T) {
+	t.Parallel()
+	g := ast.TypeGuardNode{
+		Ident: ast.Identifier("Positive"),
+		Subject: ast.SimpleParamNode{
+			Ident: ast.Ident{ID: "n"},
+			Type:  ast.TypeNode{Ident: ast.TypeInt},
+		},
+		Body: []ast.Node{
+			ast.ReturnNode{Values: []ast.ExpressionNode{ast.BoolLiteralNode{Value: true}}},
+		},
+	}
+	out, err := FormatTypeGuardNode(DefaultConfig(), g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "is (") || !strings.Contains(out, "Positive") || !strings.Contains(out, "n Int") {
+		t.Fatalf("FormatTypeGuardNode: %q", out)
+	}
+}


### PR DESCRIPTION
Introduce package `internal/hoverdoc` with markdown strings for built-in types and assertion guards. The LSP uses them for keyword hovers, for identifiers immediately after `is`, and as a fallback when variable hover chains have no leading `//` docs for a guard.

Example:

```forst
ensure x is Min(10)
```

Hovering `Min` after `is`, or a narrowed variable whose chain includes `Min`, now surfaces the built-in guard documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer hover docs for built-in types, keywords and identifiers.
  * Expanded type-guard hovers including formatted signatures and surrounding documentation.
  * Built-in guard documentation shown when appropriate.

* **Bug Fixes**
  * Boolean and nil now behave as keywords in hover (not suppressed as literals).
  * Literal suppression refined to numeric/string only.

* **Tests**
  * Expanded hover and LSP error-path tests; added formatting round-trip test for guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->