### PR TITLE
feat(typechecker)!: add union/intersection IR; typedef semantics

### DIFF
--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -28,6 +28,7 @@ examples/in/generics.ft
 examples/in/basic_function.ft
 examples/in/ensure.ft
 examples/in/nominal_error.ft (`task example:nominal-error` — nominal `error X { … }` type)
+examples/in/union_error_types.ft (`task example:union-error-types` — typedef `ParseError | IoError`, golden `examples/out/union_error_types.go`)
 examples/in/result_ensure.ft (`task example:result-ensure` — Result + `ensure … is Ok()`)
 examples/in/result_if.ft (`task example:result-if` — Result + `if x is Ok()`)
 examples/in/tictactoe/ (merged package: `task example:tictactoe`; TypeScript from `forst generate`: `task example:tictactoe:generate` — writes gitignored `examples/in/tictactoe/generated/` and `examples/in/tictactoe/client/`)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -217,6 +217,12 @@ tasks:
     cmds:
       - go run ./{{.BUILD_DIR}} run -loglevel trace -report-phases -- {{.EXAMPLES_DIR}}/nominal_error.ft
 
+  example:union-error-types:
+    desc: Compile union of nominal errors typedef (ParseError | IoError → Go error / TS union)
+    dir: forst
+    cmds:
+      - go run ./{{.BUILD_DIR}} run -loglevel trace -report-phases -- {{.EXAMPLES_DIR}}/union_error_types.ft
+
   example:result-ensure:
     desc: Compile Result + ensure Ok() example (golden examples/out/result_ensure/)
     dir: forst

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 - **`in/`** — Forst `.ft` sources used by Task targets (e.g. `task example:basic`). Paths are mirrored under **`out/`** with expected Go output for integration checks (`in` → `out`).
 
-- **`in/*.ft`** at the root of `in/` (e.g. `basic.ft`, `go_builtins.ft`, `generics.ft`, `ensure.ft`, `nominal_error.ft`) are the small, primary examples referenced by the Taskfile and [testing rules](../.cursor/rules/testing.mdc).
+- **`in/*.ft`** at the root of `in/` (e.g. `basic.ft`, `go_builtins.ft`, `generics.ft`, `ensure.ft`, `nominal_error.ft`, `union_error_types.ft`) are the small, primary examples referenced by the Taskfile and [testing rules](../.cursor/rules/testing.mdc).
 
 - **`in/imports/`** — multi-file “imports” demo (LSP merged package + `task example:imports` via `cli.ft`); see `in/imports/README.md`.
 

--- a/examples/in/union_error_narrowing.ft
+++ b/examples/in/union_error_narrowing.ft
@@ -1,0 +1,32 @@
+package main
+
+// Narrowing: failure payloads from closed nominal-error unions (ErrKind = A | B) use Result(S, ErrKind)
+// and `Err()` / `Err(...)` guards — not `is ParseError` on the union (nominal errors are not `is` guards).
+// Covered by compiler and typechecker tests; no golden .go (TestExamples skips when out/ is missing).
+
+error ParseError {
+	code: Int,
+}
+
+error IoError {
+	path: String,
+}
+
+type ErrKind = ParseError | IoError
+
+func onlyParseError(p ParseError) {}
+
+func mk(): Result(Int, ErrKind) {
+	return 0
+}
+
+func demo() {
+	x := mk()
+	if x is Err(ParseError) {
+		onlyParseError(x)
+	}
+}
+
+func main() {
+	demo()
+}

--- a/examples/in/union_error_types.ft
+++ b/examples/in/union_error_types.ft
@@ -1,0 +1,18 @@
+package main
+
+// Union of nominal errors (see RFC optionals/02 §3): a finite failure set assignable to Error.
+// Go emit lowers error-only unions to `error`; TypeScript emit uses `ParseError | IoError`.
+
+error ParseError {
+	code: Int
+}
+
+error IoError {
+	path: String
+}
+
+// Named union of two failure kinds (middle ground vs Result(_, Error)).
+type ErrKind = ParseError | IoError
+
+func main() {
+}

--- a/examples/in/union_error_types.ft
+++ b/examples/in/union_error_types.ft
@@ -1,17 +1,17 @@
 package main
 
-// Union of nominal errors (see RFC optionals/02 §3): a finite failure set assignable to Error.
-// Go emit lowers error-only unions to `error`; TypeScript emit uses `ParseError | IoError`.
-
+// Union of nominal errors (see RFC optionals/02 section 3): a finite failure set assignable to Error.
+// Go emit: sealed interface `ErrKind` + marker methods on each member; TypeScript: `ParseError | IoError`.
 error ParseError {
-	code: Int
+	code: Int,
 }
 
 error IoError {
-	path: String
+	path: String,
 }
 
 // Named union of two failure kinds (middle ground vs Result(_, Error)).
+// Also valid: `type ErrKind = ParseError | IoError` (same AST).
 type ErrKind = ParseError | IoError
 
 func main() {

--- a/forst/cmd/forst/compiler/compiler_test.go
+++ b/forst/cmd/forst/compiler/compiler_test.go
@@ -24,6 +24,11 @@ func TestProgramCompilation(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "union of nominal errors typedef",
+			filePath: "../../../../examples/in/union_error_types.ft",
+			wantErr:  false,
+		},
+		{
 			name:     "non-existent file",
 			filePath: "nonexistent.ft",
 			wantErr:  true,

--- a/forst/cmd/forst/compiler/compiler_test.go
+++ b/forst/cmd/forst/compiler/compiler_test.go
@@ -29,6 +29,11 @@ func TestProgramCompilation(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "union of nominal errors with if-branch narrowing",
+			filePath: "../../../../examples/in/union_error_narrowing.ft",
+			wantErr:  false,
+		},
+		{
 			name:     "non-existent file",
 			filePath: "nonexistent.ft",
 			wantErr:  true,
@@ -124,6 +129,34 @@ func Identity(x Wire): Wire {
 	}
 	if !strings.Contains(out, "`json:\"msg\"`") || !strings.Contains(out, "`json:\"count\"`") {
 		t.Fatalf("expected json struct tags for Forst field names, got: %.400s", out)
+	}
+}
+
+func TestCompileFile_unionErrorNarrowing_example(t *testing.T) {
+	t.Parallel()
+	c := New(Args{
+		Command:  "build",
+		FilePath: "../../../../examples/in/union_error_narrowing.ft",
+		LogLevel: "error",
+	}, nil)
+	code, err := c.CompileFile()
+	if err != nil {
+		t.Fatalf("CompileFile: %v", err)
+	}
+	if code == nil {
+		t.Fatal("nil code")
+	}
+	out := *code
+	for _, want := range []string{
+		"type ErrKind interface",
+		"isErrKind()",
+		"type ParseError struct",
+		"func onlyParseError(p ParseError)",
+		"func demo()",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("generated Go missing %q\n%.1200s", want, out)
+		}
 	}
 }
 

--- a/forst/internal/ast/result_expr.go
+++ b/forst/internal/ast/result_expr.go
@@ -43,3 +43,13 @@ func (t TypeNode) IsResultType() bool {
 func (t TypeNode) IsTupleType() bool {
 	return t.Ident == TypeTuple && len(t.TypeParams) >= 1
 }
+
+// IsUnionType reports a normalized type-level union (A | B | …).
+func (t TypeNode) IsUnionType() bool {
+	return t.Ident == TypeUnion && len(t.TypeParams) >= 2
+}
+
+// IsIntersectionType reports a normalized type-level intersection (A & B & …).
+func (t TypeNode) IsIntersectionType() bool {
+	return t.Ident == TypeIntersection && len(t.TypeParams) >= 2
+}

--- a/forst/internal/ast/type.go
+++ b/forst/internal/ast/type.go
@@ -45,6 +45,11 @@ const (
 	TypeResult TypeIdent = "TYPE_RESULT"
 	// TypeTuple is Tuple(T1, ..., Tn) for product multi-values (e.g. Go FFI)
 	TypeTuple TypeIdent = "TYPE_TUPLE"
+
+	// TypeUnion is a finite type-level union (A | B | …) used by typedef and join; members are in TypeParams.
+	TypeUnion TypeIdent = "TYPE_UNION"
+	// TypeIntersection is a finite type-level intersection (A & B & …); members are in TypeParams.
+	TypeIntersection TypeIdent = "TYPE_INTERSECTION"
 )
 
 // TypeKind represents the origin/kind of a type
@@ -148,6 +153,24 @@ func (t TypeNode) String() string {
 			return fmt.Sprintf("Tuple(%s)", strings.Join(params, ", "))
 		}
 		return "Tuple()"
+	case TypeUnion:
+		if len(t.TypeParams) > 0 {
+			parts := make([]string, len(t.TypeParams))
+			for i := range t.TypeParams {
+				parts[i] = t.TypeParams[i].String()
+			}
+			return strings.Join(parts, " | ")
+		}
+		return "Union()"
+	case TypeIntersection:
+		if len(t.TypeParams) > 0 {
+			parts := make([]string, len(t.TypeParams))
+			for i := range t.TypeParams {
+				parts[i] = t.TypeParams[i].String()
+			}
+			return strings.Join(parts, " & ")
+		}
+		return "Intersection()"
 	default:
 		if t.Assertion != nil {
 			return fmt.Sprintf("%s(%s)", t.Ident, t.Assertion.String())
@@ -196,6 +219,10 @@ func (ti TypeIdent) String() string {
 		return "Result"
 	case TypeTuple:
 		return "Tuple"
+	case TypeUnion:
+		return "Union"
+	case TypeIntersection:
+		return "Intersection"
 	default:
 		return string(ti)
 	}
@@ -292,4 +319,92 @@ func NewTupleType(elems ...TypeNode) TypeNode {
 		TypeParams: elems,
 		TypeKind:   TypeKindBuiltin,
 	}
+}
+
+// NewUnionType returns a normalized finite union (flattened nested unions, deduped by shallow equality).
+func NewUnionType(members ...TypeNode) TypeNode {
+	flat := flattenUnionMembers(members)
+	if len(flat) == 1 {
+		return flat[0]
+	}
+	return TypeNode{
+		Ident:      TypeUnion,
+		TypeParams: flat,
+		TypeKind:   TypeKindBuiltin,
+	}
+}
+
+// NewIntersectionType returns a normalized finite intersection (flattened nested intersections, deduped).
+func NewIntersectionType(members ...TypeNode) TypeNode {
+	flat := flattenIntersectionMembers(members)
+	if len(flat) == 1 {
+		return flat[0]
+	}
+	return TypeNode{
+		Ident:      TypeIntersection,
+		TypeParams: flat,
+		TypeKind:   TypeKindBuiltin,
+	}
+}
+
+func flattenUnionMembers(in []TypeNode) []TypeNode {
+	var out []TypeNode
+	for _, t := range in {
+		if t.Ident == TypeUnion && len(t.TypeParams) > 0 {
+			out = append(out, flattenUnionMembers(t.TypeParams)...)
+			continue
+		}
+		out = append(out, t)
+	}
+	return dedupeTypeNodesShallow(out)
+}
+
+func flattenIntersectionMembers(in []TypeNode) []TypeNode {
+	var out []TypeNode
+	for _, t := range in {
+		if t.Ident == TypeIntersection && len(t.TypeParams) > 0 {
+			out = append(out, flattenIntersectionMembers(t.TypeParams)...)
+			continue
+		}
+		out = append(out, t)
+	}
+	return dedupeTypeNodesShallow(out)
+}
+
+func dedupeTypeNodesShallow(types []TypeNode) []TypeNode {
+	if len(types) <= 1 {
+		if len(types) == 1 {
+			return []TypeNode{types[0]}
+		}
+		return nil
+	}
+	var out []TypeNode
+	for _, t := range types {
+		found := false
+		for _, u := range out {
+			if typeNodesShallowEqualAST(t, u) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func typeNodesShallowEqualAST(a, b TypeNode) bool {
+	if a.Ident != b.Ident {
+		return false
+	}
+	if len(a.TypeParams) != len(b.TypeParams) {
+		return false
+	}
+	for i := range a.TypeParams {
+		if !typeNodesShallowEqualAST(a.TypeParams[i], b.TypeParams[i]) {
+			return false
+		}
+	}
+	return true
 }

--- a/forst/internal/generators/go.go
+++ b/forst/internal/generators/go.go
@@ -20,40 +20,6 @@ func GenerateGoCode(goFile *goast.File) (string, error) {
 	sortDeclarations(goFile)
 	sortStructFields(goFile)
 
-	// DEBUG: Log the AST before serialization to check for issues
-	fmt.Printf("DEBUG: AST before serialization - %d declarations\n", len(goFile.Decls))
-	for _, decl := range goFile.Decls {
-		if funcDecl, ok := decl.(*goast.FuncDecl); ok {
-			fmt.Printf("DEBUG: Function %s\n", funcDecl.Name.Name)
-			// Print the function body to see what's being generated
-			if funcDecl.Body != nil {
-				for j, stmt := range funcDecl.Body.List {
-					fmt.Printf("DEBUG: Statement %d: %T\n", j, stmt)
-					// If it's a return statement, print the return values
-					if returnStmt, ok := stmt.(*goast.ReturnStmt); ok {
-						fmt.Printf("DEBUG: Return statement with %d results\n", len(returnStmt.Results))
-						for k, result := range returnStmt.Results {
-							fmt.Printf("DEBUG: Return result %d: %T\n", k, result)
-							// If it's a composite literal, print its elements
-							if compositeLit, ok := result.(*goast.CompositeLit); ok {
-								fmt.Printf("DEBUG: Composite literal type: %T\n", compositeLit.Type)
-								fmt.Printf("DEBUG: Composite literal has %d elements\n", len(compositeLit.Elts))
-								for l, elt := range compositeLit.Elts {
-									if keyValue, ok := elt.(*goast.KeyValueExpr); ok {
-										fmt.Printf("DEBUG: Element %d key: %T, value: %T\n", l, keyValue.Key, keyValue.Value)
-										if basicLit, ok := keyValue.Value.(*goast.BasicLit); ok {
-											fmt.Printf("DEBUG: BasicLit Kind: %s, Value: %s\n", basicLit.Kind, basicLit.Value)
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
 	if err := format.Node(&buf, fset, goFile); err != nil {
 		return "", fmt.Errorf("failed to format Go code: %w", err)
 	}

--- a/forst/internal/parser/typedef.go
+++ b/forst/internal/parser/typedef.go
@@ -90,6 +90,20 @@ func (p *Parser) parseTypeDefExpr() ast.TypeDefExpr {
 		return ast.TypeDefShapeExpr{Shape: shape}
 	}
 
+	// TypeScript-style leading `|` or `&` after `=` (whitespace/newlines are not tokens):
+	//   type X =
+	//     | A
+	//     | B
+	// Equivalent to `type X = A | B` — skip the first token and parse the rest.
+	if p.current().Type == ast.TokenBitwiseOr {
+		p.advance()
+		return p.parseTypeDefExpr()
+	}
+	if p.current().Type == ast.TokenBitwiseAnd {
+		p.advance()
+		return p.parseTypeDefExpr()
+	}
+
 	var left ast.TypeDefExpr
 	if p.peek().Type == ast.TokenDot {
 		assertion := p.parseAssertionChain(true)

--- a/forst/internal/parser/typedef.go
+++ b/forst/internal/parser/typedef.go
@@ -98,8 +98,7 @@ func (p *Parser) parseTypeDefExpr() ast.TypeDefExpr {
 		}
 	} else {
 		typ := p.parseType(TypeIdentOpts{AllowLowercaseTypes: false})
-
-		return &ast.TypeDefAssertionExpr{
+		left = ast.TypeDefAssertionExpr{
 			Assertion: &ast.AssertionNode{
 				BaseType: &typ.Ident,
 			},

--- a/forst/internal/parser/typedef_binary_parse_test.go
+++ b/forst/internal/parser/typedef_binary_parse_test.go
@@ -41,3 +41,40 @@ func main() {}
 		t.Fatal("expected disjunction")
 	}
 }
+
+// TypeScript-style leading | after = (newlines are not tokens; lexer skips them).
+func TestParseTypeDefExpr_leadingPipeUnion(t *testing.T) {
+	t.Parallel()
+	src := `package main
+
+type A = Int
+
+type U =
+| A | String
+
+func main() {}
+`
+	log := ast.SetupTestLogger(nil)
+	p := NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var td *ast.TypeDefNode
+	for _, n := range nodes {
+		if d, ok := n.(ast.TypeDefNode); ok && d.Ident == "U" {
+			td = &d
+			break
+		}
+	}
+	if td == nil {
+		t.Fatal("expected type U")
+	}
+	bin, ok := td.Expr.(ast.TypeDefBinaryExpr)
+	if !ok {
+		t.Fatalf("expected TypeDefBinaryExpr, got %T", td.Expr)
+	}
+	if !bin.IsDisjunction() {
+		t.Fatal("expected disjunction")
+	}
+}

--- a/forst/internal/parser/typedef_binary_parse_test.go
+++ b/forst/internal/parser/typedef_binary_parse_test.go
@@ -1,0 +1,43 @@
+package parser
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+// Regression: simple identifier on the left of | must still parse as TypeDefBinaryExpr (not return early).
+func TestParseTypeDefExpr_simpleIdentUnion(t *testing.T) {
+	t.Parallel()
+	src := `package main
+
+type A = Int
+
+type U = A | String
+
+func main() {}
+`
+	log := ast.SetupTestLogger(nil)
+	p := NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var td *ast.TypeDefNode
+	for _, n := range nodes {
+		if d, ok := n.(ast.TypeDefNode); ok && d.Ident == "U" {
+			td = &d
+			break
+		}
+	}
+	if td == nil {
+		t.Fatal("expected type U")
+	}
+	bin, ok := td.Expr.(ast.TypeDefBinaryExpr)
+	if !ok {
+		t.Fatalf("expected TypeDefBinaryExpr, got %T", td.Expr)
+	}
+	if !bin.IsDisjunction() {
+		t.Fatal("expected disjunction")
+	}
+}

--- a/forst/internal/printer/format_roundtrip_test.go
+++ b/forst/internal/printer/format_roundtrip_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"forst/internal/ast"
 	"forst/internal/lexer"
 	"forst/internal/parser"
 
@@ -166,5 +167,41 @@ func getCell(cells []String, idx Int): String {
 				t.Fatalf("re-parse: %v\n--- out ---\n%s", err, out)
 			}
 		})
+	}
+}
+
+func TestPrint_unionTypedef_multilineLeadingPipe(t *testing.T) {
+	t.Parallel()
+	src := `package main
+
+type X = A | B
+
+func main() {}
+`
+	log := ast.SetupTestLogger(nil)
+	log.SetLevel(logrus.ErrorLevel)
+	l := lexer.New([]byte(src), "t.ft", log)
+	tokens := l.Lex()
+	p := parser.New(tokens, "t.ft", log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultConfig()
+	cfg.TypeDefLineWidth = 1 // force Prettier-style break for any union with 2+ members
+	out, err := Print(cfg, nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "type X =\n") {
+		t.Fatalf("expected multiline typedef header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "| A") || !strings.Contains(out, "| B") {
+		t.Fatalf("expected leading | on each variant, got:\n%s", out)
+	}
+	// Round-trip parse formatted output
+	l2 := lexer.New([]byte(out), "t.ft", log)
+	if _, err := parser.New(l2.Lex(), "t.ft", log).ParseFile(); err != nil {
+		t.Fatalf("re-parse formatted: %v\n%s", err, out)
 	}
 }

--- a/forst/internal/printer/printer.go
+++ b/forst/internal/printer/printer.go
@@ -17,11 +17,14 @@ import (
 type Config struct {
 	// Indent is one indentation level inside blocks (default "\t").
 	Indent string
+	// TypeDefLineWidth is the maximum length for a full `type Name = expr` line before breaking
+	// union/intersection typedefs across lines (leading | or & per member, Prettier-style). Zero defaults to 80.
+	TypeDefLineWidth int
 }
 
 // DefaultConfig returns Config with tab indentation.
 func DefaultConfig() Config {
-	return Config{Indent: "\t"}
+	return Config{Indent: "\t", TypeDefLineWidth: 80}
 }
 
 // FormatSource lexes and parses src then pretty-prints the AST. fileID is used for diagnostics.
@@ -213,6 +216,13 @@ func (p *printer) printImportGroup(g ast.ImportGroupNode) string {
 	return b.String()
 }
 
+func (p *printer) effectiveTypeDefLineWidth() int {
+	if p.cfg.TypeDefLineWidth <= 0 {
+		return 80
+	}
+	return p.cfg.TypeDefLineWidth
+}
+
 func (p *printer) printTypeDef(t ast.TypeDefNode) (string, error) {
 	if _, ok := t.Expr.(ast.TypeDefErrorExpr); ok {
 		ee := t.Expr.(ast.TypeDefErrorExpr)
@@ -226,7 +236,102 @@ func (p *printer) printTypeDef(t ast.TypeDefNode) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("type %s = %s", string(t.Ident), expr), nil
+	name := string(t.Ident)
+	single := fmt.Sprintf("type %s = %s", name, expr)
+	if body, ok, err := p.maybeMultilineTypeDefAlias(name, t.Expr, single); err != nil {
+		return "", err
+	} else if ok {
+		return body, nil
+	}
+	return single, nil
+}
+
+// maybeMultilineTypeDefAlias returns (formatted, true, nil) when the typedef is broken across lines.
+func (p *printer) maybeMultilineTypeDefAlias(name string, e ast.TypeDefExpr, singleLine string) (string, bool, error) {
+	op, members := flattenTypeDefSameOpChain(e)
+	if len(members) < 2 {
+		return "", false, nil
+	}
+	if len(singleLine) <= p.effectiveTypeDefLineWidth() {
+		return "", false, nil
+	}
+	body, err := p.printTypeDefExprLeadingOps(op, members)
+	if err != nil {
+		return "", false, err
+	}
+	out := fmt.Sprintf("type %s =\n%s", name, prefixEachLine(p.cfg.Indent, body))
+	return out, true, nil
+}
+
+// flattenTypeDefSameOpChain returns (op, members) for a homogeneous | or & chain, or ("", nil) if not splittable.
+func flattenTypeDefSameOpChain(e ast.TypeDefExpr) (ast.TokenIdent, []ast.TypeDefExpr) {
+	bin, ok := unwrapTypeDefBinary(e)
+	if !ok || (bin.Op != ast.TokenBitwiseOr && bin.Op != ast.TokenBitwiseAnd) {
+		return "", nil
+	}
+	op := bin.Op
+	members := flattenTypeDefSameOp(e, op)
+	if len(members) < 2 {
+		return "", nil
+	}
+	return op, members
+}
+
+func unwrapTypeDefBinary(e ast.TypeDefExpr) (ast.TypeDefBinaryExpr, bool) {
+	switch x := e.(type) {
+	case ast.TypeDefBinaryExpr:
+		return x, true
+	case *ast.TypeDefBinaryExpr:
+		if x == nil {
+			return ast.TypeDefBinaryExpr{}, false
+		}
+		return *x, true
+	default:
+		return ast.TypeDefBinaryExpr{}, false
+	}
+}
+
+func flattenTypeDefSameOp(e ast.TypeDefExpr, op ast.TokenIdent) []ast.TypeDefExpr {
+	switch x := e.(type) {
+	case ast.TypeDefBinaryExpr:
+		if x.Op != op {
+			return []ast.TypeDefExpr{e}
+		}
+		left := flattenTypeDefSameOp(x.Left, op)
+		right := flattenTypeDefSameOp(x.Right, op)
+		out := make([]ast.TypeDefExpr, 0, len(left)+len(right))
+		out = append(out, left...)
+		out = append(out, right...)
+		return out
+	case *ast.TypeDefBinaryExpr:
+		if x == nil {
+			return []ast.TypeDefExpr{e}
+		}
+		return flattenTypeDefSameOp(*x, op)
+	default:
+		return []ast.TypeDefExpr{e}
+	}
+}
+
+func (p *printer) printTypeDefExprLeadingOps(op ast.TokenIdent, members []ast.TypeDefExpr) (string, error) {
+	opStr := "|"
+	if op == ast.TokenBitwiseAnd {
+		opStr = "&"
+	}
+	var b strings.Builder
+	for i, m := range members {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(opStr)
+		b.WriteByte(' ')
+		s, err := p.printTypeDefExpr(m)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(s)
+	}
+	return b.String(), nil
 }
 
 func (p *printer) printTypeDefExpr(e ast.TypeDefExpr) (string, error) {

--- a/forst/internal/transformer/go/error_union_sealed.go
+++ b/forst/internal/transformer/go/error_union_sealed.go
@@ -1,0 +1,129 @@
+package transformergo
+
+import (
+	"fmt"
+
+	"forst/internal/ast"
+	"forst/internal/typechecker"
+	goast "go/ast"
+	"go/token"
+)
+
+// flattenUnionTypeParams returns leaf members of a TypeUnion tree (same op chain).
+func flattenUnionTypeParams(n ast.TypeNode) []ast.TypeNode {
+	if n.Ident != ast.TypeUnion || len(n.TypeParams) == 0 {
+		return nil
+	}
+	var out []ast.TypeNode
+	for _, m := range n.TypeParams {
+		if m.Ident == ast.TypeUnion && len(m.TypeParams) > 0 {
+			out = append(out, flattenUnionTypeParams(m)...)
+		} else {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// nominalErrorUnionMembers reports whether every union member is a user-declared nominal error type
+// (error X { ... }) and returns their idents. Built-in Error or non-nominal members => false.
+func nominalErrorUnionMembers(tc *typechecker.TypeChecker, members []ast.TypeNode) ([]ast.TypeIdent, bool) {
+	var out []ast.TypeIdent
+	for _, m := range members {
+		if m.Ident == "" {
+			return nil, false
+		}
+		if m.Ident == ast.TypeError {
+			return nil, false
+		}
+		def, ok := tc.Defs[m.Ident].(ast.TypeDefNode)
+		if !ok {
+			return nil, false
+		}
+		if _, ok := def.Expr.(ast.TypeDefErrorExpr); !ok {
+			return nil, false
+		}
+		out = append(out, m.Ident)
+	}
+	return out, len(out) >= 2
+}
+
+// sealedUnionMethodName returns the unexported interface method used to seal this typedef (e.g. ErrKind -> isErrKind).
+func sealedUnionMethodName(typedefName ast.TypeIdent) string {
+	s := string(typedefName)
+	if len(s) == 0 {
+		return "isUnion"
+	}
+	// is + exported name: ErrKind -> isErrKind
+	return "is" + s
+}
+
+func (t *Transformer) tryEmitNominalErrorUnionSealedInterface(node ast.TypeDefNode, bin ast.TypeDefBinaryExpr) (*goast.GenDecl, error) {
+	canon, err := t.TypeChecker.TypeDefExprToTypeNode(bin)
+	if err != nil || canon.Ident != ast.TypeUnion || !t.TypeChecker.IsErrorKindedType(canon) {
+		return nil, nil
+	}
+	members := flattenUnionTypeParams(canon)
+	idents, ok := nominalErrorUnionMembers(t.TypeChecker, members)
+	if !ok {
+		return nil, nil
+	}
+	methodName := sealedUnionMethodName(node.Ident)
+	iface := &goast.InterfaceType{
+		Methods: &goast.FieldList{
+			List: []*goast.Field{
+				{
+					Names: []*goast.Ident{goast.NewIdent(methodName)},
+					Type: &goast.FuncType{
+						Params: &goast.FieldList{},
+					},
+				},
+			},
+		},
+	}
+	typeName := node.Ident
+	if typeName == "" {
+		return nil, nil
+	}
+	comments := []*goast.Comment{
+		{Text: fmt.Sprintf("// %s is a closed union of nominal errors (only these types implement it).", typeName)},
+	}
+	decl := &goast.GenDecl{
+		Tok: token.TYPE,
+		Specs: []goast.Spec{
+			&goast.TypeSpec{
+				Name: goast.NewIdent(string(typeName)),
+				Type: iface,
+			},
+		},
+		Doc: &goast.CommentGroup{List: comments},
+	}
+	for _, id := range idents {
+		t.emitSealedUnionMemberMethodIfNew(string(id), methodName)
+	}
+	return decl, nil
+}
+
+func (t *Transformer) emitSealedUnionMemberMethodIfNew(receiverType, methodName string) {
+	if t.emittedSealMethods == nil {
+		t.emittedSealMethods = make(map[string]struct{})
+	}
+	key := receiverType + "\x00" + methodName
+	if _, ok := t.emittedSealMethods[key]; ok {
+		return
+	}
+	t.emittedSealMethods[key] = struct{}{}
+	fn := &goast.FuncDecl{
+		Recv: &goast.FieldList{
+			List: []*goast.Field{
+				{Type: goast.NewIdent(receiverType)},
+			},
+		},
+		Name: goast.NewIdent(methodName),
+		Type: &goast.FuncType{
+			Params: &goast.FieldList{},
+		},
+		Body: &goast.BlockStmt{},
+	}
+	t.Output.AddFunction(fn)
+}

--- a/forst/internal/transformer/go/error_union_sealed_test.go
+++ b/forst/internal/transformer/go/error_union_sealed_test.go
@@ -1,0 +1,496 @@
+package transformergo
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/parser"
+	"forst/internal/typechecker"
+)
+
+func TestFlattenUnionTypeParams_emptyAndNonUnion(t *testing.T) {
+	t.Parallel()
+	if flattenUnionTypeParams(ast.TypeNode{Ident: ast.TypeString}) != nil {
+		t.Fatal("expected nil for non-union")
+	}
+	if flattenUnionTypeParams(ast.TypeNode{Ident: ast.TypeUnion}) != nil {
+		t.Fatal("expected nil for empty union params")
+	}
+}
+
+func TestFlattenUnionTypeParams_flatAndNested(t *testing.T) {
+	t.Parallel()
+	a := ast.TypeNode{Ident: ast.TypeIdent("A")}
+	b := ast.TypeNode{Ident: ast.TypeIdent("B")}
+	c := ast.TypeNode{Ident: ast.TypeIdent("C")}
+	flat := ast.NewUnionType(a, b, c)
+	got := flattenUnionTypeParams(flat)
+	if len(got) != 3 {
+		t.Fatalf("len=%d want 3: %#v", len(got), got)
+	}
+	nested := ast.NewUnionType(ast.NewUnionType(a, b), c)
+	got2 := flattenUnionTypeParams(nested)
+	if len(got2) != 3 {
+		t.Fatalf("nested: len=%d want 3", len(got2))
+	}
+}
+
+// TestFlattenUnionTypeParams_unionChildRecurses covers the recursive branch when a union member is
+// itself TypeUnion with TypeParams. ast.NewUnionType normalizes nested unions, so this must be built manually.
+func TestFlattenUnionTypeParams_unionChildRecurses(t *testing.T) {
+	t.Parallel()
+	a := ast.TypeNode{Ident: ast.TypeIdent("A")}
+	b := ast.TypeNode{Ident: ast.TypeIdent("B")}
+	c := ast.TypeNode{Ident: ast.TypeIdent("C")}
+	inner := ast.TypeNode{
+		Ident:      ast.TypeUnion,
+		TypeParams: []ast.TypeNode{a, b},
+		TypeKind:   ast.TypeKindBuiltin,
+	}
+	outer := ast.TypeNode{
+		Ident:      ast.TypeUnion,
+		TypeParams: []ast.TypeNode{inner, c},
+		TypeKind:   ast.TypeKindBuiltin,
+	}
+	got := flattenUnionTypeParams(outer)
+	if len(got) != 3 {
+		t.Fatalf("len=%d want 3: %#v", len(got), got)
+	}
+	for i, want := range []ast.TypeIdent{"A", "B", "C"} {
+		if got[i].Ident != want {
+			t.Fatalf("got[%d].Ident=%q want %q", i, got[i].Ident, want)
+		}
+	}
+}
+
+func TestFlattenUnionTypeParams_balancedQuartetOrder(t *testing.T) {
+	t.Parallel()
+	a := ast.TypeNode{Ident: ast.TypeIdent("A")}
+	b := ast.TypeNode{Ident: ast.TypeIdent("B")}
+	c := ast.TypeNode{Ident: ast.TypeIdent("C")}
+	d := ast.TypeNode{Ident: ast.TypeIdent("D")}
+	// ((A|B)|(C|D)) — still a single chain of TypeUnion leaves
+	u := ast.NewUnionType(ast.NewUnionType(a, b), ast.NewUnionType(c, d))
+	got := flattenUnionTypeParams(u)
+	if len(got) != 4 {
+		t.Fatalf("len=%d want 4: %#v", len(got), got)
+	}
+	for i, want := range []ast.TypeIdent{"A", "B", "C", "D"} {
+		if got[i].Ident != want {
+			t.Fatalf("got[%d].Ident=%q want %q", i, got[i].Ident, want)
+		}
+	}
+}
+
+func TestSealedUnionMethodName(t *testing.T) {
+	t.Parallel()
+	if sealedUnionMethodName("ErrKind") != "isErrKind" {
+		t.Fatalf("got %q", sealedUnionMethodName("ErrKind"))
+	}
+	if sealedUnionMethodName("E") != "isE" {
+		t.Fatalf("got %q", sealedUnionMethodName("E"))
+	}
+	if sealedUnionMethodName("") != "isUnion" {
+		t.Fatalf("got %q", sealedUnionMethodName(""))
+	}
+	if sealedUnionMethodName("MyUnion") != "isMyUnion" {
+		t.Fatalf("got %q", sealedUnionMethodName("MyUnion"))
+	}
+}
+
+func TestNominalErrorUnionMembers(t *testing.T) {
+	t.Parallel()
+	log := ast.SetupTestLogger(nil)
+	log.SetOutput(io.Discard)
+	tc := typechecker.New(log, false)
+
+	payload := ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}
+	tc.Defs["NomA"] = ast.TypeDefNode{Ident: "NomA", Expr: ast.TypeDefErrorExpr{Payload: payload}}
+	tc.Defs["NomB"] = ast.TypeDefNode{Ident: "NomB", Expr: ast.TypeDefErrorExpr{Payload: payload}}
+	str := ast.TypeString
+	tc.Defs["AliasStr"] = ast.TypeDefNode{
+		Ident: "AliasStr",
+		Expr: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &str}},
+	}
+	tc.Defs["Rec"] = ast.TypeDefNode{
+		Ident: "Rec",
+		Expr:  ast.TypeDefShapeExpr{Shape: payload},
+	}
+	tc.Defs["NomC"] = ast.TypeDefNode{Ident: "NomC", Expr: ast.TypeDefErrorExpr{Payload: payload}}
+
+	t.Run("two_nominals_ok", func(t *testing.T) {
+		members := []ast.TypeNode{{Ident: "NomA"}, {Ident: "NomB"}}
+		ids, ok := nominalErrorUnionMembers(tc, members)
+		if !ok || len(ids) != 2 || ids[0] != "NomA" || ids[1] != "NomB" {
+			t.Fatalf("got ok=%v ids=%v", ok, ids)
+		}
+	})
+	t.Run("builtin_error_rejected", func(t *testing.T) {
+		_, ok := nominalErrorUnionMembers(tc, []ast.TypeNode{{Ident: ast.TypeError}, {Ident: "NomA"}})
+		if ok {
+			t.Fatal("expected false when mixing built-in Error")
+		}
+	})
+	t.Run("non_nominal_rejected", func(t *testing.T) {
+		_, ok := nominalErrorUnionMembers(tc, []ast.TypeNode{{Ident: "NomA"}, {Ident: "AliasStr"}})
+		if ok {
+			t.Fatal("expected false for non-nominal member")
+		}
+	})
+	t.Run("missing_def_rejected", func(t *testing.T) {
+		_, ok := nominalErrorUnionMembers(tc, []ast.TypeNode{{Ident: "NomA"}, {Ident: "MissingType"}})
+		if ok {
+			t.Fatal("expected false for unknown type")
+		}
+	})
+	t.Run("single_member_false", func(t *testing.T) {
+		_, ok := nominalErrorUnionMembers(tc, []ast.TypeNode{{Ident: "NomA"}})
+		if ok {
+			t.Fatal("expected false for single member (need >= 2)")
+		}
+	})
+	t.Run("empty_ident_rejected", func(t *testing.T) {
+		_, ok := nominalErrorUnionMembers(tc, []ast.TypeNode{{Ident: ""}, {Ident: "NomA"}})
+		if ok {
+			t.Fatal("expected false")
+		}
+	})
+	t.Run("shape_typedef_rejected", func(t *testing.T) {
+		_, ok := nominalErrorUnionMembers(tc, []ast.TypeNode{{Ident: "NomA"}, {Ident: "Rec"}})
+		if ok {
+			t.Fatal("expected false when a member is a non-error shape typedef")
+		}
+	})
+	t.Run("three_nominals_ok", func(t *testing.T) {
+		members := []ast.TypeNode{{Ident: "NomA"}, {Ident: "NomB"}, {Ident: "NomC"}}
+		ids, ok := nominalErrorUnionMembers(tc, members)
+		if !ok || len(ids) != 3 {
+			t.Fatalf("got ok=%v ids=%v", ok, ids)
+		}
+	})
+}
+
+func TestEmitSealedUnionMemberMethodIfNew_dedupes(t *testing.T) {
+	t.Parallel()
+	log := ast.SetupTestLogger(nil)
+	log.SetOutput(io.Discard)
+	tc := typechecker.New(log, false)
+	tr := New(tc, log)
+	tr.emitSealedUnionMemberMethodIfNew("ParseError", "isErrKind")
+	tr.emitSealedUnionMemberMethodIfNew("ParseError", "isErrKind")
+	tr.emitSealedUnionMemberMethodIfNew("IoError", "isErrKind")
+	if len(tr.Output.functions) != 2 {
+		t.Fatalf("want 2 unique funcs, got %d", len(tr.Output.functions))
+	}
+}
+
+func TestEmitSealedUnionMemberMethodIfNew_sameReceiverDistinctMethods(t *testing.T) {
+	t.Parallel()
+	log := ast.SetupTestLogger(nil)
+	log.SetOutput(io.Discard)
+	tc := typechecker.New(log, false)
+	tr := New(tc, log)
+	tr.emitSealedUnionMemberMethodIfNew("ParseError", "isErrKind")
+	tr.emitSealedUnionMemberMethodIfNew("ParseError", "isAltSeal")
+	if len(tr.Output.functions) != 2 {
+		t.Fatalf("want 2 funcs (same receiver, different seal method names), got %d", len(tr.Output.functions))
+	}
+}
+
+func TestPipeline_nominalErrorUnion_sealedGoInterface(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join("..", "..", "..", "..", "examples", "in", "union_error_types.ft")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := compileForstPipeline(t, string(src))
+	for _, needle := range []string{
+		"type ErrKind interface",
+		"isErrKind()",
+		"func (ParseError) isErrKind()",
+		"func (IoError) isErrKind()",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("generated Go missing %q\n%s", needle, out)
+		}
+	}
+	if strings.Contains(out, "type ErrKind error") {
+		t.Fatalf("expected sealed interface, not error alias; got:\n%s", out)
+	}
+}
+
+func TestPipeline_errorUnion_table(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		src          string
+		mustContain  []string
+		mustNotContain []string
+	}{
+		{
+			name: "sealed_three_nominal_errors",
+			src: `package main
+error A { code: Int }
+error B { path: String }
+error C { n: Int }
+type U = A | B | C
+func main() {}
+`,
+			mustContain: []string{
+				"type U interface",
+				"isU()",
+				"func (A) isU()",
+				"func (B) isU()",
+				"func (C) isU()",
+			},
+			mustNotContain: []string{"type U error"},
+		},
+		{
+			name: "builtin_error_mixed_with_nominal_not_sealed",
+			src: `package main
+error E { code: Int }
+type U = Error | E
+func main() {}
+`,
+			mustContain:    []string{"type U error"},
+			mustNotContain: []string{"type U interface", "isU()"},
+		},
+		{
+			name: "non_error_union_string_int",
+			src: `package main
+type U = String | Int
+func main() {}
+`,
+			mustContain:    []string{"type U any"},
+			mustNotContain: []string{"type U interface", "type U error"},
+		},
+		{
+			name: "two_sealed_typedefs_distinct_methods",
+			src: `package main
+error P { code: Int }
+error Q { n: Int }
+type First = P | Q
+type Second = P | Q
+func main() {}
+`,
+			mustContain: []string{
+				"type First interface",
+				"isFirst()",
+				"type Second interface",
+				"isSecond()",
+				"func (P) isFirst()",
+				"func (Q) isFirst()",
+				"func (P) isSecond()",
+				"func (Q) isSecond()",
+			},
+		},
+		{
+			name: "leading_pipe_same_as_infix",
+			src: `package main
+error A { code: Int }
+error B { n: Int }
+type U =
+| A
+| B
+func main() {}
+`,
+			mustContain: []string{
+				"type U interface",
+				"func (A) isU()",
+				"func (B) isU()",
+			},
+		},
+		{
+			name: "sealed_four_nominal_errors",
+			src: `package main
+error A { code: Int }
+error B { path: String }
+error C { n: Int }
+error D { k: Int }
+type U = A | B | C | D
+func main() {}
+`,
+			mustContain: []string{
+				"type U interface",
+				"func (A) isU()",
+				"func (B) isU()",
+				"func (C) isU()",
+				"func (D) isU()",
+				"// U is a closed union of nominal errors",
+			},
+			mustNotContain: []string{"type U error"},
+		},
+		{
+			name: "sealed_emits_doc_comment",
+			src: `package main
+error X { code: Int }
+error Y { n: Int }
+type Kind = X | Y
+func main() {}
+`,
+			mustContain: []string{
+				"// Kind is a closed union of nominal errors",
+				"type Kind interface",
+				"func (X) isKind()",
+				"func (Y) isKind()",
+			},
+		},
+		{
+			name: "builtin_error_or_string_not_sealed",
+			src: `package main
+type U = Error | String
+func main() {}
+`,
+			mustContain: []string{"type U any"},
+			mustNotContain: []string{
+				"type U interface",
+				"isU()",
+			},
+		},
+		{
+			name: "nominal_error_or_shape_record_not_sealed",
+			src: `package main
+error E { code: Int }
+type R = { n: Int }
+type U = E | R
+func main() {}
+`,
+			mustContain: []string{"type U any"},
+			mustNotContain: []string{
+				"type U interface",
+				"func (E) isU()",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out := compileForstPipeline(t, tt.src)
+			for _, s := range tt.mustContain {
+				if !strings.Contains(out, s) {
+					t.Fatalf("missing %q\n%s", s, out)
+				}
+			}
+			for _, s := range tt.mustNotContain {
+				if strings.Contains(out, s) {
+					t.Fatalf("must not contain %q\n%s", s, out)
+				}
+			}
+		})
+	}
+}
+
+func TestTransformTypeDef_twice_no_duplicate_seal_methods(t *testing.T) {
+	t.Parallel()
+	log := ast.SetupTestLogger(nil)
+	log.SetOutput(io.Discard)
+	src := `package main
+error A { code: Int }
+error B { n: Int }
+type U = A | B
+func main() {}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := typechecker.New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
+	var udef ast.TypeDefNode
+	for _, n := range nodes {
+		if d, ok := n.(ast.TypeDefNode); ok && d.Ident == "U" {
+			udef = d
+			break
+		}
+	}
+	tr := New(tc, log)
+	_, err = tr.TransformForstFileToGo(nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstCount := countSealMethods(tr, "isU")
+	if firstCount < 2 {
+		t.Fatalf("expected at least 2 isU methods, got %d", firstCount)
+	}
+	// Second full transform simulates re-entrancy (e.g. emit pass): new transformer, same AST
+	tr2 := New(tc, log)
+	if _, err := tr2.TransformForstFileToGo(nodes); err != nil {
+		t.Fatal(err)
+	}
+	secondCount := countSealMethods(tr2, "isU")
+	if secondCount != firstCount {
+		t.Fatalf("method count mismatch: first=%d second=%d", firstCount, secondCount)
+	}
+	if udef.Ident != "U" {
+		t.Fatal("expected U typedef")
+	}
+}
+
+func TestTryEmitNominalErrorUnionSealedInterface_emptyTypeNameReturnsNil(t *testing.T) {
+	t.Parallel()
+	log := ast.SetupTestLogger(nil)
+	log.SetOutput(io.Discard)
+	tc := typechecker.New(log, false)
+	payload := ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}
+	tc.Defs["A"] = ast.TypeDefNode{Ident: "A", Expr: ast.TypeDefErrorExpr{Payload: payload}}
+	tc.Defs["B"] = ast.TypeDefNode{Ident: "B", Expr: ast.TypeDefErrorExpr{Payload: payload}}
+	aName := ast.TypeIdent("A")
+	bName := ast.TypeIdent("B")
+	bin := ast.TypeDefBinaryExpr{
+		Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &aName}},
+		Op:    ast.TokenBitwiseOr,
+		Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &bName}},
+	}
+	node := ast.TypeDefNode{Ident: "", Expr: bin}
+	tr := New(tc, log)
+	got, err := tr.tryEmitNominalErrorUnionSealedInterface(node, bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil *ast.GenDecl when typedef ident is empty, got %#v", got)
+	}
+}
+
+// If TypeDefExprToTypeNode fails on the binary body, tryEmit must bail without error (same as "not a sealed nominal union").
+func TestTryEmitNominalErrorUnionSealedInterface_typeDefExprErrorReturnsNil(t *testing.T) {
+	t.Parallel()
+	log := ast.SetupTestLogger(nil)
+	log.SetOutput(io.Discard)
+	tc := typechecker.New(log, false)
+	payload := ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}
+	tc.Defs["A"] = ast.TypeDefNode{Ident: "A", Expr: ast.TypeDefErrorExpr{Payload: payload}}
+	aName := ast.TypeIdent("A")
+	bin := ast.TypeDefBinaryExpr{
+		Left:  ast.TypeDefErrorExpr{Payload: payload},
+		Op:    ast.TokenBitwiseOr,
+		Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &aName}},
+	}
+	node := ast.TypeDefNode{Ident: "U", Expr: bin}
+	tr := New(tc, log)
+	got, err := tr.tryEmitNominalErrorUnionSealedInterface(node, bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil when binary cannot lower to TypeNode, got %#v", got)
+	}
+}
+
+func countSealMethods(tr *Transformer, method string) int {
+	n := 0
+	for _, f := range tr.Output.functions {
+		if f.Name != nil && f.Name.Name == method {
+			n++
+		}
+	}
+	return n
+}

--- a/forst/internal/transformer/go/expression.go
+++ b/forst/internal/transformer/go/expression.go
@@ -161,6 +161,44 @@ func (t *Transformer) goResultErrIdentForExpr(left ast.ExpressionNode) (goast.Ex
 	return nil, fmt.Errorf("if-is: Result Ok/Err requires a Result-bound variable (missing local split for %q)", name)
 }
 
+// goExprErrFailureTypeAssertion builds a bool expression for `Err(T)` when T is a type argument:
+// failure value is non-nil and type-asserts to T (comma-ok), for codegen when no runtime value is given.
+func (t *Transformer) goExprErrFailureTypeAssertion(errExpr goast.Expr, discriminant *ast.TypeNode) (goast.Expr, error) {
+	if discriminant == nil {
+		return nil, fmt.Errorf("if-is: Err type discriminator needs a type")
+	}
+	goTy, err := t.transformType(*discriminant)
+	if err != nil {
+		return nil, err
+	}
+	// func() bool {
+	//   if errExpr == nil { return false }
+	//   _, ok := errExpr.(T)
+	//   return ok
+	// }()
+	ifNil := &goast.IfStmt{
+		Cond: &goast.BinaryExpr{X: errExpr, Op: token.EQL, Y: goast.NewIdent("nil")},
+		Body: &goast.BlockStmt{List: []goast.Stmt{
+			&goast.ReturnStmt{Results: []goast.Expr{goast.NewIdent("false")}},
+		}},
+	}
+	assign := &goast.AssignStmt{
+		Lhs: []goast.Expr{goast.NewIdent("_"), goast.NewIdent("ok")},
+		Tok: token.DEFINE,
+		Rhs: []goast.Expr{&goast.TypeAssertExpr{X: errExpr, Type: goTy}},
+	}
+	retOk := &goast.ReturnStmt{Results: []goast.Expr{goast.NewIdent("ok")}}
+	fn := &goast.FuncLit{
+		Type: &goast.FuncType{
+			Results: &goast.FieldList{
+				List: []*goast.Field{{Type: goast.NewIdent("bool")}},
+			},
+		},
+		Body: &goast.BlockStmt{List: []goast.Stmt{ifNil, assign, retOk}},
+	}
+	return &goast.CallExpr{Fun: fn}, nil
+}
+
 // transformResultIsDiscriminator lowers `x is Ok(...)` / `Err(...)` for Result lowered to (succ, err).
 func (t *Transformer) transformResultIsDiscriminator(left ast.ExpressionNode, c ast.ConstraintNode) (goast.Expr, error) {
 	errExpr, err := t.goResultErrIdentForExpr(left)
@@ -194,6 +232,9 @@ func (t *Transformer) transformResultIsDiscriminator(left ast.ExpressionNode, c 
 			return &goast.BinaryExpr{X: errExpr, Op: token.NEQ, Y: goast.NewIdent("nil")}, nil
 		}
 		if len(c.Args) == 1 {
+			if c.Args[0].Type != nil {
+				return t.goExprErrFailureTypeAssertion(errExpr, c.Args[0].Type)
+			}
 			argExpr, err := expressionFromConstraintArg(c.Args[0])
 			if err != nil {
 				return nil, err

--- a/forst/internal/transformer/go/result_discriminator_test.go
+++ b/forst/internal/transformer/go/result_discriminator_test.go
@@ -111,6 +111,18 @@ func TestTransformResultIsDiscriminator_splitLocal(t *testing.T) {
 		}
 	})
 
+	t.Run("Err_with_type_arg", func(t *testing.T) {
+		arg := ast.ConstraintArgumentNode{Type: &ast.TypeNode{Ident: ast.TypeInt}}
+		out, err := tr.transformResultIsDiscriminator(left, ast.ConstraintNode{Name: "Err", Args: []ast.ConstraintArgumentNode{arg}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := exprString(t, out)
+		if !strings.Contains(s, "int") || !strings.Contains(s, "ok") {
+			t.Fatalf("got %q", s)
+		}
+	})
+
 	t.Run("Err_too_many_args", func(t *testing.T) {
 		var v1 ast.ValueNode = ast.IntLiteralNode{Value: 1}
 		var v2 ast.ValueNode = ast.IntLiteralNode{Value: 2}

--- a/forst/internal/transformer/go/transform_type_union_test.go
+++ b/forst/internal/transformer/go/transform_type_union_test.go
@@ -1,0 +1,71 @@
+package transformergo
+
+import (
+	"go/ast"
+	"io"
+	"testing"
+
+	forstast "forst/internal/ast"
+	"forst/internal/typechecker"
+)
+
+// Exercises transformType's TypeUnion branch: error-kinded unions lower to Go's built-in error type;
+// mixed unions lower to any (same path as typedef fallback for non-sealed unions).
+func TestTransformType_unionErrorKindedVsAny(t *testing.T) {
+	t.Parallel()
+	log := forstast.SetupTestLogger(nil)
+	log.SetOutput(io.Discard)
+	tc := typechecker.New(log, false)
+	tc.Defs["E1"] = forstast.TypeDefNode{
+		Ident: "E1",
+		Expr: forstast.TypeDefErrorExpr{
+			Payload: forstast.ShapeNode{Fields: map[string]forstast.ShapeFieldNode{}},
+		},
+	}
+	tc.Defs["E2"] = forstast.TypeDefNode{
+		Ident: "E2",
+		Expr: forstast.TypeDefErrorExpr{
+			Payload: forstast.ShapeNode{Fields: map[string]forstast.ShapeFieldNode{}},
+		},
+	}
+	tr := New(tc, log)
+
+	errKinded := forstast.NewUnionType(
+		forstast.TypeNode{Ident: "E1"},
+		forstast.TypeNode{Ident: "E2"},
+	)
+	goErr, err := tr.transformType(errKinded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, ok := goErr.(*ast.Ident)
+	if !ok || id.Name != "error" {
+		t.Fatalf("nominal error union should emit Go `error`, got %#v", goErr)
+	}
+
+	mixed := forstast.NewUnionType(
+		forstast.TypeNode{Ident: forstast.TypeError},
+		forstast.TypeNode{Ident: forstast.TypeString},
+	)
+	goAny, err := tr.transformType(mixed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, ok := goAny.(*ast.Ident)
+	if !ok || id2.Name != "any" {
+		t.Fatalf("non-uniformly error-kinded union should emit `any`, got %#v", goAny)
+	}
+
+	inter := forstast.NewIntersectionType(
+		forstast.TypeNode{Ident: "E1"},
+		forstast.TypeNode{Ident: "E2"},
+	)
+	goInter, err := tr.transformType(inter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id3, ok := goInter.(*ast.Ident)
+	if !ok || id3.Name != "any" {
+		t.Fatalf("intersection should lower to `any` in Go, got %#v", goInter)
+	}
+}

--- a/forst/internal/transformer/go/transformer.go
+++ b/forst/internal/transformer/go/transformer.go
@@ -30,6 +30,9 @@ type Transformer struct {
 	// resultLocalSplit maps a Forst variable name to the Go identifiers used when lowering
 	// "x := pkg.F()" where F returns Result (Go (values..., error)). Scoped per transformFunction.
 	resultLocalSplit map[string]resultLocalSplit
+
+	// emittedSealMethods records receiver+method pairs for nominal error union sealing (dedupe on re-emit).
+	emittedSealMethods map[string]struct{}
 }
 
 // New creates a new Transformer

--- a/forst/internal/transformer/go/type.go
+++ b/forst/internal/transformer/go/type.go
@@ -58,6 +58,16 @@ func (t *Transformer) transformType(n ast.TypeNode) (goast.Expr, error) {
 		return nil, fmt.Errorf("result types are expanded at function boundaries; use transformTypes, not transformType, or transformResultAsStructFieldGoType for struct fields")
 	case ast.TypeTuple:
 		return nil, fmt.Errorf("tuple types are expanded at function boundaries; use transformTypes, not transformType")
+	case ast.TypeUnion:
+		if t.TypeChecker.IsErrorKindedType(n) {
+			var r goast.Expr = goast.NewIdent("error")
+			return r, nil
+		}
+		var r goast.Expr = goast.NewIdent("any")
+		return r, nil
+	case ast.TypeIntersection:
+		var r goast.Expr = goast.NewIdent("any")
+		return r, nil
 	default:
 		// Always use the unified type aliasing function from the typechecker for all non-builtin, non-special types
 		name, err := t.TypeChecker.GetAliasedTypeName(n, typechecker.GetAliasedTypeNameOptions{AllowStructuralAlias: false})

--- a/forst/internal/transformer/go/typedef.go
+++ b/forst/internal/transformer/go/typedef.go
@@ -17,6 +17,15 @@ func (t *Transformer) transformTypeDef(node ast.TypeDefNode) (*goast.GenDecl, er
 	}
 	hashTypeName := hash.ToTypeIdent()
 
+	// Closed union of nominal errors: emit a sealed interface + marker methods instead of `type T error`.
+	if bin, ok := node.Expr.(ast.TypeDefBinaryExpr); ok && bin.IsDisjunction() {
+		if sealed, err := t.tryEmitNominalErrorUnionSealedInterface(node, bin); err != nil {
+			return nil, err
+		} else if sealed != nil {
+			return sealed, nil
+		}
+	}
+
 	expr, err := t.transformTypeDefExpr(node.Expr)
 	if err != nil {
 		t.log.WithFields(logrus.Fields{

--- a/forst/internal/transformer/go/typedef_expr.go
+++ b/forst/internal/transformer/go/typedef_expr.go
@@ -195,29 +195,15 @@ func (t *Transformer) transformTypeDefExpr(expr ast.TypeDefExpr) (*goast.Expr, e
 		}
 		return expr, nil
 	case ast.TypeDefBinaryExpr:
-		// binaryExpr := expr.(ast.TypeDefBinaryExpr)
-		// if binaryExpr.IsConjunction() {
-		// 	return &goast.InterfaceType{
-		// 		Methods: &goast.FieldList{
-		// 			List: []*goast.Field{
-		// 				{Type: *t.transformTypeDefExpr(binaryExpr.Left)},
-		// 				{Type: *t.transformTypeDefExpr(binaryExpr.Right)},
-		// 			},
-		// 		},
-		// 	}
-		// } else if binaryExpr.IsDisjunction() {
-		// 	return &goast.InterfaceType{
-		// 		Methods: &goast.FieldList{
-		// 			List: []*goast.Field{
-		// 				{Type: *t.transformTypeDefExpr(binaryExpr.Left)},
-		// 				{Type: *t.transformTypeDefExpr(binaryExpr.Right)},
-		// 			},
-		// 		},
-		// 	}
-		// }
-		ident := goast.NewIdent("string")
-		var result goast.Expr = ident
-		return &result, nil
+		canon, err := t.TypeChecker.TypeDefExprToTypeNode(e)
+		if err != nil {
+			return nil, fmt.Errorf("binary typedef: %w", err)
+		}
+		goTy, err := t.transformType(canon)
+		if err != nil {
+			return nil, err
+		}
+		return &goTy, nil
 	default:
 		err := fmt.Errorf("unknown type def expr: %T", expr)
 		t.log.WithFields(logrus.Fields{

--- a/forst/internal/transformer/ts/type_mapping.go
+++ b/forst/internal/transformer/ts/type_mapping.go
@@ -145,6 +145,32 @@ func (tm *TypeMapping) GetTypeScriptType(forstType *ast.TypeNode) (string, error
 		return "unknown", nil
 	case ast.TypeError:
 		return "unknown", nil
+	case ast.TypeUnion:
+		if len(forstType.TypeParams) == 0 {
+			return "never", nil
+		}
+		parts := make([]string, 0, len(forstType.TypeParams))
+		for i := range forstType.TypeParams {
+			s, err := tm.GetTypeScriptType(&forstType.TypeParams[i])
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, s)
+		}
+		return strings.Join(parts, " | "), nil
+	case ast.TypeIntersection:
+		if len(forstType.TypeParams) == 0 {
+			return "unknown", nil
+		}
+		parts := make([]string, 0, len(forstType.TypeParams))
+		for i := range forstType.TypeParams {
+			s, err := tm.GetTypeScriptType(&forstType.TypeParams[i])
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, s)
+		}
+		return strings.Join(parts, " & "), nil
 	}
 
 	// Inline object types from shape type definitions: { nested: { x: String } }

--- a/forst/internal/transformer/ts/type_mapping_test.go
+++ b/forst/internal/transformer/ts/type_mapping_test.go
@@ -241,3 +241,29 @@ func TestTypeMapping_GetTypeScriptType_implicit(t *testing.T) {
 		t.Fatalf("got %q, want unknown", got)
 	}
 }
+
+func TestTypeMapping_GetTypeScriptType_unionAndIntersection(t *testing.T) {
+	tc := typechecker.New(nil, false)
+	tc.Defs["Tag"] = ast.TypeDefNode{
+		Ident: "Tag",
+		Expr: ast.TypeDefShapeExpr{Shape: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}},
+	}
+	tm := NewTypeMapping()
+	tm.SetTypeChecker(tc)
+	u := ast.NewUnionType(ast.NewBuiltinType(ast.TypeString), ast.NewBuiltinType(ast.TypeInt))
+	got, err := tm.GetTypeScriptType(&u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "string | number" {
+		t.Fatalf("got %q", got)
+	}
+	i := ast.NewIntersectionType(ast.NewBuiltinType(ast.TypeString), ast.TypeNode{Ident: "Tag", TypeKind: ast.TypeKindUserDefined})
+	got2, err := tm.GetTypeScriptType(&i)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2 != "string & Tag" {
+		t.Fatalf("got %q", got2)
+	}
+}

--- a/forst/internal/transformer/ts/typedef.go
+++ b/forst/internal/transformer/ts/typedef.go
@@ -27,6 +27,17 @@ func (t *TypeScriptTransformer) transformTypeDef(def ast.TypeDefNode) (string, e
 		t.typeMapping.AddUserType(typeName, tsType)
 
 		return t.transformAssertionToTypeScript(expr.Assertion, typeName)
+	case ast.TypeDefBinaryExpr:
+		canon, err := t.TypeChecker.TypeDefExprToTypeNode(expr)
+		if err != nil {
+			return "", fmt.Errorf("binary typedef %s: %w", typeName, err)
+		}
+		ts, err := t.typeMapping.GetTypeScriptType(&canon)
+		if err != nil {
+			return "", err
+		}
+		t.typeMapping.AddUserType(typeName, ts)
+		return fmt.Sprintf("export type %s = %s", typeName, ts), nil
 	default:
 		return "", fmt.Errorf("unsupported type definition expression: %T", expr)
 	}

--- a/forst/internal/typechecker/alias_return_test.go
+++ b/forst/internal/typechecker/alias_return_test.go
@@ -1,6 +1,7 @@
 package typechecker
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +32,7 @@ func Hello(): Greeting {
 	}
 
 	log := logrus.New()
-	log.SetOutput(nil)
+	log.SetOutput(io.Discard)
 	merged, _, err := forstpkg.ParseAndMergePackage(log, []string{typesPath, apiPath})
 	if err != nil {
 		t.Fatalf("merge: %v", err)
@@ -43,9 +44,35 @@ func Hello(): Greeting {
 	}
 }
 
+// Regression: inferNodeType must not replace `type Greeting = String` with an empty TypeDefShapeExpr.
+// underlyingBuiltinTypeOfAliasAssertion(String) returns "" because String is not in Defs as a typedef.
+func TestInferTypeDef_directBuiltinAliasPreservesAssertionExpr(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	tc := New(log, false)
+	str := ast.TypeString
+	td := ast.TypeDefNode{
+		Ident: "Greeting",
+		Expr: ast.TypeDefAssertionExpr{
+			Assertion: &ast.AssertionNode{BaseType: &str},
+		},
+	}
+	tc.registerType(td)
+	if _, err := tc.inferNodeType(td); err != nil {
+		t.Fatalf("infer: %v", err)
+	}
+	def, ok := tc.Defs[ast.TypeIdent("Greeting")].(ast.TypeDefNode)
+	if !ok {
+		t.Fatalf("expected TypeDefNode for Greeting")
+	}
+	if _, ok := def.Expr.(ast.TypeDefAssertionExpr); !ok {
+		t.Fatalf("expected TypeDefAssertionExpr after infer, got %T", def.Expr)
+	}
+}
+
 func TestIsTypeCompatible_simpleTypeAliasToString(t *testing.T) {
 	log := logrus.New()
-	log.SetOutput(nil)
+	log.SetOutput(io.Discard)
 	tc := New(log, false)
 	tc.Defs[ast.TypeIdent("Greeting")] = ast.TypeDefNode{
 		Ident: ast.TypeIdent("Greeting"),

--- a/forst/internal/typechecker/flow_fact.go
+++ b/forst/internal/typechecker/flow_fact.go
@@ -16,6 +16,7 @@ type FlowTypeFact struct {
 // MergeFlowFactsAtIfJoin applies JoinAfterIfMerge to each fact key shared with branch narrowing.
 // outerByIdent maps each binding to its pre-if (enclosing scope) type.
 func MergeFlowFactsAtIfJoin(
+	tc *TypeChecker,
 	outerByIdent map[ast.Identifier]ast.TypeNode,
 	branchFacts []FlowTypeFact,
 ) map[ast.Identifier]ast.TypeNode {
@@ -30,7 +31,7 @@ func MergeFlowFactsAtIfJoin(
 		if len(refinements) == 0 {
 			continue
 		}
-		out[id] = JoinAfterIfMerge(outer, refinements)
+		out[id] = JoinAfterIfMerge(tc, outer, refinements)
 	}
 	return out
 }

--- a/forst/internal/typechecker/flow_fact_test.go
+++ b/forst/internal/typechecker/flow_fact_test.go
@@ -8,11 +8,12 @@ import (
 
 func TestMergeFlowFactsAtIfJoin_emptyInputs(t *testing.T) {
 	t.Parallel()
-	out := MergeFlowFactsAtIfJoin(nil, nil)
+	tc := New(discardLogger(), false)
+	out := MergeFlowFactsAtIfJoin(tc, nil, nil)
 	if len(out) != 0 {
 		t.Fatalf("expected empty map, got %d entries", len(out))
 	}
-	out = MergeFlowFactsAtIfJoin(map[ast.Identifier]ast.TypeNode{}, []FlowTypeFact{})
+	out = MergeFlowFactsAtIfJoin(tc, map[ast.Identifier]ast.TypeNode{}, []FlowTypeFact{})
 	if len(out) != 0 {
 		t.Fatalf("expected empty map")
 	}
@@ -20,12 +21,20 @@ func TestMergeFlowFactsAtIfJoin_emptyInputs(t *testing.T) {
 
 func TestMergeFlowFactsAtIfJoin_oneRefinementWidensToOuter(t *testing.T) {
 	t.Parallel()
+	tc := New(discardLogger(), false)
+	str := ast.TypeString
+	tc.registerType(ast.TypeDefNode{
+		Ident: "MyStr",
+		Expr: &ast.TypeDefAssertionExpr{
+			Assertion: &ast.AssertionNode{BaseType: &str},
+		},
+	})
 	id := ast.Identifier("x")
 	outer := ast.TypeNode{Ident: ast.TypeIdent("MyStr")}
 	facts := []FlowTypeFact{
 		{Ident: id, RefinedType: ast.TypeNode{Ident: ast.TypeString}},
 	}
-	out := MergeFlowFactsAtIfJoin(map[ast.Identifier]ast.TypeNode{id: outer}, facts)
+	out := MergeFlowFactsAtIfJoin(tc, map[ast.Identifier]ast.TypeNode{id: outer}, facts)
 	if len(out) != 1 || out[id].Ident != outer.Ident {
 		t.Fatalf("merge: got %+v", out)
 	}
@@ -33,6 +42,14 @@ func TestMergeFlowFactsAtIfJoin_oneRefinementWidensToOuter(t *testing.T) {
 
 func TestMergeFlowFactsAtIfJoin_outerWithoutMatchingFactsSkipped(t *testing.T) {
 	t.Parallel()
+	tc := New(discardLogger(), false)
+	str := ast.TypeString
+	tc.registerType(ast.TypeDefNode{
+		Ident: "MyStr",
+		Expr: &ast.TypeDefAssertionExpr{
+			Assertion: &ast.AssertionNode{BaseType: &str},
+		},
+	})
 	x, y := ast.Identifier("x"), ast.Identifier("y")
 	outerX := ast.TypeNode{Ident: ast.TypeIdent("MyStr")}
 	outerY := ast.TypeNode{Ident: ast.TypeInt}
@@ -40,6 +57,7 @@ func TestMergeFlowFactsAtIfJoin_outerWithoutMatchingFactsSkipped(t *testing.T) {
 		{Ident: x, RefinedType: ast.TypeNode{Ident: ast.TypeString}},
 	}
 	out := MergeFlowFactsAtIfJoin(
+		tc,
 		map[ast.Identifier]ast.TypeNode{x: outerX, y: outerY},
 		facts,
 	)
@@ -54,8 +72,9 @@ func TestMergeFlowFactsAtIfJoin_outerWithoutMatchingFactsSkipped(t *testing.T) {
 	}
 }
 
-func TestMergeFlowFactsAtIfJoin_multipleRefinementsSameIdJoinToOuter(t *testing.T) {
+func TestMergeFlowFactsAtIfJoin_multipleRefinementsSameIdJoinToUnion(t *testing.T) {
 	t.Parallel()
+	tc := New(discardLogger(), false)
 	id := ast.Identifier("x")
 	outer := ast.TypeNode{Ident: ast.TypeIdent("Outer")}
 	facts := []FlowTypeFact{
@@ -63,14 +82,19 @@ func TestMergeFlowFactsAtIfJoin_multipleRefinementsSameIdJoinToOuter(t *testing.
 		{Ident: id, RefinedType: ast.TypeNode{Ident: ast.TypeString}},
 		{Ident: id, RefinedType: ast.TypeNode{Ident: ast.TypeInt}},
 	}
-	out := MergeFlowFactsAtIfJoin(map[ast.Identifier]ast.TypeNode{id: outer}, facts)
-	if len(out) != 1 || out[id].Ident != outer.Ident {
-		t.Fatalf("merge to outer: got %+v", out)
+	out := MergeFlowFactsAtIfJoin(tc, map[ast.Identifier]ast.TypeNode{id: outer}, facts)
+	if len(out) != 1 {
+		t.Fatalf("merge: got %+v", out)
+	}
+	got := out[id]
+	if got.Ident != ast.TypeUnion || len(got.TypeParams) != 3 {
+		t.Fatalf("want union(Outer,String,Int), got %+v", got)
 	}
 }
 
 func TestMergeFlowFactsAtIfJoin_twoIdsIndependent(t *testing.T) {
 	t.Parallel()
+	tc := New(discardLogger(), false)
 	x, y := ast.Identifier("x"), ast.Identifier("y")
 	ox := ast.TypeNode{Ident: ast.TypeIdent("A")}
 	oy := ast.TypeNode{Ident: ast.TypeIdent("B")}
@@ -79,35 +103,37 @@ func TestMergeFlowFactsAtIfJoin_twoIdsIndependent(t *testing.T) {
 		{Ident: y, RefinedType: ast.TypeNode{Ident: ast.TypeInt}},
 	}
 	out := MergeFlowFactsAtIfJoin(
+		tc,
 		map[ast.Identifier]ast.TypeNode{x: ox, y: oy},
 		facts,
 	)
 	if len(out) != 2 {
 		t.Fatalf("want 2 keys, got %+v", out)
 	}
-	if out[x].Ident != ox.Ident || out[y].Ident != oy.Ident {
-		t.Fatalf("each key widens to its own outer: %+v", out)
+	if out[x].Ident != ast.TypeUnion || out[y].Ident != ast.TypeUnion {
+		t.Fatalf("want union join per id: %+v", out)
 	}
 }
 
 func TestMergeFlowFactsAtIfJoin_factsPreserveOrderInRefinementsSlice(t *testing.T) {
 	t.Parallel()
-	// JoinAfterIfMerge ignores refinement values today; still ensure MergeFlowFacts passes
-	// every fact through to JoinAfterIfMerge (future union/LUB may depend on order).
+	tc := New(discardLogger(), false)
+	// Order of refinements is preserved through dedupe + union (String before Int).
 	id := ast.Identifier("x")
 	outer := ast.TypeNode{Ident: ast.TypeIdent("U")}
 	facts := []FlowTypeFact{
 		{Ident: id, RefinedType: ast.TypeNode{Ident: ast.TypeString}, NarrowingTypeGuards: []string{"g1"}},
 		{Ident: id, RefinedType: ast.TypeNode{Ident: ast.TypeInt}, NarrowingTypeGuards: []string{"g2"}},
 	}
-	out := MergeFlowFactsAtIfJoin(map[ast.Identifier]ast.TypeNode{id: outer}, facts)
-	if len(out) != 1 || out[id].Ident != outer.Ident {
+	out := MergeFlowFactsAtIfJoin(tc, map[ast.Identifier]ast.TypeNode{id: outer}, facts)
+	if len(out) != 1 || out[id].Ident != ast.TypeUnion {
 		t.Fatalf("got %+v", out)
 	}
 }
 
 func TestMergeFlowFactsAtIfJoin_branchFactsForUnknownOuterIgnored(t *testing.T) {
 	t.Parallel()
+	tc := New(discardLogger(), false)
 	// Facts mentioning z with no outer entry: outer loop only emits keys present in outerByIdent.
 	x := ast.Identifier("x")
 	z := ast.Identifier("z")
@@ -116,8 +142,8 @@ func TestMergeFlowFactsAtIfJoin_branchFactsForUnknownOuterIgnored(t *testing.T) 
 		{Ident: x, RefinedType: ast.TypeNode{Ident: ast.TypeInt}},
 		{Ident: z, RefinedType: ast.TypeNode{Ident: ast.TypeBool}},
 	}
-	out := MergeFlowFactsAtIfJoin(map[ast.Identifier]ast.TypeNode{x: outer}, facts)
-	if len(out) != 1 || out[x].Ident != outer.Ident {
+	out := MergeFlowFactsAtIfJoin(tc, map[ast.Identifier]ast.TypeNode{x: outer}, facts)
+	if len(out) != 1 || out[x].Ident != ast.TypeUnion {
 		t.Fatalf("got %+v", out)
 	}
 	if _, ok := out[z]; ok {

--- a/forst/internal/typechecker/go_builtins.go
+++ b/forst/internal/typechecker/go_builtins.go
@@ -393,6 +393,13 @@ var BuiltinFunctions = map[string]BuiltinFunction{
 // IsTypeCompatible checks if a type is compatible with an expected type,
 // taking into account subtypes and type guards
 func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNode) bool {
+	if a, ok := tc.expandTypeDefBinaryIfNeeded(actual); ok {
+		actual = a
+	}
+	if e, ok := tc.expandTypeDefBinaryIfNeeded(expected); ok {
+		expected = e
+	}
+
 	tc.log.WithFields(logrus.Fields{
 		"actual":   actual.Ident,
 		"expected": expected.Ident,
@@ -418,6 +425,16 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 				}
 			}
 			return true
+		case ast.TypeUnion, ast.TypeIntersection:
+			if len(actual.TypeParams) != len(expected.TypeParams) {
+				return false
+			}
+			for i := range actual.TypeParams {
+				if !tc.IsTypeCompatible(actual.TypeParams[i], expected.TypeParams[i]) {
+					return false
+				}
+			}
+			return true
 		default:
 			tc.log.WithFields(logrus.Fields{
 				"actual":   actual.Ident,
@@ -426,6 +443,46 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 			}).Debug("Direct type match")
 			return true
 		}
+	}
+
+	// Union on the left: Union(A,B) <: T iff A <: T and B <: T.
+	if actual.Ident == ast.TypeUnion && len(actual.TypeParams) > 0 {
+		for _, m := range actual.TypeParams {
+			if !tc.IsTypeCompatible(m, expected) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Intersection on the right: S <: A & B iff S <: A and S <: B.
+	if expected.Ident == ast.TypeIntersection && len(expected.TypeParams) > 0 {
+		for _, m := range expected.TypeParams {
+			if !tc.IsTypeCompatible(actual, m) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Intersection on the left: A & B <: T iff A <: T and B <: T.
+	if actual.Ident == ast.TypeIntersection && len(actual.TypeParams) > 0 {
+		for _, m := range actual.TypeParams {
+			if !tc.IsTypeCompatible(m, expected) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Union on the right: S <: Union(A,B) iff S <: A or S <: B.
+	if expected.Ident == ast.TypeUnion && len(expected.TypeParams) > 0 {
+		for _, m := range expected.TypeParams {
+			if tc.IsTypeCompatible(actual, m) {
+				return true
+			}
+		}
+		return false
 	}
 
 	// RFC 02: nominal `error X { ... }` (`TypeDefErrorExpr`) is assignable to the built-in `Error` type.

--- a/forst/internal/typechecker/infer.go
+++ b/forst/internal/typechecker/infer.go
@@ -228,9 +228,16 @@ func (tc *TypeChecker) inferNodeType(node ast.Node) ([]ast.TypeNode, error) {
 			// or a chain of such aliases): do not replace Defs with an empty TypeDefShapeExpr — the collect
 			// pass already stored TypeDefAssertionExpr and alias-chain / narrowing logic needs it.
 			if len(mergedFields) == 0 && len(assertionExpr.Assertion.Constraints) == 0 &&
-				assertionExpr.Assertion.BaseType != nil &&
-				tc.underlyingBuiltinTypeOfAliasAssertion(*assertionExpr.Assertion.BaseType) != "" {
-				return nil, nil
+				assertionExpr.Assertion.BaseType != nil {
+				base := *assertionExpr.Assertion.BaseType
+				// Direct alias to a built-in (e.g. type Greeting = String): underlyingBuiltinTypeOfAliasAssertion
+				// only resolves named typedef chains via Defs and returns "" when base is itself a built-in ident.
+				if tc.isBuiltinType(base) {
+					return nil, nil
+				}
+				if tc.underlyingBuiltinTypeOfAliasAssertion(base) != "" {
+					return nil, nil
+				}
 			}
 
 			shape := ast.ShapeNode{

--- a/forst/internal/typechecker/narrow_if.go
+++ b/forst/internal/typechecker/narrow_if.go
@@ -526,7 +526,7 @@ func (tc *TypeChecker) endIfChainApplyJoin() {
 		outerByIdent[id] = sym.Types[0]
 	}
 
-	mergedByIdent := MergeFlowFactsAtIfJoin(outerByIdent, branchFacts)
+	mergedByIdent := MergeFlowFactsAtIfJoin(tc, outerByIdent, branchFacts)
 	for id, merged := range mergedByIdent {
 		outer := outerByIdent[id]
 		tc.log.WithFields(logrus.Fields{

--- a/forst/internal/typechecker/narrow_if.go
+++ b/forst/internal/typechecker/narrow_if.go
@@ -350,7 +350,28 @@ func (tc *TypeChecker) refinedTypesForResultIsNarrowing(varLeftType ast.TypeNode
 	if c.Name == "Ok" {
 		return true, []ast.TypeNode{varLeftType.TypeParams[0]}, nil
 	}
-	return true, []ast.TypeNode{varLeftType.TypeParams[1]}, nil
+	fail := varLeftType.TypeParams[1]
+	if len(c.Args) == 0 {
+		return true, []ast.TypeNode{fail}, nil
+	}
+	if len(c.Args) != 1 {
+		return true, nil, fmt.Errorf("Err(...) expects at most one argument")
+	}
+	arg := c.Args[0]
+	if arg.Type != nil {
+		return true, []ast.TypeNode{*arg.Type}, nil
+	}
+	if arg.Value == nil {
+		return true, nil, fmt.Errorf("Err(...) requires a value or type argument")
+	}
+	vt, err := tc.inferExpressionType(*arg.Value)
+	if err != nil {
+		return true, nil, err
+	}
+	if len(vt) != 1 {
+		return true, nil, fmt.Errorf("err argument: expected a single type")
+	}
+	return true, []ast.TypeNode{vt[0]}, nil
 }
 
 // refinedTypesForAssertionOnVariable returns the refined type(s) for a variable under the given

--- a/forst/internal/typechecker/narrow_merge_test.go
+++ b/forst/internal/typechecker/narrow_merge_test.go
@@ -96,9 +96,17 @@ func TestIfMergePoint_xWidensToOuterTypeAfterIfChain(t *testing.T) {
 
 func TestJoinAfterIfMerge_returnsOuter(t *testing.T) {
 	t.Parallel()
+	tc := New(discardLogger(), false)
+	str := ast.TypeString
+	tc.registerType(ast.TypeDefNode{
+		Ident: "MyStr",
+		Expr: &ast.TypeDefAssertionExpr{
+			Assertion: &ast.AssertionNode{BaseType: &str},
+		},
+	})
 	outer := ast.TypeNode{Ident: ast.TypeIdent("MyStr")}
 	refined := []ast.TypeNode{{Ident: ast.TypeString}}
-	got := JoinAfterIfMerge(outer, refined)
+	got := JoinAfterIfMerge(tc, outer, refined)
 	if got.Ident != outer.Ident {
 		t.Fatalf("JoinAfterIfMerge: got %s want %s", got.Ident, outer.Ident)
 	}

--- a/forst/internal/typechecker/result_narrowing_test.go
+++ b/forst/internal/typechecker/result_narrowing_test.go
@@ -204,6 +204,55 @@ func main() {
 	}
 }
 
+func TestIfResult_isErr_typeArg_narrowsToNominalFailureArm(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+
+error ParseError { code: Int }
+
+type ErrKind = ParseError
+
+func mk(): Result(Int, ErrKind) {
+	return 0
+}
+
+func main() {
+	x := mk()
+	if x is Err(ParseError) {
+		y := x
+		println(y)
+	}
+}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	mainFn := findMainFunction(t, nodes)
+	ifStmt := unwrapIfNode(t, mainFn.Body[1])
+	printlnCall, ok := ifStmt.Body[1].(ast.FunctionCallNode)
+	if !ok {
+		t.Fatalf("expected println call, got %T", ifStmt.Body[1])
+	}
+	vn, ok := printlnCall.Arguments[0].(ast.VariableNode)
+	if !ok {
+		t.Fatalf("expected variable arg, got %T", printlnCall.Arguments[0])
+	}
+	types, ok := tc.InferredTypesForVariableNode(vn)
+	if !ok || len(types) != 1 {
+		t.Fatalf("y: ok=%v types=%v", ok, types)
+	}
+	if types[0].Ident != ast.TypeIdent("ParseError") {
+		t.Fatalf("expected ParseError narrowed failure payload, got %s", types[0].String())
+	}
+}
+
 func unwrapIfNode(t *testing.T, n ast.Node) ast.IfNode {
 	t.Helper()
 	switch x := n.(type) {

--- a/forst/internal/typechecker/typedef_binary.go
+++ b/forst/internal/typechecker/typedef_binary.go
@@ -1,0 +1,171 @@
+package typechecker
+
+import (
+	"fmt"
+	"forst/internal/ast"
+)
+
+// TypeDefExprToTypeNode lowers a type-definition expression (including `|` / `&`) to a TypeNode.
+// Used for typedef bodies and for compatibility checks on Result failure parameters.
+func (tc *TypeChecker) TypeDefExprToTypeNode(expr ast.TypeDefExpr) (ast.TypeNode, error) {
+	if expr == nil {
+		return ast.TypeNode{}, fmt.Errorf("nil type definition expression")
+	}
+	switch e := expr.(type) {
+	case ast.TypeDefAssertionExpr:
+		return tc.typeDefAssertionExprToTypeNode(e)
+	case ast.TypeDefShapeExpr:
+		hash, err := tc.Hasher.HashNode(e.Shape)
+		if err != nil {
+			return ast.TypeNode{}, fmt.Errorf("hash shape: %w", err)
+		}
+		return ast.TypeNode{Ident: hash.ToTypeIdent(), TypeKind: ast.TypeKindHashBased}, nil
+	case ast.TypeDefErrorExpr:
+		return ast.TypeNode{}, fmt.Errorf("anonymous error payload in type expression is not valid; use a named error type")
+	case ast.TypeDefBinaryExpr:
+		left, err := tc.TypeDefExprToTypeNode(e.Left)
+		if err != nil {
+			return ast.TypeNode{}, err
+		}
+		right, err := tc.TypeDefExprToTypeNode(e.Right)
+		if err != nil {
+			return ast.TypeNode{}, err
+		}
+		if e.IsDisjunction() {
+			parts := append(flattenUnionForCombine(left), flattenUnionForCombine(right)...)
+			return ast.NewUnionType(parts...), nil
+		}
+		return tc.meetTypeDefPair(left, right)
+	default:
+		return ast.TypeNode{}, fmt.Errorf("unsupported type definition expression %T", expr)
+	}
+}
+
+func flattenUnionForCombine(t ast.TypeNode) []ast.TypeNode {
+	if t.Ident == ast.TypeUnion && len(t.TypeParams) > 0 {
+		var out []ast.TypeNode
+		for _, m := range t.TypeParams {
+			out = append(out, flattenUnionForCombine(m)...)
+		}
+		return out
+	}
+	return []ast.TypeNode{t}
+}
+
+func (tc *TypeChecker) typeDefAssertionExprToTypeNode(e ast.TypeDefAssertionExpr) (ast.TypeNode, error) {
+	if e.Assertion == nil {
+		return ast.TypeNode{}, fmt.Errorf("missing assertion in type definition")
+	}
+	if e.Assertion.BaseType != nil && len(e.Assertion.Constraints) == 0 {
+		return ast.TypeNode{Ident: *e.Assertion.BaseType, TypeKind: ast.TypeKindUserDefined}, nil
+	}
+	return ast.NewAssertionType(e.Assertion), nil
+}
+
+func (tc *TypeChecker) meetTypeDefPair(a, b ast.TypeNode) (ast.TypeNode, error) {
+	if m, ok := MeetTypes(a, b); ok {
+		return m, nil
+	}
+	if m, ok := tc.MeetTypesSubtyping(a, b); ok {
+		return m, nil
+	}
+	return ast.TypeNode{}, fmt.Errorf("intersection %s & %s is empty (unrelated types)", a.String(), b.String())
+}
+
+// MeetTypesSubtyping returns the greatest lower bound of a and b when one is a subtype of the other
+// (e.g. nominal error <: Error), or when they are mutually assignable as equivalent.
+func (tc *TypeChecker) MeetTypesSubtyping(a, b ast.TypeNode) (ast.TypeNode, bool) {
+	if typeNodesShallowEqual(a, b) {
+		return a, true
+	}
+	aSubB := tc.IsTypeCompatible(a, b)
+	bSubA := tc.IsTypeCompatible(b, a)
+	if aSubB && !bSubA {
+		return a, true
+	}
+	if bSubA && !aSubB {
+		return b, true
+	}
+	if aSubB && bSubA {
+		return a, true
+	}
+	return ast.TypeNode{}, false
+}
+
+// IsErrorKindedType reports whether t is the built-in Error, a nominal error, or a union/intersection
+// whose members are all error-kinded (for Result failure checking).
+func (tc *TypeChecker) IsErrorKindedType(t ast.TypeNode) bool {
+	if c, ok := tc.expandTypeDefBinaryIfNeeded(t); ok {
+		t = c
+	}
+	if t.Ident == ast.TypeError {
+		return true
+	}
+	if t.Ident == ast.TypeUnion {
+		for _, m := range t.TypeParams {
+			if !tc.IsErrorKindedType(m) {
+				return false
+			}
+		}
+		return len(t.TypeParams) > 0
+	}
+	if t.Ident == ast.TypeIntersection {
+		for _, m := range t.TypeParams {
+			if !tc.IsErrorKindedType(m) {
+				return false
+			}
+		}
+		return len(t.TypeParams) > 0
+	}
+	if def, ok := tc.Defs[t.Ident].(ast.TypeDefNode); ok {
+		if _, ok := def.Expr.(ast.TypeDefErrorExpr); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (tc *TypeChecker) validateTypeDefBinary(ident ast.TypeIdent, expr ast.TypeDefBinaryExpr) error {
+	_, err := tc.TypeDefExprToTypeNode(expr)
+	if err != nil {
+		return fmt.Errorf("type %s: %w", ident, err)
+	}
+	return nil
+}
+
+// expandTypeDefBinaryIfNeeded returns the canonical TypeNode for a typedef whose body is A | B or A & B.
+func (tc *TypeChecker) expandTypeDefBinaryIfNeeded(t ast.TypeNode) (ast.TypeNode, bool) {
+	if t.Ident == "" {
+		return ast.TypeNode{}, false
+	}
+	def, ok := tc.Defs[t.Ident].(ast.TypeDefNode)
+	if !ok {
+		return ast.TypeNode{}, false
+	}
+	bin, ok := def.Expr.(ast.TypeDefBinaryExpr)
+	if !ok {
+		return ast.TypeNode{}, false
+	}
+	canon, err := tc.TypeDefExprToTypeNode(bin)
+	if err != nil {
+		return ast.TypeNode{}, false
+	}
+	// Do not expand self-referential typedefs (e.g. invalid U = U | T): canonical IR still mentions
+	// this ident and would make IsTypeCompatible recurse forever (expand → Union → … → expand(U)).
+	if containsTypeIdentParam(canon, t.Ident) {
+		return ast.TypeNode{}, false
+	}
+	return canon, true
+}
+
+func containsTypeIdentParam(t ast.TypeNode, id ast.TypeIdent) bool {
+	if t.Ident == id {
+		return true
+	}
+	for i := range t.TypeParams {
+		if containsTypeIdentParam(t.TypeParams[i], id) {
+			return true
+		}
+	}
+	return false
+}

--- a/forst/internal/typechecker/typedef_binary_more_test.go
+++ b/forst/internal/typechecker/typedef_binary_more_test.go
@@ -1,0 +1,256 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestFlattenUnionForCombine_nestedUnionMember(t *testing.T) {
+	t.Parallel()
+	a := ast.TypeNode{Ident: ast.TypeIdent("A")}
+	b := ast.TypeNode{Ident: ast.TypeIdent("B")}
+	c := ast.TypeNode{Ident: ast.TypeIdent("C")}
+	inner := ast.TypeNode{Ident: ast.TypeUnion, TypeParams: []ast.TypeNode{a, b}, TypeKind: ast.TypeKindBuiltin}
+	outer := ast.TypeNode{Ident: ast.TypeUnion, TypeParams: []ast.TypeNode{inner, c}, TypeKind: ast.TypeKindBuiltin}
+	got := flattenUnionForCombine(outer)
+	if len(got) != 3 {
+		t.Fatalf("len=%d want 3: %#v", len(got), got)
+	}
+}
+
+func TestTypeDefExprToTypeNode_shapeExpr(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	u, err := tc.TypeDefExprToTypeNode(ast.TypeDefShapeExpr{
+		Shape: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Ident == "" || u.TypeKind != ast.TypeKindHashBased {
+		t.Fatalf("expected hash-based type node, got %+v", u)
+	}
+}
+
+func TestTypeDefExprToTypeNode_errorExprErrors(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	_, err := tc.TypeDefExprToTypeNode(ast.TypeDefErrorExpr{
+		Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}},
+	})
+	if err == nil {
+		t.Fatal("expected error for anonymous TypeDefErrorExpr in type expression")
+	}
+}
+
+func TestTypeDefExprToTypeNode_binaryPropagatesLeftError(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	aName := ast.TypeIdent("A")
+	_, err := tc.TypeDefExprToTypeNode(ast.TypeDefBinaryExpr{
+		Left:  ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}},
+		Op:    ast.TokenBitwiseOr,
+		Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &aName}},
+	})
+	if err == nil {
+		t.Fatal("expected error from failed left subexpression")
+	}
+}
+
+func TestTypeDefExprToTypeNode_binaryPropagatesRightError(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	aName := ast.TypeIdent("A")
+	_, err := tc.TypeDefExprToTypeNode(ast.TypeDefBinaryExpr{
+		Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &aName}},
+		Op:    ast.TokenBitwiseOr,
+		Right: ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}},
+	})
+	if err == nil {
+		t.Fatal("expected error from failed right subexpression")
+	}
+}
+
+func TestTypeDefExprToTypeNode_assertionMissingAssertion(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	_, err := tc.TypeDefExprToTypeNode(ast.TypeDefAssertionExpr{Assertion: nil})
+	if err == nil {
+		t.Fatal("expected error when assertion is nil")
+	}
+}
+
+func TestTypeDefExprToTypeNode_assertionWithConstraintsUsesAssertionType(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	str := ast.TypeString
+	u, err := tc.TypeDefExprToTypeNode(ast.TypeDefAssertionExpr{
+		Assertion: &ast.AssertionNode{
+			BaseType: &str,
+			Constraints: []ast.ConstraintNode{
+				{Name: "Guard"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Ident != ast.TypeAssertion {
+		t.Fatalf("expected assertion type node, got %+v", u)
+	}
+}
+
+func TestTypeDefExprToTypeNode_conjunctiveIdenticalMeetTypes(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	str := ast.TypeString
+	got, err := tc.TypeDefExprToTypeNode(ast.TypeDefBinaryExpr{
+		Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &str}},
+		Op:    ast.TokenBitwiseAnd,
+		Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &str}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Ident != ast.TypeString {
+		t.Fatalf("String & String should meet to String, got %+v", got)
+	}
+}
+
+func TestTypeDefExprToTypeNode_conjunctiveNominalErrorAndErrorMeet(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "NE",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"k": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			}},
+		},
+	})
+	ne := ast.TypeIdent("NE")
+	errT := ast.TypeError
+	got, err := tc.TypeDefExprToTypeNode(ast.TypeDefBinaryExpr{
+		Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &ne}},
+		Op:    ast.TokenBitwiseAnd,
+		Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &errT}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Ident != "NE" {
+		t.Fatalf("NE & Error should meet to NE via subtyping, got %+v", got)
+	}
+}
+
+func TestMeetTypesSubtyping_ErrorAndNominal_reverseOrder(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "NE",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"k": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			}},
+		},
+	})
+	got, ok := tc.MeetTypesSubtyping(ast.TypeNode{Ident: ast.TypeError}, ast.TypeNode{Ident: "NE"})
+	if !ok || got.Ident != "NE" {
+		t.Fatalf("MeetTypesSubtyping(Error, NE) want NE, got %+v ok=%v", got, ok)
+	}
+}
+
+func TestValidateTypeDefBinary_wrapsLowerError(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	aName := ast.TypeIdent("A")
+	err := tc.validateTypeDefBinary("MyAlias", ast.TypeDefBinaryExpr{
+		Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &aName}},
+		Op:    ast.TokenBitwiseOr,
+		Right: ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "MyAlias") {
+		t.Fatalf("expected wrapped error mentioning typedef name, got %v", err)
+	}
+}
+
+func TestExpandTypeDefBinaryIfNeeded_cases(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+
+	if _, ok := tc.expandTypeDefBinaryIfNeeded(ast.TypeNode{Ident: ""}); ok {
+		t.Fatal("empty ident should not expand")
+	}
+	if _, ok := tc.expandTypeDefBinaryIfNeeded(ast.TypeNode{Ident: "NoSuch"}); ok {
+		t.Fatal("missing typedef should not expand")
+	}
+
+	tc.registerType(ast.TypeDefNode{
+		Ident: "Plain",
+		Expr:  ast.TypeDefShapeExpr{Shape: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}},
+	})
+	if _, ok := tc.expandTypeDefBinaryIfNeeded(ast.TypeNode{Ident: "Plain"}); ok {
+		t.Fatal("non-binary typedef body should not expand")
+	}
+
+	tc.registerType(ast.TypeDefNode{
+		Ident: "BadBin",
+		Expr: ast.TypeDefBinaryExpr{
+			Left:  ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}},
+			Op:    ast.TokenBitwiseOr,
+			Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrIdent("A")}},
+		},
+	})
+	if _, ok := tc.expandTypeDefBinaryIfNeeded(ast.TypeNode{Ident: "BadBin"}); ok {
+		t.Fatal("typedef whose body does not lower should not expand")
+	}
+
+	tc.registerType(ast.TypeDefNode{Ident: "A", Expr: ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}}})
+	tc.registerType(ast.TypeDefNode{
+		Ident: "SelfU",
+		Expr: ast.TypeDefBinaryExpr{
+			Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrIdent("SelfU")}},
+			Op:    ast.TokenBitwiseOr,
+			Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrIdent("A")}},
+		},
+	})
+	if _, ok := tc.expandTypeDefBinaryIfNeeded(ast.TypeNode{Ident: "SelfU"}); ok {
+		t.Fatal("self-referential binary typedef should not expand (avoids infinite expand)")
+	}
+
+	tc.registerType(ast.TypeDefNode{
+		Ident: "AB",
+		Expr: ast.TypeDefBinaryExpr{
+			Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrIdent("A")}},
+			Op:    ast.TokenBitwiseOr,
+			Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrIdent("B")}},
+		},
+	})
+	tc.registerType(ast.TypeDefNode{Ident: "B", Expr: ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}}})
+	canon, ok := tc.expandTypeDefBinaryIfNeeded(ast.TypeNode{Ident: "AB"})
+	if !ok || canon.Ident != ast.TypeUnion || len(canon.TypeParams) != 2 {
+		t.Fatalf("expected expanded union, got ok=%v %+v", ok, canon)
+	}
+}
+
+func TestIsErrorKindedType_namedTypedefExpandsToErrorUnion(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	tc.registerType(ast.TypeDefNode{Ident: "A", Expr: ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}}})
+	tc.registerType(ast.TypeDefNode{Ident: "B", Expr: ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{}}}})
+	tc.registerType(ast.TypeDefNode{
+		Ident: "AB",
+		Expr: ast.TypeDefBinaryExpr{
+			Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrIdent("A")}},
+			Op:    ast.TokenBitwiseOr,
+			Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrIdent("B")}},
+		},
+	})
+	if !tc.IsErrorKindedType(ast.TypeNode{Ident: "AB"}) {
+		t.Fatal("IsErrorKindedType should expand named typedef AB to a union of nominal errors")
+	}
+}

--- a/forst/internal/typechecker/typedef_binary_test.go
+++ b/forst/internal/typechecker/typedef_binary_test.go
@@ -1,0 +1,183 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/parser"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestTypeDefExprToTypeNode_unionAndMeet(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	e1name := ast.TypeIdent("E1")
+	e2name := ast.TypeIdent("E2")
+	tc.registerType(ast.TypeDefNode{
+		Ident: "E1",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"a": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			}},
+		},
+	})
+	tc.registerType(ast.TypeDefNode{
+		Ident: "E2",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"b": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+			}},
+		},
+	})
+
+	unionExpr := ast.TypeDefBinaryExpr{
+		Left: ast.TypeDefAssertionExpr{
+			Assertion: &ast.AssertionNode{BaseType: &e1name},
+		},
+		Op: ast.TokenBitwiseOr,
+		Right: ast.TypeDefAssertionExpr{
+			Assertion: &ast.AssertionNode{BaseType: &e2name},
+		},
+	}
+	u, err := tc.TypeDefExprToTypeNode(unionExpr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Ident != ast.TypeUnion || len(u.TypeParams) != 2 {
+		t.Fatalf("want union of E1 E2, got %+v", u)
+	}
+	if !tc.IsErrorKindedType(u) {
+		t.Fatal("union of nominal errors should be error-kinded")
+	}
+	if !tc.IsTypeCompatible(u, ast.TypeNode{Ident: ast.TypeError}) {
+		t.Fatal("union of error nominals should be assignable to Error")
+	}
+
+	str := ast.TypeString
+	intT := ast.TypeInt
+	_, err = tc.TypeDefExprToTypeNode(ast.TypeDefBinaryExpr{
+		Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &str}},
+		Op:    ast.TokenBitwiseAnd,
+		Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: &intT}},
+	})
+	if err == nil {
+		t.Fatal("expected error for String & Int")
+	}
+}
+
+func TestMeetTypesSubtyping_errorWidth(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "NE",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"k": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			}},
+		},
+	})
+	got, ok := tc.MeetTypesSubtyping(ast.TypeNode{Ident: "NE"}, ast.TypeNode{Ident: ast.TypeError})
+	if !ok || got.Ident != "NE" {
+		t.Fatalf("MeetTypesSubtyping: got %+v ok=%v", got, ok)
+	}
+}
+
+func TestJoinTypes_flattensNestedUnion(t *testing.T) {
+	t.Parallel()
+	u := ast.NewUnionType(
+		ast.TypeNode{Ident: ast.TypeString},
+		ast.TypeNode{Ident: ast.TypeInt},
+	)
+	got, ok := JoinTypes([]ast.TypeNode{u, ast.TypeNode{Ident: ast.TypeBool}})
+	if !ok || got.Ident != ast.TypeUnion || len(got.TypeParams) != 3 {
+		t.Fatalf("got %+v ok=%v", got, ok)
+	}
+}
+
+func TestNewUnionType_singleMemberCollapses(t *testing.T) {
+	t.Parallel()
+	u := ast.NewUnionType(ast.TypeNode{Ident: ast.TypeString})
+	if u.Ident != ast.TypeString {
+		t.Fatalf("expected collapse to String, got %+v", u)
+	}
+}
+
+func TestIsTypeCompatible_unionRightSumIntro(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "E1",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			}},
+		},
+	})
+	u := ast.NewUnionType(ast.TypeNode{Ident: "E1"}, ast.TypeNode{Ident: ast.TypeString})
+	if !tc.IsTypeCompatible(ast.TypeNode{Ident: "E1"}, u) {
+		t.Fatal("E1 <: E1 | String")
+	}
+	if !tc.IsTypeCompatible(ast.TypeNode{Ident: ast.TypeString}, u) {
+		t.Fatal("String <: E1 | String (second arm)")
+	}
+	if tc.IsTypeCompatible(ast.TypeNode{Ident: ast.TypeInt}, u) {
+		t.Fatal("Int should not be assignable to E1 | String")
+	}
+}
+
+func TestCheckTypes_unionErrorTypedef_source(t *testing.T) {
+	t.Parallel()
+	log := ast.SetupTestLogger(nil)
+	src := `package main
+
+error A { x: Int }
+error B { y: String }
+
+type AB = A | B
+
+func main() {}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExpandTypeDefBinaryIfNeeded_roundTrip(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "AB",
+		Expr: ast.TypeDefBinaryExpr{
+			Left:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrIdent("A")}},
+			Op:    ast.TokenBitwiseOr,
+			Right: ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrIdent("B")}},
+		},
+	})
+	tc.registerType(ast.TypeDefNode{
+		Ident: "A",
+		Expr: ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+			"k": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+		}}},
+	})
+	tc.registerType(ast.TypeDefNode{
+		Ident: "B",
+		Expr: ast.TypeDefErrorExpr{Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+			"k": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+		}}},
+	})
+	if !tc.IsTypeCompatible(ast.TypeNode{Ident: "AB"}, ast.TypeNode{Ident: ast.TypeError}) {
+		t.Fatal("named typedef binary should expand to union and assign to Error")
+	}
+}
+
+func ptrIdent(id string) *ast.TypeIdent {
+	t := ast.TypeIdent(id)
+	return &t
+}

--- a/forst/internal/typechecker/typedef_binary_test.go
+++ b/forst/internal/typechecker/typedef_binary_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func TestTypeDefExprToTypeNode_nilExprErrors(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	_, err := tc.TypeDefExprToTypeNode(nil)
+	if err == nil {
+		t.Fatal("expected error for nil typedef expression")
+	}
+}
+
 func TestTypeDefExprToTypeNode_unionAndMeet(t *testing.T) {
 	t.Parallel()
 	tc := New(logrus.New(), false)
@@ -174,6 +183,43 @@ func TestExpandTypeDefBinaryIfNeeded_roundTrip(t *testing.T) {
 	})
 	if !tc.IsTypeCompatible(ast.TypeNode{Ident: "AB"}, ast.TypeNode{Ident: ast.TypeError}) {
 		t.Fatal("named typedef binary should expand to union and assign to Error")
+	}
+}
+
+func TestIsErrorKindedType_unionAndIntersectionBranches(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	if tc.IsErrorKindedType(ast.TypeNode{Ident: ast.TypeUnion, TypeParams: nil}) {
+		t.Fatal("empty union should not be error-kinded")
+	}
+	if tc.IsErrorKindedType(ast.TypeNode{Ident: ast.TypeUnion, TypeParams: []ast.TypeNode{}}) {
+		t.Fatal("union with zero members should not be error-kinded")
+	}
+	// Mixed non-error member => false
+	if tc.IsErrorKindedType(ast.NewUnionType(ast.TypeNode{Ident: ast.TypeError}, ast.TypeNode{Ident: ast.TypeString})) {
+		t.Fatal("Error | String is not fully error-kinded (String is not)")
+	}
+	tc.registerType(ast.TypeDefNode{
+		Ident: "E1",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"a": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			}},
+		},
+	})
+	tc.registerType(ast.TypeDefNode{
+		Ident: "E2",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"b": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+			}},
+		},
+	})
+	if !tc.IsErrorKindedType(ast.NewUnionType(ast.TypeNode{Ident: "E1"}, ast.TypeNode{Ident: "E2"})) {
+		t.Fatal("E1 | E2 nominal errors should be error-kinded")
+	}
+	if !tc.IsErrorKindedType(ast.NewIntersectionType(ast.TypeNode{Ident: "E1"}, ast.TypeNode{Ident: "E2"})) {
+		t.Fatal("E1 & E2 (both nominal errors) should be error-kinded for IsErrorKindedType")
 	}
 }
 

--- a/forst/internal/typechecker/typeops.go
+++ b/forst/internal/typechecker/typeops.go
@@ -5,20 +5,57 @@ import (
 )
 
 // InternalType is the semantic type representation used by lattice operations.
-// It aliases ast.TypeNode today; a dedicated IR may replace this (see narrowing plan §9.5).
+// It aliases ast.TypeNode today; a dedicated IR may replace it (see narrowing plan §9.5).
 type InternalType = ast.TypeNode
 
-// JoinAfterIfMerge implements merge-after-if for control-flow narrowing (plan §3.2, §0.3):
-// at the join point following a completed if / else-if / else chain, the static type of a
-// binding is the outer (pre-if) type until union types exist in the language.
-//
-// branchRefinements lists types inferred for the same binding along paths that narrowed it;
-// outer is the binding type in the enclosing scope before the if chain. The result is always
-// outer for this policy. When union/LUB types exist, consult branchRefinements to compute a
-// finer join without breaking callers that already pass refinements from MergeFlowFactsAtIfJoin.
-func JoinAfterIfMerge(outer InternalType, branchRefinements []InternalType) InternalType {
-	_ = branchRefinements // reserved for union / LUB when InternalType can represent unions
-	return outer
+// JoinAfterIfMerge combines the pre-if binding type with branch refinements at an if-chain merge point.
+// When tc is nil, returns outer (conservative). Otherwise forms a union of outer and refinements,
+// then collapses to outer when every union member is assignable to outer (width / subtyping).
+func JoinAfterIfMerge(tc *TypeChecker, outer InternalType, branchRefinements []InternalType) InternalType {
+	if len(branchRefinements) == 0 {
+		return outer
+	}
+	if tc == nil {
+		return outer
+	}
+	all := append([]InternalType{outer}, branchRefinements...)
+	flat := flattenUnionOperandsForJoin(all)
+	deduped := DedupeTypesPreservingOrder(flat)
+	j, ok := JoinTypes(deduped)
+	if !ok {
+		return outer
+	}
+	if j.Ident == ast.TypeUnion {
+		for _, m := range j.TypeParams {
+			if !tc.IsTypeCompatible(m, outer) {
+				return j
+			}
+		}
+		return outer
+	}
+	if tc.IsTypeCompatible(j, outer) {
+		return outer
+	}
+	return j
+}
+
+func flattenUnionOperandsForJoin(types []InternalType) []InternalType {
+	var out []InternalType
+	for _, t := range types {
+		out = append(out, flattenOneForJoin(t)...)
+	}
+	return out
+}
+
+func flattenOneForJoin(t InternalType) []InternalType {
+	if t.Ident == ast.TypeUnion && len(t.TypeParams) > 0 {
+		var out []InternalType
+		for _, m := range t.TypeParams {
+			out = append(out, flattenOneForJoin(m)...)
+		}
+		return out
+	}
+	return []InternalType{t}
 }
 
 // JoinTypesOutcome describes how JoinTypes combined its inputs.
@@ -31,23 +68,25 @@ const (
 	JoinTypesSingleton
 	// JoinTypesAllEquivalent means every operand is structurally the same (shallow + TypeParams).
 	JoinTypesAllEquivalent
-	// JoinTypesHeterogeneous means operands differ; union IR is not available yet — result is first after dedupe.
+	// JoinTypesHeterogeneous means operands differ; result is a normalized TypeUnion (or singleton after collapse).
 	JoinTypesHeterogeneous
 )
 
-// JoinTypesDetailed classifies n-ary join: duplicates collapse for reporting, but multiple
-// shallow-equal operands are JoinTypesAllEquivalent (not Singleton). Heterogeneous lists
-// return the first type after DedupeTypesPreservingOrder (union IR not available yet).
+// JoinTypesDetailed classifies n-ary join: duplicates collapse; heterogeneous lists become TypeUnion IR.
 func JoinTypesDetailed(types []InternalType) (InternalType, JoinTypesOutcome) {
 	if len(types) == 0 {
 		return InternalType{}, JoinTypesEmpty
 	}
-	if len(types) == 1 {
-		return types[0], JoinTypesSingleton
+	flat := flattenUnionOperandsForJoin(types)
+	if len(flat) == 0 {
+		return InternalType{}, JoinTypesEmpty
 	}
-	first := types[0]
+	if len(flat) == 1 {
+		return flat[0], JoinTypesSingleton
+	}
+	first := flat[0]
 	allEq := true
-	for _, t := range types[1:] {
+	for _, t := range flat[1:] {
 		if !typeNodesShallowEqual(first, t) {
 			allEq = false
 			break
@@ -56,19 +95,22 @@ func JoinTypesDetailed(types []InternalType) (InternalType, JoinTypesOutcome) {
 	if allEq {
 		return first, JoinTypesAllEquivalent
 	}
-	deduped := DedupeTypesPreservingOrder(types)
-	return deduped[0], JoinTypesHeterogeneous
+	deduped := DedupeTypesPreservingOrder(flat)
+	if len(deduped) == 1 {
+		return deduped[0], JoinTypesSingleton
+	}
+	u := ast.NewUnionType(deduped...)
+	return u, JoinTypesHeterogeneous
 }
 
-// JoinTypes is n-ary join for type-level union (future typedef A | B). Without union IR,
-// equivalent operands collapse; heterogeneous lists return (first, false).
+// JoinTypes is n-ary join for type-level union (typedef A | B and control-flow join).
 func JoinTypes(types []InternalType) (InternalType, bool) {
 	t, outcome := JoinTypesDetailed(types)
 	switch outcome {
 	case JoinTypesEmpty:
 		return InternalType{}, false
 	case JoinTypesHeterogeneous:
-		return t, false
+		return t, true
 	default:
 		return t, true
 	}
@@ -113,7 +155,7 @@ func typeNodesShallowEqual(a, b InternalType) bool {
 	return true
 }
 
-// MeetTypes intersects types for typedef A & B (stub: equal idents only; extend with normalization).
+// MeetTypes intersects types for typedef A & B (structural equality or subtype GLB via MeetTypesSubtyping on use sites).
 func MeetTypes(a, b InternalType) (InternalType, bool) {
 	if typeNodesShallowEqual(a, b) {
 		return a, true

--- a/forst/internal/typechecker/typeops_test.go
+++ b/forst/internal/typechecker/typeops_test.go
@@ -16,23 +16,28 @@ func TestWidenToEnclosing_isIdentity(t *testing.T) {
 
 func TestJoinAfterIfMerge_table(t *testing.T) {
 	t.Parallel()
+	tc := New(discardLogger(), false)
 	outer := ast.TypeNode{Ident: ast.TypeIdent("Outer")}
 	cases := []struct {
 		name string
 		ref  []ast.TypeNode
-		want ast.TypeIdent
+		want func(ast.TypeNode) bool
 	}{
-		{"nil_refinements", nil, outer.Ident},
-		{"empty_refinements", []ast.TypeNode{}, outer.Ident},
-		{"single_refinement", []ast.TypeNode{{Ident: ast.TypeString}}, outer.Ident},
-		{"multiple_refinements", []ast.TypeNode{{Ident: ast.TypeString}, {Ident: ast.TypeInt}}, outer.Ident},
+		{"nil_refinements", nil, func(g ast.TypeNode) bool { return g.Ident == outer.Ident }},
+		{"empty_refinements", []ast.TypeNode{}, func(g ast.TypeNode) bool { return g.Ident == outer.Ident }},
+		{"single_refinement", []ast.TypeNode{{Ident: ast.TypeString}}, func(g ast.TypeNode) bool {
+			return g.Ident == ast.TypeUnion && len(g.TypeParams) == 2
+		}},
+		{"multiple_refinements", []ast.TypeNode{{Ident: ast.TypeString}, {Ident: ast.TypeInt}}, func(g ast.TypeNode) bool {
+			return g.Ident == ast.TypeUnion && len(g.TypeParams) == 3
+		}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			got := JoinAfterIfMerge(outer, c.ref)
-			if got.Ident != c.want {
-				t.Fatalf("got %s want %s", got.Ident, c.want)
+			got := JoinAfterIfMerge(tc, outer, c.ref)
+			if !c.want(got) {
+				t.Fatalf("got %+v", got)
 			}
 		})
 	}
@@ -148,7 +153,7 @@ func TestJoinTypes_heterogeneous(t *testing.T) {
 		{Ident: ast.TypeInt},
 	}
 	got, ok := JoinTypes(types)
-	if ok || got.Ident != ast.TypeString {
+	if !ok || got.Ident != ast.TypeUnion || len(got.TypeParams) != 2 {
 		t.Fatalf("JoinTypes heterogeneous: got %+v ok=%v", got, ok)
 	}
 }
@@ -167,13 +172,13 @@ func TestJoinTypes_empty(t *testing.T) {
 
 func TestJoinTypes_heterogeneousFirstStubAfterDedupe(t *testing.T) {
 	t.Parallel()
-	// [String, Int, String] → dedupe [String, Int] → stub first is String, outcome heterogeneous.
+	// [String, Int, String] → dedupe [String, Int] → union IR.
 	got, ok := JoinTypes([]ast.TypeNode{
 		{Ident: ast.TypeString},
 		{Ident: ast.TypeInt},
 		{Ident: ast.TypeString},
 	})
-	if ok || got.Ident != ast.TypeString {
+	if !ok || got.Ident != ast.TypeUnion || len(got.TypeParams) != 2 {
 		t.Fatalf("got %+v ok=%v", got, ok)
 	}
 }
@@ -202,8 +207,8 @@ func TestJoinTypes_typeParams_heterogeneous(t *testing.T) {
 	a := ast.TypeNode{Ident: box, TypeParams: []ast.TypeNode{{Ident: ast.TypeString}}}
 	b := ast.TypeNode{Ident: box, TypeParams: []ast.TypeNode{{Ident: ast.TypeInt}}}
 	got, ok := JoinTypes([]ast.TypeNode{a, b})
-	if ok {
-		t.Fatalf("expected heterogeneous, got ok=true %+v", got)
+	if !ok || got.Ident != ast.TypeUnion || len(got.TypeParams) != 2 {
+		t.Fatalf("expected union of Box types, got ok=%v %+v", ok, got)
 	}
 }
 
@@ -257,7 +262,7 @@ func TestJoinTypesDetailed_outcomes(t *testing.T) {
 			{Ident: ast.TypeString},
 			{Ident: ast.TypeInt},
 		})
-		if out != JoinTypesHeterogeneous || got.Ident != ast.TypeString {
+		if out != JoinTypesHeterogeneous || got.Ident != ast.TypeUnion {
 			t.Fatalf("got %+v outcome %v", got, out)
 		}
 	})

--- a/forst/internal/typechecker/unify_is_test.go
+++ b/forst/internal/typechecker/unify_is_test.go
@@ -69,3 +69,33 @@ func main() {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestUnifyIs_nominalErrorBaseType_rejected(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+
+error ParseError { code: Int }
+type ErrKind = ParseError
+
+func main() {
+	var e: ErrKind = { code: 1 }
+	if e is ParseError {
+		println(e)
+	}
+}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	err = tc.CheckTypes(nodes)
+	if err == nil {
+		t.Fatal("expected CheckTypes error: nominal error cannot be bare `is` guard")
+	}
+	if !strings.Contains(err.Error(), "cannot be used as an `is` guard") || !strings.Contains(err.Error(), "Err()") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/forst/internal/typechecker/unify_typeguard.go
+++ b/forst/internal/typechecker/unify_typeguard.go
@@ -7,10 +7,39 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
+// typeIdentIsNominalError reports whether id names a user `error Name { ... }` type.
+func (tc *TypeChecker) typeIdentIsNominalError(id ast.TypeIdent) bool {
+	def, ok := tc.Defs[id].(ast.TypeDefNode)
+	if !ok {
+		return false
+	}
+	switch def.Expr.(type) {
+	case ast.TypeDefErrorExpr, *ast.TypeDefErrorExpr:
+		return true
+	default:
+		return false
+	}
+}
+
+// rejectNominalErrorAsBareIsGuard rejects `x is ParseError`-style guards: nominal errors must be
+// discriminated via Result and `Err()` / `Err(...)` (built-in Result guards), not as the RHS base type.
+func (tc *TypeChecker) rejectNominalErrorAsBareIsGuard(assertionNode *ast.AssertionNode) error {
+	if assertionNode == nil || assertionNode.BaseType == nil {
+		return nil
+	}
+	if tc.typeIdentIsNominalError(*assertionNode.BaseType) {
+		return fmt.Errorf("nominal error type %q cannot be used as an `is` guard; narrow failure values via Result using `Err()` or `Err(...)`", *assertionNode.BaseType)
+	}
+	return nil
+}
+
 // validateTypeDefAssertion validates a TypeDefAssertionExpr against the left-hand side type
 func (tc *TypeChecker) validateTypeDefAssertion(assertionNode *ast.AssertionNode, varLeftType ast.TypeNode) error {
 	if assertionNode == nil {
 		return fmt.Errorf("right-hand side of 'is' must be an assertion")
+	}
+	if err := tc.rejectNominalErrorAsBareIsGuard(assertionNode); err != nil {
+		return err
 	}
 
 	// Check that the assertion's base type matches the left-hand side type or is a subtype
@@ -117,6 +146,9 @@ func (tc *TypeChecker) processTypeGuardFields(shapeNode *ast.ShapeNode, assertio
 
 // validateAssertionNode validates a direct assertion node
 func (tc *TypeChecker) validateAssertionNode(assertionNode ast.AssertionNode, varLeftType ast.TypeNode) error {
+	if err := tc.rejectNominalErrorAsBareIsGuard(&assertionNode); err != nil {
+		return err
+	}
 	if len(assertionNode.Constraints) == 1 && assertionNode.BaseType == nil {
 		c := assertionNode.Constraints[0]
 		if c.Name == "Ok" || c.Name == "Err" {
@@ -197,10 +229,17 @@ func (tc *TypeChecker) validateResultDiscriminatorAssertion(a ast.AssertionNode,
 		case 0:
 			return nil
 		case 1:
-			if c.Args[0].Value == nil {
-				return fmt.Errorf("Err(...) requires a value argument")
+			arg := c.Args[0]
+			if arg.Type != nil {
+				if !tc.IsTypeCompatible(*arg.Type, fail) {
+					return fmt.Errorf("Err(...) type argument incompatible with failure type %s", fail.String())
+				}
+				return nil
 			}
-			vt, err := tc.inferExpressionType(*c.Args[0].Value)
+			if arg.Value == nil {
+				return fmt.Errorf("Err(...) requires a value or type argument")
+			}
+			vt, err := tc.inferExpressionType(*arg.Value)
 			if err != nil {
 				return err
 			}

--- a/forst/internal/typechecker/union_error_narrowing_e2e_test.go
+++ b/forst/internal/typechecker/union_error_narrowing_e2e_test.go
@@ -1,0 +1,72 @@
+package typechecker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"forst/internal/parser"
+
+	"github.com/sirupsen/logrus"
+)
+
+// End-to-end: examples/in/union_error_narrowing.ft — Result(Int, ErrKind) and `if x is Err(ParseError)`
+// narrows x to ParseError in the branch so onlyParseError(x) typechecks.
+func TestCheckTypes_unionErrorNarrowing_exampleFile(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", "examples", "in", "union_error_narrowing.ft"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := os.ReadFile(root)
+	if err != nil {
+		t.Fatalf("read %s: %v", root, err)
+	}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+	p := parser.NewTestParser(string(src), log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+}
+
+// Same program as a string — documents the narrowing contract without relying on filesystem layout.
+func TestCheckTypes_unionErrorNarrowing_inline(t *testing.T) {
+	t.Parallel()
+	src := `package main
+
+error ParseError { code: Int }
+error IoError { path: String }
+type ErrKind = ParseError | IoError
+
+func onlyParseError(p ParseError) {}
+
+func mk(): Result(Int, ErrKind) {
+	return 0
+}
+
+func main() {
+	x := mk()
+	if x is Err(ParseError) {
+		onlyParseError(x)
+	}
+}
+`
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+}

--- a/forst/internal/typechecker/validate_references.go
+++ b/forst/internal/typechecker/validate_references.go
@@ -16,6 +16,11 @@ func (tc *TypeChecker) validateReferencedTypesAfterCollect() error {
 		if !ok {
 			continue
 		}
+		if bin, ok := typeDef.Expr.(ast.TypeDefBinaryExpr); ok {
+			if err := tc.validateTypeDefBinary(typeDef.Ident, bin); err != nil {
+				return err
+			}
+		}
 		payload, ok := ast.PayloadShape(typeDef.Expr)
 		if !ok {
 			continue
@@ -107,6 +112,13 @@ func (tc *TypeChecker) validateTypeReference(t ast.TypeNode, ctx string) error {
 	case ast.TypeTuple:
 		for i, p := range t.TypeParams {
 			if err := tc.validateTypeReference(p, fmt.Sprintf("%s tuple[%d]", ctx, i)); err != nil {
+				return err
+			}
+		}
+		return nil
+	case ast.TypeUnion, ast.TypeIntersection:
+		for i, p := range t.TypeParams {
+			if err := tc.validateTypeReference(p, fmt.Sprintf("%s %s[%d]", ctx, t.Ident, i)); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Introduce `TYPE_UNION` / `TYPE_INTERSECTION` `TypeNode`s with `NewUnionType` /
`NewIntersectionType` (flatten/dedupe). Lower typedef binary expressions via
`TypeDefExprToTypeNode`, `MeetTypesSubtyping`, `expandTypeDefBinaryIfNeeded`, and
n-ary `JoinTypes` / `JoinTypesDetailed` for heterogeneous joins and if-branch
merging (`MergeFlowFactsAtIfJoin`, `JoinAfterIfMerge` wiring). Extend
`IsTypeCompatible` for unions/intersections and validate references for union/
intersection type params.

fix(parser): parse `type U = A | B` when the LHS is a simple identifier

The `=` RHS used to return `TypeDefAssertionExpr` immediately, so `|` was never
parsed. Assign to `left` and fall through to binary `|` / `&` handling.
Covered by `TestParseTypeDefExpr_simpleIdentUnion`.

fix(typechecker): keep assertion-only aliases to built-ins after infer

For `type Greeting = String`, underlyingBuiltinTypeOfAliasAssertion(String) is
empty (String is not in Defs); treat isBuiltinType(base) so infer does not
replace the typedef with an empty `TypeDefShapeExpr`.

feat(transformer): emit binary typedefs from canonical TypeNode; Go/TS unions

Go: transformType maps error-kinded unions to `error`, otherwise `any` for
union/intersection; typedef_expr uses TypeDefExprToTypeNode + transformType.
TS: GetTypeScriptType emits ` | ` and ` & ` chains; typedef transform aligned.

refactor(generators): drop accidental fmt.Printf debug from GenerateGoCode

test: typedef_binary tests, flow_fact / narrow_merge / typeops / alias tests;
compiler compiles union_error_types.ft

docs: Taskfile example:union-error-types, testing rule + examples README

Example:

```forst
error ParseError { code: Int }
error IoError { path: String }
type ErrKind = ParseError | IoError
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added support for union types using the `|` operator and intersection types using the `&` operator in type definitions.
  * Implemented error union narrowing—conditionally narrow Result failure types within if-statements using type guards.
  * Added sealed interface generation for nominal error unions in Go output.

* **Improvements**
  * Enhanced type definition formatting with configurable line-width handling for multi-line union/intersection types.
  * Extended TypeScript code generation to properly emit union and intersection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->