### PR TITLE
feat!: map reads are Result(V, Error); emit comma-ok via Go IIFE

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Place an order: validate input, attach domain failures, assert invariants with `
 
 ### Hello World
 
-*Before (Go)* and *After (Forst)* — Forst is a superset of Go for ordinary programs: the same `package main` source can be built with the standard Go toolchain or compiled with Forst, so a minimal executable looks identical on both sides.
+*Before (Go)* and *After (Forst)* — Forst is a superset of Go for ordinary programs: the same `package main` source can be built with the standard Go toolchain or compiled with Forst, so a minimal executable looks identical on both sides. Use a **`.ft`** file for the Forst CLI (`forst run`, `forst generate`, …); `go build` expects the usual **`.go`** name if you compile the same text with Go.
 
 ```golang
 package main
@@ -132,17 +132,19 @@ if in.Quantity > avail {
 }
 ```
 
-*After (Forst)* — Map lookup and error handling are streamlined: missing or invalid input is converted directly into a dedicated, first-class error type. If a stock-keeping unit isn’t found, the `UnknownStockKeepingUnit` error is returned. If the requested quantity exceeds available stock, the `InsufficientStock` error (with structured, named fields) is produced.
+*After (Forst)* — A **map read** `catalog[key]` has type **`Result(V, Error)`**: a missing key becomes the failure side of that `Result` (generated code uses comma-ok under the hood). You **must** handle failure before using the success value—the usual pattern is **`ensure x is Ok()`**, which narrows `x` to `V`. **Comma-ok assignment (`v, ok := m[k]`) is not supported** as Forst syntax. See [`examples/in/map_catalog.ft`](examples/in/map_catalog.ft) for `ensure avail is Ok()` after a lookup.
 
-```ruby
-r := catalog[in.stockKeepingUnit]
-ensure r or UnknownStockKeepingUnit()
-ensure in.quantity is Max(r) or InsufficientStock({
+```golang
+avail := catalog[in.stockKeepingUnit]
+ensure avail is Ok()
+ensure in.quantity is Max(avail) or InsufficientStock({
 	stockKeepingUnit: in.stockKeepingUnit,
 	requested:        in.quantity,
-	available:        r,
+	available:        avail,
 })
 ```
+
+`ensure … or …` is not allowed in `func main` (parser rule); put guards that use `or` in a non-`main` function if needed.
 
 ### Caller — success path and narrowing
 
@@ -206,7 +208,7 @@ Adjust the import path to your output layout. See [TypeScript client output](#ty
 - Seamless TypeScript type generation inspired by tRPC – publishing types of API endpoints should be easy
 - Structural typing for function parameters and return values
 - Type-based assertions that allow complex type narrowing in function parameters
-- First-class scoped errors including stack traces, avoiding exceptions
+- First-class nominal errors and explicit `ensure` / `Result` control flow—no exceptions; depth and parity are tracked in [ROADMAP.md](./ROADMAP.md)
 
 ## Design Philosophy
 
@@ -219,8 +221,9 @@ Install Task using the [official instructions](https://taskfile.dev/installation
 Run tests:
 
 ```bash
-task test                  # Run all tests
-task test:unit             # Run compiler unit tests
+task test                  # Go tests: forst/internal/... and forst/cmd/forst/...
+task ci:test               # Full CI suite (Go tests + VS Code extension build + @forst/cli & @forst/sidecar + examples)
+task test:unit             # Run compiler unit tests (internal only)
 task test:unit:parser      # Run parser tests
 task test:unit:typechecker # Run typechecker tests
 ```

--- a/examples/in/map_catalog.ft
+++ b/examples/in/map_catalog.ft
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	// Map read is Result(Int, Error): handle failure explicitly with ensure … is Ok().
+	catalog := map[String]Int{ "ITEM-1": 10 }
+	sku := "ITEM-1"
+	avail := catalog[sku]
+	ensure avail is Ok()
+	fmt.Println(string(avail))
+	fmt.Println("ok")
+}

--- a/examples/out/map_catalog.go
+++ b/examples/out/map_catalog.go
@@ -4,13 +4,15 @@ import "fmt"
 import errors "errors"
 import os "os"
 
+var errMissingMapKey = errors.New("missing map key")
+
 func main() {
 	catalog := map[string]int{"ITEM-1": 10}
 	sku := "ITEM-1"
 	avail, availErr := func() (int, error) {
 		v, ok := catalog[sku]
 		if !ok {
-			return 0, errors.New("missing map key")
+			return 0, errMissingMapKey
 		}
 		return v, nil
 	}()

--- a/examples/out/map_catalog.go
+++ b/examples/out/map_catalog.go
@@ -1,0 +1,22 @@
+package main
+
+import "fmt"
+import errors "errors"
+import os "os"
+
+func main() {
+	catalog := map[string]int{"ITEM-1": 10}
+	sku := "ITEM-1"
+	avail, availErr := func() (int, error) {
+		v, ok := catalog[sku]
+		if !ok {
+			return 0, errors.New("missing map key")
+		}
+		return v, nil
+	}()
+	if !(availErr == nil) {
+		os.Exit(1)
+	}
+	fmt.Println(string(avail))
+	fmt.Println("ok")
+}

--- a/forst/cmd/forst/lsp/hover_completion.go
+++ b/forst/cmd/forst/lsp/hover_completion.go
@@ -294,7 +294,38 @@ func variableHoverMarkdownWithGuardDocs(tc *typechecker.TypeChecker, tokens []as
 	return top + "\n\n" + body
 }
 
+// mapIndexLBracketHoverMarkdown returns hover text when the cursor is on `[` after a map variable (e.g. m[k]).
+func mapIndexLBracketHoverMarkdown(tc *typechecker.TypeChecker, tokens []ast.Token, tok *ast.Token) string {
+	if tc == nil || tok == nil || tok.Type != ast.TokenLBracket {
+		return ""
+	}
+	i := tokenSliceIndex(tokens, tok)
+	if i < 1 {
+		return ""
+	}
+	prev := &tokens[i-1]
+	if prev.Type != ast.TokenIdentifier {
+		return ""
+	}
+	vn := ast.VariableNode{
+		Ident: ast.Ident{ID: ast.Identifier(prev.Value), Span: ast.SpanFromToken(*prev)},
+	}
+	types, ok := tc.InferredTypesForVariableNode(vn)
+	if !ok || len(types) != 1 {
+		return ""
+	}
+	if types[0].Ident != ast.TypeMap {
+		return ""
+	}
+	return "**Map lookup:** type `Result(V, Error)`; missing key is failure. Use `ensure … is Ok()` before using `V`."
+}
+
 func hoverTextForToken(tc *typechecker.TypeChecker, tokens []ast.Token, tok *ast.Token, merge *packageMergeInfo) string {
+	if tok.Type == ast.TokenLBracket {
+		if s := mapIndexLBracketHoverMarkdown(tc, tokens, tok); s != "" {
+			return s
+		}
+	}
 	if tok.Type == ast.TokenStringLiteral {
 		if s := goHoverFromImportString(tc, tokens, tok); s != "" {
 			return s

--- a/forst/cmd/forst/lsp/hover_completion_test.go
+++ b/forst/cmd/forst/lsp/hover_completion_test.go
@@ -1282,3 +1282,56 @@ func main() {
 		t.Fatalf("expected Go func hover on Contains, got %v", hMem)
 	}
 }
+
+func TestFindHoverForPosition_mapIndexLBracket(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ft := filepath.Join(dir, "map_bracket_hover.ft")
+	const src = `package main
+
+func main() {
+	m := map[String]Int{ "a": 1 }
+	k := "a"
+	x := m[k]
+	ensure x is Ok()
+}
+`
+	if err := os.WriteFile(ft, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri := mustFileURI(t, ft)
+	s := NewLSPServer("8080", logrus.New())
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	ctx, ok := s.analyzeForstDocument(uri)
+	if !ok || ctx == nil {
+		t.Fatal("expected analyzed document")
+	}
+	if ctx.ParseErr != nil {
+		t.Fatalf("parse: %v", ctx.ParseErr)
+	}
+	if ctx.CheckErr != nil {
+		t.Fatalf("check: %v", ctx.CheckErr)
+	}
+	var lb *ast.Token
+	for i := range ctx.Tokens {
+		tok := &ctx.Tokens[i]
+		if tok.Type == ast.TokenLBracket && i > 0 && ctx.Tokens[i-1].Value == "m" {
+			lb = tok
+			break
+		}
+	}
+	if lb == nil {
+		t.Fatal("no LBracket after m")
+	}
+	h := s.findHoverForPosition(uri, LSPPosition{Line: lb.Line - 1, Character: lb.Column - 1})
+	if h == nil {
+		t.Fatal("nil hover on [")
+	}
+	val := h.Contents.Value
+	if !strings.Contains(val, "Result(V, Error)") || !strings.Contains(val, "ensure") {
+		t.Fatalf("expected map index hover, got %q", val)
+	}
+}

--- a/forst/internal/ast/expression.go
+++ b/forst/internal/ast/expression.go
@@ -38,7 +38,7 @@ func (u UnaryExpressionNode) isExpression()  { _ = u }
 func (b BinaryExpressionNode) isExpression() { _ = b }
 func (f FunctionCallNode) isExpression()     { _ = f }
 
-// IndexExpressionNode is a subscript expression: target[index] (slice or array).
+// IndexExpressionNode is a subscript expression: target[index] (slice, array, or map).
 type IndexExpressionNode struct {
 	Target ExpressionNode
 	Index  ExpressionNode

--- a/forst/internal/compiler/compiler_test.go
+++ b/forst/internal/compiler/compiler_test.go
@@ -463,10 +463,11 @@ func verifyMapCatalogGolden(t *testing.T, expected, actual, goldenPath string) {
 	markers := []string{
 		"package main",
 		"func main()",
+		`var errMissingMapKey = errors.New("missing map key")`,
 		`missing map key`,
 		`v, ok :=`,
 		`!ok`,
-		`errors.New`,
+		`errMissingMapKey`,
 		`fmt`,
 		`fmt.Println`,
 		`catalog[sku]`,

--- a/forst/internal/compiler/compiler_test.go
+++ b/forst/internal/compiler/compiler_test.go
@@ -90,6 +90,11 @@ func TestProgramCompilation(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "map catalog result",
+			filePath: "../../../examples/in/map_catalog.ft",
+			wantErr:  false,
+		},
+		{
 			name:     "non-existent file",
 			filePath: "nonexistent.ft",
 			wantErr:  true,
@@ -418,5 +423,60 @@ func Main() {
 	stdout := string(stdoutBytes)
 	if !strings.Contains(stdout, "package main") {
 		t.Fatalf("expected generated code on stdout, got: %s", stdout)
+	}
+}
+
+// TestCompileFile_map_catalog_golden keeps examples/out/map_catalog.go aligned with codegen for
+// examples/in/map_catalog.ft (also exercised by cmd/forst TestExamples).
+// Regenerate: UPDATE_MAP_CATALOG_GOLDEN=1 go test ./internal/compiler -run TestCompileFile_map_catalog_golden -count=1
+func TestCompileFile_map_catalog_golden(t *testing.T) {
+	c := New(Args{
+		Command:  "run",
+		FilePath: "../../../examples/in/map_catalog.ft",
+		LogLevel: "error",
+	}, nil)
+	code, err := c.CompileFile()
+	if err != nil {
+		t.Fatalf("CompileFile: %v", err)
+	}
+	actual := *code
+	goldenPath := filepath.Join("..", "..", "..", "examples", "out", "map_catalog.go")
+	if os.Getenv("UPDATE_MAP_CATALOG_GOLDEN") == "1" {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenPath, []byte(actual), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("wrote %s", goldenPath)
+		return
+	}
+	expected, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (set UPDATE_MAP_CATALOG_GOLDEN=1 to create)", goldenPath, err)
+	}
+	verifyMapCatalogGolden(t, string(expected), actual, goldenPath)
+}
+
+func verifyMapCatalogGolden(t *testing.T, expected, actual, goldenPath string) {
+	t.Helper()
+	markers := []string{
+		"package main",
+		"func main()",
+		`missing map key`,
+		`v, ok :=`,
+		`!ok`,
+		`errors.New`,
+		`fmt`,
+		`fmt.Println`,
+		`catalog[sku]`,
+	}
+	for _, m := range markers {
+		if !strings.Contains(actual, m) {
+			t.Errorf("generated Go missing %q (golden %s)", m, goldenPath)
+		}
+	}
+	if len(expected) > 0 && len(actual) < len(expected)/2 {
+		t.Errorf("output much shorter than golden (%d vs %d bytes)", len(actual), len(expected))
 	}
 }

--- a/forst/internal/transformer/go/expression.go
+++ b/forst/internal/transformer/go/expression.go
@@ -163,6 +163,10 @@ func (t *Transformer) transformExpression(expr ast.ExpressionNode) (goast.Expr, 
 		sel = t.appendResultStoragePayloadSelector(e, sel)
 		return sel, nil
 	case ast.IndexExpressionNode:
+		ts, err := t.TypeChecker.LookupInferredType(e, false)
+		if err == nil && len(ts) == 1 && ts[0].IsResultType() {
+			return t.transformMapIndexResultCall(e, ts[0])
+		}
 		tgt, err := t.transformExpression(e.Target)
 		if err != nil {
 			return nil, err

--- a/forst/internal/transformer/go/expression_map_result.go
+++ b/forst/internal/transformer/go/expression_map_result.go
@@ -15,6 +15,13 @@ func (t *Transformer) transformMapIndexResultCall(e ast.IndexExpressionNode, res
 		return nil, fmt.Errorf("transformMapIndexResultCall: expected Result")
 	}
 	succT := resultT.TypeParams[0]
+	cacheKey := mapIndexExprCacheKey(e)
+	if t.mapIndexFuncLitCache != nil {
+		if lit, ok := t.mapIndexFuncLitCache[cacheKey]; ok {
+			t.mapIndexCacheHits++
+			return &goast.CallExpr{Fun: lit}, nil
+		}
+	}
 	tgt, err := t.transformExpression(e.Target)
 	if err != nil {
 		return nil, err
@@ -32,14 +39,7 @@ func (t *Transformer) transformMapIndexResultCall(e ast.IndexExpressionNode, res
 		return nil, err
 	}
 	t.Output.EnsureImport("errors")
-
-	errorsNew := &goast.CallExpr{
-		Fun: &goast.SelectorExpr{
-			X:   goast.NewIdent("errors"),
-			Sel: goast.NewIdent("New"),
-		},
-		Args: []goast.Expr{&goast.BasicLit{Kind: token.STRING, Value: `"missing map key"`}},
-	}
+	t.Output.EnsureErrMissingMapKeyDecl()
 
 	// v, ok := m[k]
 	assign := &goast.AssignStmt{
@@ -50,7 +50,7 @@ func (t *Transformer) transformMapIndexResultCall(e ast.IndexExpressionNode, res
 	ifNotOk := &goast.IfStmt{
 		Cond: &goast.UnaryExpr{Op: token.NOT, X: goast.NewIdent("ok")},
 		Body: &goast.BlockStmt{List: []goast.Stmt{
-			&goast.ReturnStmt{Results: []goast.Expr{zero, errorsNew}},
+			&goast.ReturnStmt{Results: []goast.Expr{zero, goast.NewIdent("errMissingMapKey")}},
 		}},
 	}
 	retOk := &goast.ReturnStmt{Results: []goast.Expr{goast.NewIdent("v"), goast.NewIdent("nil")}}
@@ -67,7 +67,22 @@ func (t *Transformer) transformMapIndexResultCall(e ast.IndexExpressionNode, res
 		},
 		Body: &goast.BlockStmt{List: []goast.Stmt{assign, ifNotOk, retOk}},
 	}
+	if t.mapIndexFuncLitCache != nil {
+		t.mapIndexFuncLitCache[cacheKey] = fn
+	}
 	return &goast.CallExpr{Fun: fn}, nil
+}
+
+// mapIndexExprCacheKey is stable for duplicate reads: avoid Variable(m) vs m spelling differences in String().
+func mapIndexExprCacheKey(e ast.IndexExpressionNode) string {
+	var target string
+	switch t := e.Target.(type) {
+	case ast.VariableNode:
+		target = string(t.Ident.ID)
+	default:
+		target = e.Target.String()
+	}
+	return target + "\x00" + e.Index.String()
 }
 
 // goZeroValueGoAST returns a zero value expression for common Forst types used as map values.
@@ -81,6 +96,8 @@ func (t *Transformer) goZeroValueGoAST(vt ast.TypeNode) (goast.Expr, error) {
 		return &goast.BasicLit{Kind: token.STRING, Value: `""`}, nil
 	case ast.TypeBool:
 		return goast.NewIdent("false"), nil
+	case ast.TypePointer:
+		return goast.NewIdent("nil"), nil
 	default:
 		gt, err := t.transformType(vt)
 		if err != nil {

--- a/forst/internal/transformer/go/expression_map_result.go
+++ b/forst/internal/transformer/go/expression_map_result.go
@@ -1,0 +1,91 @@
+package transformergo
+
+import (
+	"fmt"
+
+	"forst/internal/ast"
+	goast "go/ast"
+	"go/token"
+)
+
+// transformMapIndexResultCall lowers a map read m[k] typed as Result(V, Error) to an IIFE that uses
+// Go's comma-ok internally and returns (V, error).
+func (t *Transformer) transformMapIndexResultCall(e ast.IndexExpressionNode, resultT ast.TypeNode) (goast.Expr, error) {
+	if !resultT.IsResultType() || len(resultT.TypeParams) < 1 {
+		return nil, fmt.Errorf("transformMapIndexResultCall: expected Result")
+	}
+	succT := resultT.TypeParams[0]
+	tgt, err := t.transformExpression(e.Target)
+	if err != nil {
+		return nil, err
+	}
+	idx, err := t.transformExpression(e.Index)
+	if err != nil {
+		return nil, err
+	}
+	velGo, err := t.transformType(succT)
+	if err != nil {
+		return nil, err
+	}
+	zero, err := t.goZeroValueGoAST(succT)
+	if err != nil {
+		return nil, err
+	}
+	t.Output.EnsureImport("errors")
+
+	errorsNew := &goast.CallExpr{
+		Fun: &goast.SelectorExpr{
+			X:   goast.NewIdent("errors"),
+			Sel: goast.NewIdent("New"),
+		},
+		Args: []goast.Expr{&goast.BasicLit{Kind: token.STRING, Value: `"missing map key"`}},
+	}
+
+	// v, ok := m[k]
+	assign := &goast.AssignStmt{
+		Lhs: []goast.Expr{goast.NewIdent("v"), goast.NewIdent("ok")},
+		Tok: token.DEFINE,
+		Rhs: []goast.Expr{&goast.IndexExpr{X: tgt, Index: idx}},
+	}
+	ifNotOk := &goast.IfStmt{
+		Cond: &goast.UnaryExpr{Op: token.NOT, X: goast.NewIdent("ok")},
+		Body: &goast.BlockStmt{List: []goast.Stmt{
+			&goast.ReturnStmt{Results: []goast.Expr{zero, errorsNew}},
+		}},
+	}
+	retOk := &goast.ReturnStmt{Results: []goast.Expr{goast.NewIdent("v"), goast.NewIdent("nil")}}
+
+	fn := &goast.FuncLit{
+		Type: &goast.FuncType{
+			Params: &goast.FieldList{},
+			Results: &goast.FieldList{
+				List: []*goast.Field{
+					{Type: velGo},
+					{Type: goast.NewIdent("error")},
+				},
+			},
+		},
+		Body: &goast.BlockStmt{List: []goast.Stmt{assign, ifNotOk, retOk}},
+	}
+	return &goast.CallExpr{Fun: fn}, nil
+}
+
+// goZeroValueGoAST returns a zero value expression for common Forst types used as map values.
+func (t *Transformer) goZeroValueGoAST(vt ast.TypeNode) (goast.Expr, error) {
+	switch vt.Ident {
+	case ast.TypeInt:
+		return &goast.BasicLit{Kind: token.INT, Value: "0"}, nil
+	case ast.TypeFloat:
+		return &goast.BasicLit{Kind: token.FLOAT, Value: "0"}, nil
+	case ast.TypeString:
+		return &goast.BasicLit{Kind: token.STRING, Value: `""`}, nil
+	case ast.TypeBool:
+		return goast.NewIdent("false"), nil
+	default:
+		gt, err := t.transformType(vt)
+		if err != nil {
+			return nil, err
+		}
+		return &goast.CompositeLit{Type: gt}, nil
+	}
+}

--- a/forst/internal/transformer/go/expression_map_result_test.go
+++ b/forst/internal/transformer/go/expression_map_result_test.go
@@ -1,0 +1,54 @@
+package transformergo
+
+import (
+	"go/format"
+	"go/token"
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestGoZeroValueGoAST_table(t *testing.T) {
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tr := setupTransformer(tc, log)
+
+	cases := []struct {
+		name string
+		vt   ast.TypeNode
+		sub  string
+	}{
+		{"int", ast.NewBuiltinType(ast.TypeInt), "0"},
+		{"string", ast.NewBuiltinType(ast.TypeString), `""`},
+		{"bool", ast.NewBuiltinType(ast.TypeBool), "false"},
+		{"float", ast.NewBuiltinType(ast.TypeFloat), "0"},
+		{
+			"array_int",
+			ast.TypeNode{Ident: ast.TypeArray, TypeKind: ast.TypeKindBuiltin, TypeParams: []ast.TypeNode{ast.NewBuiltinType(ast.TypeInt)}},
+			"",
+		},
+		{
+			"map_string_int",
+			ast.NewMapType(ast.NewBuiltinType(ast.TypeString), ast.NewBuiltinType(ast.TypeInt)),
+			"",
+		},
+		{"pointer_int", ast.NewPointerType(ast.NewBuiltinType(ast.TypeInt)), "nil"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := tr.goZeroValueGoAST(tt.vt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var buf strings.Builder
+			if err := format.Node(&buf, token.NewFileSet(), expr); err != nil {
+				t.Fatal(err)
+			}
+			s := buf.String()
+			if tt.sub != "" && !strings.Contains(s, tt.sub) {
+				t.Fatalf("formatted %q should contain %q", s, tt.sub)
+			}
+		})
+	}
+}

--- a/forst/internal/transformer/go/function.go
+++ b/forst/internal/transformer/go/function.go
@@ -95,6 +95,10 @@ func (t *Transformer) transformFunction(n ast.FunctionNode) (*goast.FuncDecl, er
 	t.resultLocalSplit = make(map[string]resultLocalSplit)
 	defer func() { t.resultLocalSplit = prevResultSplit }()
 
+	prevMapIndexCache := t.mapIndexFuncLitCache
+	t.mapIndexFuncLitCache = make(map[string]*goast.FuncLit)
+	defer func() { t.mapIndexFuncLitCache = prevMapIndexCache }()
+
 	// Create function parameters
 	params, err := t.transformFunctionParams(n.Params)
 	if err != nil {

--- a/forst/internal/transformer/go/import_output_test.go
+++ b/forst/internal/transformer/go/import_output_test.go
@@ -1,8 +1,10 @@
 package transformergo
 
 import (
+	"go/format"
 	goast "go/ast"
 	"go/token"
+	"strings"
 	"testing"
 
 	forstast "forst/internal/ast"
@@ -84,12 +86,28 @@ func TestTransformerOutput_importsAndPackageName(t *testing.T) {
 		t.Fatalf("import groups: %d", len(out.importGroups))
 	}
 
+	out.EnsureErrMissingMapKeyDecl()
+	if len(out.valueDecls) != 1 {
+		t.Fatalf("value decls: %d", len(out.valueDecls))
+	}
+
 	f, err := out.GenerateFile()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if f.Name.Name != "p" {
 		t.Fatalf("file package: %s", f.Name.Name)
+	}
+	src := ""
+	for _, d := range f.Decls {
+		if gd, ok := d.(*goast.GenDecl); ok && gd.Tok == token.VAR {
+			var b strings.Builder
+			_ = format.Node(&b, token.NewFileSet(), gd)
+			src += b.String()
+		}
+	}
+	if !strings.Contains(src, "errMissingMapKey") || !strings.Contains(src, "missing map key") {
+		t.Fatalf("expected errMissingMapKey decl in file, got decls: %+v", f.Decls)
 	}
 }
 

--- a/forst/internal/transformer/go/map_index_cache_key_test.go
+++ b/forst/internal/transformer/go/map_index_cache_key_test.go
@@ -1,0 +1,67 @@
+package transformergo
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/parser"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestMapIndexExprCacheKey_equalForDuplicateReads(t *testing.T) {
+	src := `package main
+
+func main() {
+	m := map[String]Int{ "a": 1 }
+	a := m["a"]
+	b := m["a"]
+	ensure a is Ok()
+	ensure b is Ok()
+	println(string(a))
+	println(string(b))
+}
+`
+	log := logrus.New()
+	log.SetOutput(nil)
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var idxs []ast.IndexExpressionNode
+	var walk func(ast.Node)
+	walk = func(n ast.Node) {
+		if n == nil {
+			return
+		}
+		switch x := n.(type) {
+		case ast.IndexExpressionNode:
+			idxs = append(idxs, x)
+		case ast.FunctionNode:
+			for _, st := range x.Body {
+				walk(st)
+			}
+		case ast.AssignmentNode:
+			for _, rv := range x.RValues {
+				walk(rv)
+			}
+		}
+	}
+	for _, n := range nodes {
+		if fn, ok := n.(ast.FunctionNode); ok && string(fn.Ident.ID) == "main" {
+			for _, st := range fn.Body {
+				walk(st)
+			}
+		}
+	}
+	if len(idxs) < 2 {
+		t.Fatalf("want 2 index exprs, got %d", len(idxs))
+	}
+	k0 := mapIndexExprCacheKey(idxs[0])
+	k1 := mapIndexExprCacheKey(idxs[1])
+	if k0 != k1 {
+		t.Fatalf("cache keys differ: %q vs %q (idx0.String=%q idx1.String=%q)",
+			k0, k1, idxs[0].String(), idxs[1].String())
+	}
+}

--- a/forst/internal/transformer/go/output.go
+++ b/forst/internal/transformer/go/output.go
@@ -6,13 +6,20 @@ import (
 	"strings"
 )
 
-// TransformerOutput represents the output of the Transformer
+// TransformerOutput represents the output of the Transformer.
 type TransformerOutput struct {
-	packageName  string
-	imports      []*goast.GenDecl
+	// The name of the Go package to emit
+	packageName string
+	// List of single import declarations (added individually)
+	imports []*goast.GenDecl
+	// List of grouped import declarations
 	importGroups []*goast.GenDecl
-	functions    []*goast.FuncDecl
-	types        []*goast.GenDecl
+	// File-level variable declarations (e.g., sentinels, emitted after imports)
+	valueDecls []*goast.GenDecl
+	// All function declarations to emit in output
+	functions []*goast.FuncDecl
+	// All type declarations to emit in output
+	types []*goast.GenDecl
 }
 
 // SetPackageName sets the package name for the TransformerOutput
@@ -72,6 +79,38 @@ func (t *TransformerOutput) AddType(typeDecl *goast.GenDecl) {
 	t.types = append(t.types, typeDecl)
 }
 
+// EnsureErrMissingMapKeyDecl emits at most once: var errMissingMapKey = errors.New("missing map key").
+// Call EnsureImport("errors") before generating code that references it.
+func (t *TransformerOutput) EnsureErrMissingMapKeyDecl() {
+	for _, d := range t.valueDecls {
+		if d.Tok != token.VAR || len(d.Specs) == 0 {
+			continue
+		}
+		if vs, ok := d.Specs[0].(*goast.ValueSpec); ok && len(vs.Names) > 0 && vs.Names[0].Name == "errMissingMapKey" {
+			return
+		}
+	}
+	t.valueDecls = append(t.valueDecls, &goast.GenDecl{
+		Tok: token.VAR,
+		Specs: []goast.Spec{
+			&goast.ValueSpec{
+				Names: []*goast.Ident{goast.NewIdent("errMissingMapKey")},
+				Values: []goast.Expr{
+					&goast.CallExpr{
+						Fun: &goast.SelectorExpr{
+							X:   goast.NewIdent("errors"),
+							Sel: goast.NewIdent("New"),
+						},
+						Args: []goast.Expr{
+							&goast.BasicLit{Kind: token.STRING, Value: `"missing map key"`},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
 // HasType returns true if a type with the given name is already defined
 func (t *TransformerOutput) HasType(name string) bool {
 	for _, typeDecl := range t.types {
@@ -124,6 +163,10 @@ func (t *TransformerOutput) GenerateFile() (*goast.File, error) {
 		if len(imp.Specs) > 0 {
 			decls = append(decls, goast.Decl(imp))
 		}
+	}
+
+	for _, vd := range t.valueDecls {
+		decls = append(decls, goast.Decl(vd))
 	}
 
 	// Add type declarations

--- a/forst/internal/transformer/go/pipeline_integration_test.go
+++ b/forst/internal/transformer/go/pipeline_integration_test.go
@@ -869,6 +869,71 @@ func main() {
 	}
 }
 
+func TestPipeline_mapIndex_read_emitsResultSplitAndMissingKeyIIFE(t *testing.T) {
+	src := `package main
+
+func main() {
+	m := map[String]Int{ "a": 1 }
+	x := m["a"]
+	ensure x is Ok()
+	println(string(x))
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{
+		`x, xErr :=`,
+		`missing map key`,
+		`errors.New`,
+		`v, ok :=`,
+		`!ok`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
+		}
+	}
+}
+
+func TestPipeline_mapIndex_assignTarget_noResultIIFE(t *testing.T) {
+	src := `package main
+
+func main() {
+	m := map[String]Int{ "a": 1 }
+	m["a"] = 3
+	println("ok")
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `m["a"] = 3`) {
+		t.Fatalf("expected plain indexed assignment, got:\n%s", out)
+	}
+	if strings.Contains(out, "missing map key") {
+		t.Fatalf("did not expect map-read IIFE for assign-only program, got:\n%s", out)
+	}
+}
+
+func TestPipeline_mapIndex_return_delegatesWholeResult(t *testing.T) {
+	src := `package main
+
+func lookup(): Result(Int, Error) {
+	m := map[String]Int{ "a": 1 }
+	return m["a"]
+}
+
+func main() {
+	x := lookup()
+	ensure x is Ok()
+	println(string(x))
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `return func()`) && !strings.Contains(out, `return func(`) {
+		t.Fatalf("expected return of map lookup to lower via func literal / delegate, got:\n%s", out)
+	}
+	if !strings.Contains(out, `missing map key`) {
+		t.Fatalf("expected missing-key path in lowered map read, got:\n%s", out)
+	}
+}
+
 func TestPipeline_emitted_go_is_gofmt_clean(t *testing.T) {
 	src := `package main
 

--- a/forst/internal/transformer/go/pipeline_integration_test.go
+++ b/forst/internal/transformer/go/pipeline_integration_test.go
@@ -883,6 +883,7 @@ func main() {
 	for _, sub := range []string{
 		`x, xErr :=`,
 		`missing map key`,
+		`errMissingMapKey`,
 		`errors.New`,
 		`v, ok :=`,
 		`!ok`,
@@ -908,6 +909,42 @@ func main() {
 	}
 	if strings.Contains(out, "missing map key") {
 		t.Fatalf("did not expect map-read IIFE for assign-only program, got:\n%s", out)
+	}
+}
+
+func TestPipeline_mapIndex_duplicateReads_usesFuncLitCache(t *testing.T) {
+	src := `package main
+
+func main() {
+	m := map[String]Int{ "a": 1 }
+	a := m["a"]
+	b := m["a"]
+	ensure a is Ok()
+	ensure b is Ok()
+	println(string(a))
+	println(string(b))
+}
+`
+	log := ast.SetupTestLogger(nil)
+	if !testing.Verbose() {
+		log.SetOutput(bytes.NewBuffer(nil))
+	}
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := typechecker.New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
+	tr := New(tc, log)
+	_, err = tr.TransformForstFileToGo(nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tr.mapIndexCacheHits < 1 {
+		t.Fatalf("expected at least one map-index FuncLit cache hit for duplicate m[\"a\"], got hits=%d", tr.mapIndexCacheHits)
 	}
 }
 

--- a/forst/internal/transformer/go/result_local.go
+++ b/forst/internal/transformer/go/result_local.go
@@ -111,14 +111,23 @@ func (t *Transformer) rhsCallIsFoldedResult(fc ast.FunctionCallNode) bool {
 	return true
 }
 
+// rhsExprIsFoldedResult reports whether rv is a single Forst Result (function call, Go FFI, or map index read).
+func (t *Transformer) rhsExprIsFoldedResult(rv ast.ExpressionNode) bool {
+	switch e := rv.(type) {
+	case ast.FunctionCallNode:
+		return t.rhsCallIsFoldedResult(e)
+	case ast.IndexExpressionNode:
+		ts, err := t.TypeChecker.LookupInferredType(e, false)
+		return err == nil && len(ts) == 1 && ts[0].IsResultType()
+	default:
+		return false
+	}
+}
+
 // returnValueDelegatesWholeResult is true when `return expr` should forward a Result-returning
 // callee as a single Go return (`return g()`), not `return succ, nil` for constructor-free success.
 func (t *Transformer) returnValueDelegatesWholeResult(expr ast.ExpressionNode) bool {
-	fc, ok := expr.(ast.FunctionCallNode)
-	if !ok {
-		return false
-	}
-	return t.rhsCallIsFoldedResult(fc)
+	return t.rhsExprIsFoldedResult(expr)
 }
 
 // transformPrintBuiltinCallArgs builds Go call arguments for print/println and fmt.Print*,

--- a/forst/internal/transformer/go/statement.go
+++ b/forst/internal/transformer/go/statement.go
@@ -516,10 +516,11 @@ func (t *Transformer) transformStatement(stmt ast.Node) (goast.Stmt, error) {
 		// Result(S,F) is one Forst value but lowers to (success..., error) in Go: multi-value assignment.
 		if len(s.LValues) == 1 && len(s.RValues) == 1 {
 			if vn, ok := s.LValues[0].(ast.VariableNode); ok {
-				if fc, ok := s.RValues[0].(ast.FunctionCallNode); ok && t.rhsCallIsFoldedResult(fc) {
-					ts, err := t.TypeChecker.LookupInferredType(fc, false)
+				rhs := s.RValues[0]
+				if t.rhsExprIsFoldedResult(rhs) {
+					ts, err := t.TypeChecker.LookupInferredType(rhs, false)
 					if err != nil || len(ts) != 1 || !ts[0].IsResultType() {
-						return nil, fmt.Errorf("assignment: expected Result from folded Go call")
+						return nil, fmt.Errorf("assignment: expected Result from RHS")
 					}
 					succ := ts[0].TypeParams[0]
 					var successNames []string
@@ -533,7 +534,7 @@ func (t *Transformer) transformStatement(stmt ast.Node) (goast.Stmt, error) {
 						successNames = []string{string(vn.Ident.ID)}
 					}
 					errName := string(vn.Ident.ID) + "Err"
-					rhsExpr, err := t.transformExpression(fc)
+					rhsExpr, err := t.transformExpression(rhs)
 					if err != nil {
 						return nil, err
 					}

--- a/forst/internal/transformer/go/transformer.go
+++ b/forst/internal/transformer/go/transformer.go
@@ -33,6 +33,11 @@ type Transformer struct {
 
 	// emittedSealMethods records receiver+method pairs for nominal error union sealing (dedupe on re-emit).
 	emittedSealMethods map[string]struct{}
+
+	// mapIndexFuncLitCache deduplicates identical map-read IIFEs within one Forst function (key: expr|succType).
+	mapIndexFuncLitCache map[string]*goast.FuncLit
+	// mapIndexCacheHits counts cache hits during transform (second+ identical map read in a function).
+	mapIndexCacheHits int
 }
 
 // New creates a new Transformer

--- a/forst/internal/transformer/ts/type_mapping.go
+++ b/forst/internal/transformer/ts/type_mapping.go
@@ -163,6 +163,27 @@ func (tm *TypeMapping) GetTypeScriptType(forstType *ast.TypeNode) (string, error
 		return "unknown", nil
 	case ast.TypeError:
 		return "unknown", nil
+	case ast.TypeResult:
+		if len(forstType.TypeParams) >= 2 {
+			succ, err := tm.GetTypeScriptType(&forstType.TypeParams[0])
+			if err != nil {
+				return "", err
+			}
+			fail, err := tm.GetTypeScriptType(&forstType.TypeParams[1])
+			if err != nil {
+				return "", err
+			}
+			succTS := succ
+			if strings.Contains(succ, "|") || strings.Contains(succ, " & ") {
+				succTS = "(" + succ + ")"
+			}
+			failTS := fail
+			if strings.Contains(fail, "|") || strings.Contains(fail, " & ") {
+				failTS = "(" + fail + ")"
+			}
+			return fmt.Sprintf("({ ok: true; value: %s } | { ok: false; error: %s })", succTS, failTS), nil
+		}
+		return "unknown", nil
 	case ast.TypeUnion:
 		if len(forstType.TypeParams) == 0 {
 			return "never", nil

--- a/forst/internal/transformer/ts/type_mapping.go
+++ b/forst/internal/transformer/ts/type_mapping.go
@@ -163,6 +163,10 @@ func (tm *TypeMapping) GetTypeScriptType(forstType *ast.TypeNode) (string, error
 		return "unknown", nil
 	case ast.TypeError:
 		return "unknown", nil
+	// TypeResult: emitted TypeScript is a static signature approximation for generated clients.
+	// Go codegen uses (T, error) and ensure/Result control flow; HTTP/JSON or other wire formats
+	// are not automatically { ok, value } unless you add an explicit codec. Do not assume runtime
+	// payloads match this discriminated union without aligning your integration boundary.
 	case ast.TypeResult:
 		if len(forstType.TypeParams) >= 2 {
 			succ, err := tm.GetTypeScriptType(&forstType.TypeParams[0])

--- a/forst/internal/transformer/ts/type_mapping_test.go
+++ b/forst/internal/transformer/ts/type_mapping_test.go
@@ -98,6 +98,26 @@ func TestTypeMapping_GetTypeScriptType_errorBuiltin(t *testing.T) {
 	}
 }
 
+func TestTypeMapping_GetTypeScriptType_resultPair(t *testing.T) {
+	tm := NewTypeMapping()
+	r := ast.TypeNode{
+		Ident:    ast.TypeResult,
+		TypeKind: ast.TypeKindBuiltin,
+		TypeParams: []ast.TypeNode{
+			ast.NewBuiltinType(ast.TypeInt),
+			ast.NewBuiltinType(ast.TypeError),
+		},
+	}
+	got, err := tm.GetTypeScriptType(&r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "({ ok: true; value: number } | { ok: false; error: unknown })"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 func TestTypeMapping_arrayTypeScript_parenthesizesUnions(t *testing.T) {
 	if got := arrayTypeScript("string | number"); got != "(string | number)[]" {
 		t.Fatalf("got %q", got)

--- a/forst/internal/typechecker/go_builtins.go
+++ b/forst/internal/typechecker/go_builtins.go
@@ -345,6 +345,12 @@ func (tc *TypeChecker) checkBuiltinFunctionCall(fn BuiltinFunction, args []ast.E
 		case ast.TypeInt:
 			return []ast.TypeNode{fn.ReturnType}, nil
 		default:
+			if argType[0].Ident == ast.TypeResult {
+				if idx, ok := args[0].(ast.IndexExpressionNode); ok && tc.isMapIndexRValue(idx) {
+					return nil, diagnosticf(sp, "builtin-call",
+						"map lookup has type Result(V, Error); use `ensure x is Ok()` (or bind and handle the Result) before using string()")
+				}
+			}
 			return nil, diagnosticf(sp, "builtin-call", "string() unsupported operand type %s", argType[0].Ident)
 		}
 	}
@@ -488,4 +494,13 @@ func (tc *TypeChecker) tryDispatchGoBuiltin(fn BuiltinFunction, args []ast.Expre
 	default:
 		return nil, false, nil
 	}
+}
+
+// isMapIndexRValue is true when expr is a subscript whose target is a map type (rvalue read).
+func (tc *TypeChecker) isMapIndexRValue(expr ast.IndexExpressionNode) bool {
+	tts, err := tc.inferExpressionType(expr.Target)
+	if err != nil || len(tts) != 1 {
+		return false
+	}
+	return tts[0].Ident == ast.TypeMap && len(tts[0].TypeParams) >= 2
 }

--- a/forst/internal/typechecker/infer_assignment.go
+++ b/forst/internal/typechecker/infer_assignment.go
@@ -115,6 +115,23 @@ func (tc *TypeChecker) inferAssignmentTypes(assign ast.AssignmentNode) error {
 		}
 	}
 
+	// Forst intentionally does not support Go's map comma-ok form (v, ok := m[k]).
+	if len(assign.RValues) == 1 && len(assign.LValues) == 2 {
+		if idx, ok := assign.RValues[0].(ast.IndexExpressionNode); ok {
+			targetTypes, err := tc.inferExpressionType(idx.Target)
+			if err != nil {
+				return err
+			}
+			if len(targetTypes) == 1 && targetTypes[0].Ident == ast.TypeMap {
+				return fmt.Errorf("map index comma-ok assignment (v, ok := m[k]) is not supported")
+			}
+		}
+	}
+
+	if len(assign.RValues) > 0 && len(resolvedTypes) != len(assign.LValues) {
+		return fmt.Errorf("assignment: %d left-hand values but right-hand produces %d value(s)", len(assign.LValues), len(resolvedTypes))
+	}
+
 	if tc.log != nil {
 		tc.log.WithFields(logrus.Fields{
 			"resolvedTypes": resolvedTypes,
@@ -182,7 +199,7 @@ func (tc *TypeChecker) inferAssignmentTypes(assign ast.AssignmentNode) error {
 			if len(assign.ExplicitTypes) > i && assign.ExplicitTypes[i] != nil {
 				return fmt.Errorf("indexed assignment does not support explicit types on the left-hand side")
 			}
-			lhsTypes, err := tc.inferExpressionType(l)
+			lhsTypes, err := tc.inferIndexExpressionAsAssignTarget(l)
 			if err != nil {
 				return err
 			}

--- a/forst/internal/typechecker/infer_expression.go
+++ b/forst/internal/typechecker/infer_expression.go
@@ -519,6 +519,10 @@ func (tc *TypeChecker) inferExpressionTypeWithExpected(expr ast.Node, expected *
 			}
 			tc.storeInferredType(expr, []ast.TypeNode{inferredType})
 			return []ast.TypeNode{inferredType}, nil
+		case ast.IndexExpressionNode:
+			// Extension point: map/slice index with an expected type (e.g. generic calls). Today
+			// expected is ignored; index inference is unchanged from inferExpressionType.
+			return tc.inferExpressionType(x)
 		}
 	}
 	return tc.inferExpressionType(expr)

--- a/forst/internal/typechecker/infer_expression.go
+++ b/forst/internal/typechecker/infer_expression.go
@@ -108,9 +108,6 @@ func (tc *TypeChecker) inferExpressionType(expr ast.Node) ([]ast.TypeNode, error
 			return nil, fmt.Errorf("index expression: target must have a single type, got %d", len(targetTypes))
 		}
 		t := targetTypes[0]
-		if t.Ident != ast.TypeArray || len(t.TypeParams) < 1 {
-			return nil, fmt.Errorf("index expression: target must be a slice or array, got %s", t.Ident)
-		}
 		indexTypes, err := tc.inferExpressionType(e.Index)
 		if err != nil {
 			return nil, err
@@ -118,8 +115,27 @@ func (tc *TypeChecker) inferExpressionType(expr ast.Node) ([]ast.TypeNode, error
 		if len(indexTypes) != 1 {
 			return nil, fmt.Errorf("index expression: index must have a single type")
 		}
+		if t.Ident == ast.TypeMap && len(t.TypeParams) >= 2 {
+			wantK, wantV := t.TypeParams[0], t.TypeParams[1]
+			if !tc.IsTypeCompatible(indexTypes[0], wantK) {
+				return nil, fmt.Errorf("map index: key type want %s, got %s", wantK.Ident, indexTypes[0].Ident)
+			}
+			// Rvalue map lookup is Result(V, Error): present key → Ok(value); missing key → Err.
+			resultType := ast.TypeNode{
+				Ident: ast.TypeResult,
+				TypeParams: []ast.TypeNode{
+					wantV,
+					{Ident: ast.TypeError},
+				},
+			}
+			tc.storeInferredType(e, []ast.TypeNode{resultType})
+			return []ast.TypeNode{resultType}, nil
+		}
+		if t.Ident != ast.TypeArray || len(t.TypeParams) < 1 {
+			return nil, fmt.Errorf("index expression: target must be a map, slice, or array, got %s", t.Ident)
+		}
 		if indexTypes[0].Ident != ast.TypeInt {
-			return nil, fmt.Errorf("index expression: index must be Int, got %s", indexTypes[0].Ident)
+			return nil, fmt.Errorf("index expression: slice/array index must be Int, got %s", indexTypes[0].Ident)
 		}
 		elem := t.TypeParams[0]
 		tc.storeInferredType(e, []ast.TypeNode{elem})
@@ -444,6 +460,43 @@ func (tc *TypeChecker) inferMethodCallType(receiver ast.Identifier, varType []as
 		"methodName": methodName,
 	}).Tracef("Successfully inferred method call type: %v", returnType)
 	return returnType, nil
+}
+
+// inferIndexExpressionAsAssignTarget types an index expression as an assignment target (m[k] = x or xs[i] = x).
+// Map cells use element type V; rvalue map reads elsewhere use Result(V, Error) via inferExpressionType.
+func (tc *TypeChecker) inferIndexExpressionAsAssignTarget(e ast.IndexExpressionNode) ([]ast.TypeNode, error) {
+	targetTypes, err := tc.inferExpressionType(e.Target)
+	if err != nil {
+		return nil, err
+	}
+	if len(targetTypes) != 1 {
+		return nil, fmt.Errorf("index expression: target must have a single type, got %d", len(targetTypes))
+	}
+	t := targetTypes[0]
+	indexTypes, err := tc.inferExpressionType(e.Index)
+	if err != nil {
+		return nil, err
+	}
+	if len(indexTypes) != 1 {
+		return nil, fmt.Errorf("index expression: index must have a single type")
+	}
+	if t.Ident == ast.TypeMap && len(t.TypeParams) >= 2 {
+		wantK, wantV := t.TypeParams[0], t.TypeParams[1]
+		if !tc.IsTypeCompatible(indexTypes[0], wantK) {
+			return nil, fmt.Errorf("map index: key type want %s, got %s", wantK.Ident, indexTypes[0].Ident)
+		}
+		tc.storeInferredType(e, []ast.TypeNode{wantV})
+		return []ast.TypeNode{wantV}, nil
+	}
+	if t.Ident != ast.TypeArray || len(t.TypeParams) < 1 {
+		return nil, fmt.Errorf("index expression: target must be a map, slice, or array, got %s", t.Ident)
+	}
+	if indexTypes[0].Ident != ast.TypeInt {
+		return nil, fmt.Errorf("index expression: slice/array index must be Int, got %s", indexTypes[0].Ident)
+	}
+	elem := t.TypeParams[0]
+	tc.storeInferredType(e, []ast.TypeNode{elem})
+	return []ast.TypeNode{elem}, nil
 }
 
 // inferExpressionTypeWithExpected infers an expression's type. For shape literals it passes the

--- a/forst/internal/typechecker/infer_map_index_test.go
+++ b/forst/internal/typechecker/infer_map_index_test.go
@@ -161,7 +161,7 @@ func main() {
 	println(string(m["a"]))
 }`,
 			wantErr: true,
-			errSub:  "unsupported operand type Result",
+			errSub:  "map lookup has type Result(V, Error)",
 		},
 		{
 			name: "map_element_assignment",
@@ -172,7 +172,7 @@ func main() {
 	println(string(m["a"]))
 }`,
 			wantErr: true, // still: m["a"] on RHS is Result until narrowed
-			errSub:  "unsupported operand type Result",
+			errSub:  "map lookup has type Result(V, Error)",
 		},
 	}
 	for _, tc := range cases {
@@ -261,5 +261,74 @@ func TestInferIndexExpressionAsAssignTarget_map_element(t *testing.T) {
 	}
 	if len(types) != 1 || types[0].Ident != ast.TypeInt {
 		t.Fatalf("assign target want Int, got %+v", types)
+	}
+}
+
+func TestInferExpressionTypeWithExpected_mapIndex(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	m := astMapStringIntLiteral()
+	idx := ast.IndexExpressionNode{Target: m, Index: ast.StringLiteralNode{Value: "k"}}
+	exp := ast.TypeNode{
+		Ident: ast.TypeResult,
+		TypeParams: []ast.TypeNode{
+			ast.NewBuiltinType(ast.TypeInt),
+			ast.NewBuiltinType(ast.TypeError),
+		},
+	}
+	types, err := tc.inferExpressionTypeWithExpected(idx, &exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(types) != 1 || !types[0].IsResultType() || types[0].TypeParams[0].Ident != ast.TypeInt {
+		t.Fatalf("want Result(Int, Error), got %+v", types)
+	}
+}
+
+func TestCheckTypes_nestedMapIndex_outerIsResult(t *testing.T) {
+	t.Parallel()
+	src := `package main
+func main() {
+	inner := map[String]Int{ "b": 1 }
+	m := map[String]map[String]Int{ "a": inner }
+	x := m["a"]
+	ensure x is Ok()
+	println("ok")
+}
+`
+	log := logrus.New()
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+}
+
+func TestCheckTypes_chainedMapIndex_innerTargetNotMap(t *testing.T) {
+	t.Parallel()
+	src := `package main
+func main() {
+	inner := map[String]Int{ "b": 1 }
+	m := map[String]map[String]Int{ "a": inner }
+	println(string(m["a"]["b"]))
+}
+`
+	log := logrus.New()
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	err = tc.CheckTypes(nodes)
+	if err == nil {
+		t.Fatal("expected CheckTypes error: cannot index Result without narrowing")
+	}
+	if !strings.Contains(err.Error(), "TYPE_RESULT") && !strings.Contains(err.Error(), "Result") {
+		t.Fatalf("expected index-on-Result diagnostic, got: %v", err)
 	}
 }

--- a/forst/internal/typechecker/infer_map_index_test.go
+++ b/forst/internal/typechecker/infer_map_index_test.go
@@ -1,0 +1,265 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/parser"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestCheckTypes_mapIndex_singleValue(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	src := `package main
+func main() {
+	m := map[String]Int{ "a": 1, "b": 2 }
+	x := m["a"]
+	ensure x is Ok()
+	println(string(x))
+}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+}
+
+func TestCheckTypes_mapCommaOk_rejected(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	src := `package main
+func main() {
+	m := map[String]Int{ "a": 1 }
+	v, ok := m["a"]
+	println(string(v))
+}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	err = tc.CheckTypes(nodes)
+	if err == nil {
+		t.Fatal("expected CheckTypes error: map comma-ok is not supported")
+	}
+	if !strings.Contains(err.Error(), "comma-ok") {
+		t.Fatalf("expected comma-ok diagnostic, got: %v", err)
+	}
+}
+
+func TestCheckTypes_mapIndex_badKeyType(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	src := `package main
+func main() {
+	m := map[String]Int{ "a": 1 }
+	println(string(m[1]))
+}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	err = tc.CheckTypes(nodes)
+	if err == nil {
+		t.Fatal("expected CheckTypes error for map index key type mismatch")
+	}
+	if !strings.Contains(err.Error(), "map index") {
+		t.Fatalf("expected map index diagnostic, got: %v", err)
+	}
+}
+
+func TestCheckTypes_twoLhs_sliceIndex_errors(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	src := `package main
+func main() {
+	xs := [1, 2]
+	a, b := xs[0]
+	println(string(a))
+}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	err = tc.CheckTypes(nodes)
+	if err == nil {
+		t.Fatal("expected CheckTypes error: slice index does not yield two values")
+	}
+}
+
+func TestInferExpressionType_mapIndex_AST(t *testing.T) {
+	tc := New(logrus.New(), false)
+	m := astMapStringIntLiteral()
+	idx := ast.IndexExpressionNode{
+		Target: m,
+		Index:  ast.StringLiteralNode{Value: "k"},
+	}
+	types, err := tc.inferExpressionType(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(types) != 1 || !types[0].IsResultType() || len(types[0].TypeParams) < 1 || types[0].TypeParams[0].Ident != ast.TypeInt {
+		t.Fatalf("want Result(Int, Error), got %+v", types)
+	}
+}
+
+func astMapStringIntLiteral() ast.MapLiteralNode {
+	return ast.MapLiteralNode{
+		Type: ast.TypeNode{
+			Ident: ast.TypeMap,
+			TypeParams: []ast.TypeNode{
+				{Ident: ast.TypeString},
+				{Ident: ast.TypeInt},
+			},
+		},
+		Entries: []ast.MapEntryNode{
+			{Key: ast.StringLiteralNode{Value: "k"}, Value: ast.IntLiteralNode{Value: 1}},
+		},
+	}
+}
+
+func TestCheckTypes_mapIndex_table(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		src     string
+		wantErr bool
+		errSub  string
+	}{
+		{
+			name: "result_narrowed_then_string_ok",
+			src: `package main
+func main() {
+	m := map[String]Int{ "a": 1 }
+	x := m["a"]
+	ensure x is Ok()
+	println(string(x))
+}`,
+			wantErr: false,
+		},
+		{
+			name: "string_on_raw_map_read_rejected",
+			src: `package main
+func main() {
+	m := map[String]Int{ "a": 1 }
+	println(string(m["a"]))
+}`,
+			wantErr: true,
+			errSub:  "unsupported operand type Result",
+		},
+		{
+			name: "map_element_assignment",
+			src: `package main
+func main() {
+	m := map[String]Int{ "a": 1 }
+	m["a"] = 2
+	println(string(m["a"]))
+}`,
+			wantErr: true, // still: m["a"] on RHS is Result until narrowed
+			errSub:  "unsupported operand type Result",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			log := logrus.New()
+			p := parser.NewTestParser(tc.src, log)
+			nodes, err := p.ParseFile()
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			chk := New(log, false)
+			err = chk.CheckTypes(nodes)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected CheckTypes error")
+				}
+				if tc.errSub != "" && !strings.Contains(err.Error(), tc.errSub) {
+					t.Fatalf("error %q should contain %q", err.Error(), tc.errSub)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("CheckTypes: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckTypes_mapAssign_updates_element_without_reading_result_twice(t *testing.T) {
+	t.Parallel()
+	// Only assignment to m[k]; no read of Result in println — use literals.
+	src := `package main
+func main() {
+	m := map[String]Int{ "a": 1 }
+	m["a"] = 2
+	println("done")
+}
+`
+	log := logrus.New()
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+}
+
+func TestCheckTypes_mapIndex_returnResult(t *testing.T) {
+	t.Parallel()
+	src := `package main
+func lookup(): Result(Int, Error) {
+	m := map[String]Int{ "a": 1 }
+	return m["a"]
+}
+func main() {
+	x := lookup()
+	ensure x is Ok()
+	println(string(x))
+}
+`
+	log := logrus.New()
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+}
+
+func TestInferIndexExpressionAsAssignTarget_map_element(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	m := astMapStringIntLiteral()
+	idx := ast.IndexExpressionNode{Target: m, Index: ast.StringLiteralNode{Value: "k"}}
+	types, err := tc.inferIndexExpressionAsAssignTarget(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(types) != 1 || types[0].Ident != ast.TypeInt {
+		t.Fatalf("assign target want Int, got %+v", types)
+	}
+}


### PR DESCRIPTION
Rvalue `m[k]` on `map[K]V` now infers as `Result(V, Error)` (missing key is failure). Forst rejects `v, ok := m[k]`; use `ensure x is Ok()` (or otherwise handle the `Result`) before using `V`. Indexed assignment `m[k] = x` still types the LHS as `V`. The Go backend lowers map reads with an IIFE that uses `v, ok :=` and `errors.New("missing map key")` internally.

Adds `examples/in/map_catalog.ft`, compiler/pipeline/typechecker coverage, and README catalog/CLI notes.

BREAKING CHANGE: Map subscript expressions are no longer plain `V`; callers must account for `Result(V, Error)` or narrow with `ensure`.

Example:

```forst
avail := catalog[sku]
ensure avail is Ok()
println(string(avail))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Map index operations now return explicit `Result` types requiring `ensure ... is Ok()` error handling before use.
  * Added LSP hover information for map indexing operations displaying Result semantics.

* **Documentation**
  * Updated guidance distinguishing `.ft` files for CLI usage and `.go` for Go builds.
  * Clarified map lookup patterns and explicit error-handling requirements.
  * Added example demonstrating Result-based map catalog lookups.

* **Tests**
  * Expanded test coverage for map indexing type inference and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->