### PR TITLE
feat(security): cap HTTP bodies and confine FS reads with os.Root

### DIFF
--- a/forst/cmd/forst/config.go
+++ b/forst/cmd/forst/config.go
@@ -3,12 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"forst/internal/compiler"
 	"forst/internal/configiface"
+	"forst/internal/httpbody"
+	"forst/internal/safefs"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
@@ -74,7 +77,7 @@ type ServerConfig struct {
 	// Write timeout in seconds
 	WriteTimeout int `json:"writeTimeout"`
 
-	// Max request size in bytes
+	// MaxRequestSize is the maximum HTTP request body size in bytes (enforced on /invoke and LSP POST).
 	MaxRequestSize int64 `json:"maxRequestSize"`
 }
 
@@ -209,7 +212,15 @@ func LoadConfig(configPath string) (*ForstConfig, error) {
 		}
 	}
 
+	normalizeServerMaxRequestSize(config)
+
 	return config, nil
+}
+
+func normalizeServerMaxRequestSize(config *ForstConfig) {
+	if config.Server.MaxRequestSize <= 0 {
+		config.Server.MaxRequestSize = httpbody.DefaultMaxBytes
+	}
 }
 
 // loadConfigFromFile loads configuration from a JSON file
@@ -228,39 +239,35 @@ func loadConfigFromFile(configPath string, config *ForstConfig) error {
 	return nil
 }
 
-// FindForstFiles recursively finds all .ft files in the configured directories
+// FindForstFiles recursively finds all .ft files in the configured directories under rootDir.
 func (c *ForstConfig) FindForstFiles(rootDir string) ([]string, error) {
+	root, err := safefs.OpenRoot(rootDir)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
 	var files []string
-
-	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
+	err = fs.WalkDir(root.FS(), ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
-
-		// Skip directories
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
-
-		// Check if file has .ft extension
-		if !strings.HasSuffix(strings.ToLower(path), ".ft") {
+		absPath := root.AbsPath(path)
+		if !strings.HasSuffix(strings.ToLower(absPath), ".ft") {
 			return nil
 		}
-
-		// Check include patterns
-		if !c.matchesIncludePatterns(path) {
+		if !c.matchesIncludePatterns(absPath) {
 			return nil
 		}
-
-		// Check exclude patterns
-		if c.matchesExcludePatterns(path) {
+		if c.matchesExcludePatterns(absPath) {
 			return nil
 		}
-
-		files = append(files, path)
+		files = append(files, absPath)
 		return nil
 	})
-
 	return files, err
 }
 

--- a/forst/cmd/forst/config_test.go
+++ b/forst/cmd/forst/config_test.go
@@ -113,6 +113,38 @@ func TestLoadConfig_emptyPath_findsConfigInWorkingDirectory(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_negativeMaxRequestSize_clampedToDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ftconfig.json")
+	json := `{"server": { "maxRequestSize": -1 }}`
+	if err := os.WriteFile(path, []byte(json), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.MaxRequestSize != 10*1024*1024 {
+		t.Fatalf("expected default max request size, got %d", cfg.Server.MaxRequestSize)
+	}
+}
+
+func TestLoadConfig_zeroMaxRequestSize_clampedToDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ftconfig.json")
+	json := `{"server": { "maxRequestSize": 0 }}`
+	if err := os.WriteFile(path, []byte(json), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.MaxRequestSize != 10*1024*1024 {
+		t.Fatalf("expected default max request size, got %d", cfg.Server.MaxRequestSize)
+	}
+}
+
 func TestForstConfig_FindForstFiles_nonexistentRoot_returnsError(t *testing.T) {
 	cfg := DefaultConfig()
 	root := filepath.Join(t.TempDir(), "nope_subdir_missing")

--- a/forst/cmd/forst/dev_server_http.go
+++ b/forst/cmd/forst/dev_server_http.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"forst/internal/discovery"
+	"forst/internal/httpbody"
 )
 
 // jsonMarshalVersionPayload marshals the /version payload; tests may replace to inject errors.
@@ -93,8 +94,17 @@ func (s *DevServer) handleInvoke(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	body, err := httpbody.ReadAll(r.Body, s.config.Server.MaxRequestSize)
+	if err != nil {
+		if httpbody.IsTooLarge(err) {
+			s.sendError(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		s.sendError(w, fmt.Sprintf("Failed to read request: %v", err), http.StatusBadRequest)
+		return
+	}
 	var req InvokeRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.Unmarshal(body, &req); err != nil {
 		s.sendError(w, fmt.Sprintf("Failed to decode request: %v", err), http.StatusBadRequest)
 		return
 	}

--- a/forst/cmd/forst/dev_server_http_test.go
+++ b/forst/cmd/forst/dev_server_http_test.go
@@ -131,6 +131,18 @@ func TestHandleInvoke_invalidJSON(t *testing.T) {
 	}
 }
 
+func TestHandleInvoke_oversizedBody(t *testing.T) {
+	s := testDevServer(t)
+	s.config.Server.MaxRequestSize = 64
+
+	body := strings.Repeat("x", 128)
+	rr := httptest.NewRecorder()
+	s.handleInvoke(rr, httptest.NewRequest(http.MethodPost, "/invoke", strings.NewReader(body)))
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("want 413, got %d body %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestHandleInvoke_packageNotFound(t *testing.T) {
 	s := testDevServer(t)
 	s.functions = make(map[string]map[string]discovery.FunctionInfo)

--- a/forst/cmd/forst/lsp/import_definition.go
+++ b/forst/cmd/forst/lsp/import_definition.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -9,6 +10,7 @@ import (
 	"forst/internal/ast"
 	"forst/internal/goload"
 	"forst/internal/lexer"
+	"forst/internal/safefs"
 )
 
 // qualifiedImportSymbolAt reports pkgLocal.symbol when tokIdx is the right-hand identifier in an import qualifier.
@@ -70,21 +72,28 @@ func (s *LSPServer) forstFileURIsUnderModule(moduleRoot string) []string {
 	}
 	s.documentMu.RUnlock()
 
-	_ = filepath.WalkDir(moduleRoot, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
+	root, err := safefs.OpenRoot(moduleRoot)
+	if err != nil {
+		return out
+	}
+	defer root.Close()
+
+	_ = fs.WalkDir(root.FS(), ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
 			return nil
 		}
 		if d.IsDir() {
 			switch d.Name() {
 			case ".git", "vendor", "node_modules":
-				return filepath.SkipDir
+				return fs.SkipDir
 			}
 			return nil
 		}
-		if !strings.HasSuffix(path, ".ft") {
+		absPath := root.AbsPath(path)
+		if !strings.HasSuffix(absPath, ".ft") {
 			return nil
 		}
-		u := fileURIForLocalPath(path)
+		u := fileURIForLocalPath(absPath)
 		if _, ok := seen[u]; ok {
 			return nil
 		}

--- a/forst/cmd/forst/lsp/import_definition_test.go
+++ b/forst/cmd/forst/lsp/import_definition_test.go
@@ -8,6 +8,31 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func TestForstFileURIsUnderModule_listsDiskFt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module urimod\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ftPath := filepath.Join(dir, "lib.ft")
+	if err := os.WriteFile(ftPath, []byte("package lib\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := NewLSPServer("8080", logrus.New())
+	out := s.forstFileURIsUnderModule(dir)
+	wantURI := fileURIForLocalPath(ftPath)
+	var found bool
+	for _, u := range out {
+		if u == wantURI {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("forstFileURIsUnderModule=%v want URI %s", out, wantURI)
+	}
+}
+
 func writeXpkgCrossPackageFixture(t *testing.T, dir string) (alphaLogPath, betaHandlePath string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module testmod\n\ngo 1.23\n"), 0o644); err != nil {

--- a/forst/cmd/forst/lsp/package_analysis.go
+++ b/forst/cmd/forst/lsp/package_analysis.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -16,6 +17,7 @@ import (
 	"forst/internal/lexer"
 	"forst/internal/modulecheck"
 	"forst/internal/parser"
+	"forst/internal/safefs"
 	"forst/internal/typechecker"
 
 	"github.com/sirupsen/logrus"
@@ -64,7 +66,7 @@ func (s *LSPServer) samePackageOpenURIs(anchorURI string) []string {
 
 	anchorContent := s.openDocumentContent(anchorURI)
 	if anchorContent == "" {
-		b, err := os.ReadFile(anchorPath)
+		b, err := readFileUnderModuleRoot(anchorPath)
 		if err != nil {
 			return []string{canonicalAnchor}
 		}
@@ -126,7 +128,12 @@ func (s *LSPServer) mergeSamePackageDiskFt(dir, pkg string, uris []string) []str
 	for _, u := range uris {
 		seen[u] = struct{}{}
 	}
-	entries, err := os.ReadDir(dir)
+	root, err := safefs.OpenRoot(dir)
+	if err != nil {
+		return uris
+	}
+	defer root.Close()
+	entries, err := fs.ReadDir(root.FS(), ".")
 	if err != nil {
 		return uris
 	}
@@ -134,12 +141,12 @@ func (s *LSPServer) mergeSamePackageDiskFt(dir, pkg string, uris []string) []str
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".ft") {
 			continue
 		}
-		full := filepath.Join(dir, e.Name())
+		full := root.AbsPath(e.Name())
 		u := fileURIForLocalPath(full)
 		if _, ok := seen[u]; ok {
 			continue
 		}
-		head, err := readForstFilePrefix(full, 64*1024)
+		head, err := readForstFilePrefixFromRoot(root, e.Name(), 64*1024)
 		if err != nil {
 			continue
 		}
@@ -152,8 +159,8 @@ func (s *LSPServer) mergeSamePackageDiskFt(dir, pkg string, uris []string) []str
 	return uris
 }
 
-func readForstFilePrefix(path string, maxBytes int) (string, error) {
-	b, err := os.ReadFile(path)
+func readForstFilePrefixFromRoot(r *safefs.RootedFS, rel string, maxBytes int) (string, error) {
+	b, err := r.ReadFile(rel)
 	if err != nil {
 		return "", err
 	}
@@ -161,6 +168,24 @@ func readForstFilePrefix(path string, maxBytes int) (string, error) {
 		b = b[:maxBytes]
 	}
 	return string(b), nil
+}
+
+// readFileUnderModuleRoot reads absPath using safefs scoped to its Go module root.
+func readFileUnderModuleRoot(absPath string) ([]byte, error) {
+	moduleRoot := goload.FindModuleRoot(filepath.Dir(absPath))
+	if moduleRoot == "" {
+		return os.ReadFile(absPath)
+	}
+	root, err := safefs.OpenRoot(moduleRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	rel, err := root.RelPath(absPath)
+	if err != nil {
+		return nil, err
+	}
+	return root.ReadFile(rel)
 }
 
 // loadPackageGroupContents returns the text used for lex/parse and fingerprinting: open buffer
@@ -178,7 +203,7 @@ func (s *LSPServer) loadPackageGroupContents(uris []string) (map[string]string, 
 			continue
 		}
 		p := filePathFromDocumentURI(u)
-		b, err := os.ReadFile(p)
+		b, err := readFileUnderModuleRoot(p)
 		if err != nil {
 			return nil, err
 		}

--- a/forst/cmd/forst/lsp/package_analysis_test.go
+++ b/forst/cmd/forst/lsp/package_analysis_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"forst/internal/safefs"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -131,6 +133,39 @@ func fromPeer(): Int {
 	}
 }
 
+func TestSamePackageOpenURIs_readsAnchorFromDiskWhenNotOpen(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	s := NewLSPServer("8080", log)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module anchordisk\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aPath := filepath.Join(dir, "anchor.ft")
+	const srcA = `package main
+
+func anchor(): Int {
+	return 1
+}
+`
+	if err := os.WriteFile(aPath, []byte(srcA), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uriA := mustFileURI(t, aPath)
+
+	out := s.samePackageOpenURIs(uriA)
+	if len(out) < 1 {
+		t.Fatalf("expected anchor URI, got %v", out)
+	}
+	for _, u := range out {
+		if u == uriA {
+			return
+		}
+	}
+	t.Fatalf("expected %s in %v", uriA, out)
+}
+
 func TestReadForstFilePrefix_truncatesLargeFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -143,11 +178,64 @@ func TestReadForstFilePrefix_truncatesLargeFile(t *testing.T) {
 	if err := os.WriteFile(p, []byte(b.String()), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	head, err := readForstFilePrefix(p, 64*1024)
+	root, err := safefs.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	head, err := readForstFilePrefixFromRoot(root, "big.ft", 64*1024)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(head) != 64*1024 {
 		t.Fatalf("want 64KiB prefix, got %d", len(head))
+	}
+}
+
+func TestReadFileUnderModuleRoot_readsFileInModule(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module readmod\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ftPath := filepath.Join(dir, "on_disk.ft")
+	const want = "package main\n"
+	if err := os.WriteFile(ftPath, []byte(want), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readFileUnderModuleRoot(ftPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestLoadPackageGroupContents_readsFromDiskWhenBufferEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module diskload\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ftPath := filepath.Join(dir, "disk.ft")
+	const want = `package main
+
+func Disk(): Int {
+	return 1
+}
+`
+	if err := os.WriteFile(ftPath, []byte(want), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri := mustFileURI(t, ftPath)
+	s := NewLSPServer("8080", logrus.New())
+
+	contents, err := s.loadPackageGroupContents([]string{uri})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contents[uri] != want {
+		t.Fatalf("got %q want %q", contents[uri], want)
 	}
 }

--- a/forst/cmd/forst/lsp/server.go
+++ b/forst/cmd/forst/lsp/server.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"forst/internal/ast"
+	"forst/internal/httpbody"
 	"forst/internal/goload"
 	"forst/internal/lexer"
 	"forst/internal/parser"
@@ -70,6 +70,9 @@ type LSPServer struct {
 
 	// packageAnalysis caches merged same-package snapshots by content fingerprint (bounded LRU).
 	packageAnalysis *packageAnalysisLRU
+
+	// maxRequestBodyBytes caps POST body size; 0 uses httpbody.DefaultMaxBytes.
+	maxRequestBodyBytes int64
 }
 
 // peerAnalysisCacheEntry is a content-keyed snapshot for same-package peer buffers (completion only).
@@ -175,9 +178,17 @@ func (s *LSPServer) handleLSP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read request body
-	body, err := io.ReadAll(r.Body)
+	maxBody := s.maxRequestBodyBytes
+	if maxBody <= 0 {
+		maxBody = httpbody.DefaultMaxBytes
+	}
+	body, err := httpbody.ReadAll(r.Body, maxBody)
 	if err != nil {
+		if httpbody.IsTooLarge(err) {
+			s.log.Warn("LSP request body too large")
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		s.log.Errorf("Failed to read request body: %v", err)
 		http.Error(w, "Failed to read request", http.StatusBadRequest)
 		return

--- a/forst/cmd/forst/lsp/server_http_test.go
+++ b/forst/cmd/forst/lsp/server_http_test.go
@@ -1,0 +1,59 @@
+package lsp
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"forst/internal/httpbody"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestHandleLSP_rejectsOversizedBody(t *testing.T) {
+	s := NewLSPServer("8080", logrus.New())
+	s.maxRequestBodyBytes = 32
+
+	body := strings.Repeat("x", 64)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	s.handleLSP(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status=%d want 413 body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleLSP_acceptsBodyUnderLimit(t *testing.T) {
+	s := NewLSPServer("8080", logrus.New())
+	s.maxRequestBodyBytes = 1024
+
+	payload := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload))
+	rr := httptest.NewRecorder()
+
+	s.handleLSP(rr, req)
+
+	if rr.Code == http.StatusRequestEntityTooLarge {
+		t.Fatalf("unexpected 413 for small body")
+	}
+}
+
+func TestReadAll_usesDefaultWhenLSPServerMaxZero(t *testing.T) {
+	_, err := httpbody.ReadAll(bytes.NewReader([]byte("ok")), 0)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+}
+
+func TestLimitReader_interface(t *testing.T) {
+	r := httpbody.LimitReader(strings.NewReader("ab"), 1)
+	_, err := io.ReadAll(r)
+	if err == nil || !httpbody.IsTooLarge(err) {
+		t.Fatalf("expected too large, got %v", err)
+	}
+}

--- a/forst/internal/compiler/package.go
+++ b/forst/internal/compiler/package.go
@@ -2,7 +2,7 @@ package compiler
 
 import (
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -12,6 +12,7 @@ import (
 	"forst/internal/goload"
 	"forst/internal/lexer"
 	"forst/internal/parser"
+	"forst/internal/safefs"
 
 	"github.com/sirupsen/logrus"
 )
@@ -27,17 +28,27 @@ func (c *Compiler) goWorkspaceDirForCheck() string {
 // collectSamePackageFtPaths finds all .ft files under rootDir that declare the same package
 // as entryPath (parsed). Paths are sorted for stable merges.
 func collectSamePackageFtPaths(log *logrus.Logger, rootDir, entryPath string) ([]string, error) {
-	entryNodes, err := forstpkg.ParseForstFile(log, entryPath)
+	rootDir = filepath.Clean(rootDir)
+	root, err := safefs.OpenRoot(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("open package root: %w", err)
+	}
+	defer root.Close()
+
+	entryRel, err := root.RelPath(entryPath)
+	if err != nil {
+		return nil, fmt.Errorf("entry file must be under -root: %w", err)
+	}
+	entryNodes, err := forstpkg.ParseForstFileFromRoot(log, root, entryRel, entryPath)
 	if err != nil {
 		return nil, fmt.Errorf("parse entry file: %w", err)
 	}
 	pkg := forstpkg.PackageNameOrDefault(forstpkg.PackageNameFromNodes(entryNodes))
 
-	rootDir = filepath.Clean(rootDir)
 	var out []string
-	err = filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
+	err = fs.WalkDir(root.FS(), ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
 		if d.IsDir() {
 			return nil
@@ -45,12 +56,13 @@ func collectSamePackageFtPaths(log *logrus.Logger, rootDir, entryPath string) ([
 		if !strings.HasSuffix(strings.ToLower(path), ".ft") {
 			return nil
 		}
-		nodes, err := forstpkg.ParseForstFile(log, path)
+		absPath := root.AbsPath(path)
+		nodes, err := forstpkg.ParseForstFileFromRoot(log, root, path, absPath)
 		if err != nil {
 			return nil
 		}
 		if forstpkg.PackageNameOrDefault(forstpkg.PackageNameFromNodes(nodes)) == pkg {
-			out = append(out, path)
+			out = append(out, absPath)
 		}
 		return nil
 	})

--- a/forst/internal/forstpkg/forstpkg.go
+++ b/forst/internal/forstpkg/forstpkg.go
@@ -8,6 +8,7 @@ import (
 	"forst/internal/ast"
 	"forst/internal/lexer"
 	"forst/internal/parser"
+	"forst/internal/safefs"
 
 	"github.com/sirupsen/logrus"
 )
@@ -33,6 +34,30 @@ func ParseForstFile(log *logrus.Logger, path string) (nodes []ast.Node, err erro
 	l := lexer.New(source, path, log)
 	tokens := l.Lex()
 	psr := parser.New(tokens, path, log)
+	return psr.ParseFile()
+}
+
+// ParseForstFileFromRoot reads and parses a .ft file relative to root.
+// displayPath is used in diagnostics (typically the absolute path).
+func ParseForstFileFromRoot(log *logrus.Logger, root *safefs.RootedFS, relPath, displayPath string) (nodes []ast.Node, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if pe, ok := r.(*parser.ParseError); ok {
+				err = pe
+				nodes = nil
+				return
+			}
+			err = fmt.Errorf("parse panic in %s: %v", displayPath, r)
+			nodes = nil
+		}
+	}()
+	source, err := root.ReadFile(relPath)
+	if err != nil {
+		return nil, err
+	}
+	l := lexer.New(source, displayPath, log)
+	tokens := l.Lex()
+	psr := parser.New(tokens, displayPath, log)
 	return psr.ParseFile()
 }
 

--- a/forst/internal/forstpkg/forstpkg_test.go
+++ b/forst/internal/forstpkg/forstpkg_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"forst/internal/ast"
+	"forst/internal/safefs"
 
 	"github.com/sirupsen/logrus"
 )
@@ -84,6 +85,45 @@ func main() {
 	}
 	if PackageNameFromNodes(nodes) != "main" {
 		t.Fatalf("package name: %#v", nodes)
+	}
+}
+
+func TestParseForstFileFromRoot(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	absPath := filepath.Join(dir, "scoped.ft")
+	const content = `package demo
+
+func F(): Int {
+	return 1
+}
+`
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root, err := safefs.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	log := logrus.New()
+	log.SetOutput(nil)
+	nodes, err := ParseForstFileFromRoot(log, root, "scoped.ft", absPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if PackageNameFromNodes(nodes) != "demo" {
+		t.Fatalf("package: %#v", nodes)
+	}
+	var fnCount int
+	for _, n := range nodes {
+		if _, ok := n.(ast.FunctionNode); ok {
+			fnCount++
+		}
+	}
+	if fnCount != 1 {
+		t.Fatalf("expected one function, got %d nodes", fnCount)
 	}
 }
 

--- a/forst/internal/httpbody/httpbody.go
+++ b/forst/internal/httpbody/httpbody.go
@@ -1,0 +1,42 @@
+// Package httpbody provides helpers to read HTTP request bodies with a byte limit.
+package httpbody
+
+import (
+	"io"
+	"net/http"
+	"strings"
+)
+
+// DefaultMaxBytes is the default maximum request body size (10MB).
+const DefaultMaxBytes = 10 * 1024 * 1024
+
+// normalizeMaxBytes returns maxBytes when positive, otherwise DefaultMaxBytes.
+func normalizeMaxBytes(maxBytes int64) int64 {
+	if maxBytes <= 0 {
+		return DefaultMaxBytes
+	}
+	return maxBytes
+}
+
+// LimitReader wraps r so reads past maxBytes fail.
+// maxBytes <= 0 uses DefaultMaxBytes (never unlimited for untrusted HTTP).
+func LimitReader(r io.Reader, maxBytes int64) io.Reader {
+	rc, ok := r.(io.ReadCloser)
+	if !ok {
+		rc = io.NopCloser(r)
+	}
+	return http.MaxBytesReader(nil, rc, normalizeMaxBytes(maxBytes))
+}
+
+// ReadAll reads from r up to maxBytes.
+func ReadAll(r io.Reader, maxBytes int64) ([]byte, error) {
+	return io.ReadAll(LimitReader(r, maxBytes))
+}
+
+// IsTooLarge reports whether err is from exceeding the MaxBytesReader limit.
+func IsTooLarge(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "http: request body too large")
+}

--- a/forst/internal/httpbody/httpbody_test.go
+++ b/forst/internal/httpbody/httpbody_test.go
@@ -1,0 +1,66 @@
+package httpbody
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadAll_underLimit(t *testing.T) {
+	data := []byte("hello")
+	got, err := ReadAll(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("got %q want %q", got, data)
+	}
+}
+
+func TestReadAll_exactLimit(t *testing.T) {
+	data := []byte("abc")
+	got, err := ReadAll(bytes.NewReader(data), 3)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("got %q want %q", got, data)
+	}
+}
+
+func TestReadAll_overLimit(t *testing.T) {
+	data := []byte("abcd")
+	_, err := ReadAll(bytes.NewReader(data), 3)
+	if err == nil {
+		t.Fatal("expected error for over-limit body")
+	}
+	if !IsTooLarge(err) {
+		t.Fatalf("IsTooLarge=false for %v", err)
+	}
+}
+
+func TestReadAll_zeroMaxUsesDefault(t *testing.T) {
+	// Default is 10MB; a small body should succeed.
+	_, err := ReadAll(bytes.NewReader([]byte("x")), 0)
+	if err != nil {
+		t.Fatalf("ReadAll with max 0: %v", err)
+	}
+}
+
+func TestLimitReader_overLimit(t *testing.T) {
+	r := LimitReader(strings.NewReader("too long"), 3)
+	_, err := io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected limit error")
+	}
+	if !IsTooLarge(err) {
+		t.Fatalf("IsTooLarge=false for %v", err)
+	}
+}
+
+func TestIsTooLarge_nil(t *testing.T) {
+	if IsTooLarge(nil) {
+		t.Fatal("nil should not be too large")
+	}
+}

--- a/forst/internal/safefs/safefs.go
+++ b/forst/internal/safefs/safefs.go
@@ -1,0 +1,84 @@
+// Package safefs provides symlink-safe filesystem access confined to a directory root.
+package safefs
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RootedFS confines file operations to one directory tree using os.Root.
+type RootedFS struct {
+	root    *os.Root
+	absRoot string
+}
+
+// OpenRoot opens absRoot as the filesystem root. absRoot must be an existing directory.
+func OpenRoot(absRoot string) (*RootedFS, error) {
+	abs, err := filepath.Abs(absRoot)
+	if err != nil {
+		return nil, err
+	}
+	abs = filepath.Clean(abs)
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("safefs: not a directory: %s", abs)
+	}
+	root, err := os.OpenRoot(abs)
+	if err != nil {
+		return nil, err
+	}
+	return &RootedFS{root: root, absRoot: abs}, nil
+}
+
+// AbsRoot returns the absolute root directory path.
+func (r *RootedFS) AbsRoot() string {
+	return r.absRoot
+}
+
+// Close releases the root.
+func (r *RootedFS) Close() error {
+	return r.root.Close()
+}
+
+// FS returns an fs.FS for the tree under the root (symlink-safe walks).
+func (r *RootedFS) FS() fs.FS {
+	return r.root.FS()
+}
+
+// ReadFile reads a file relative to the root.
+func (r *RootedFS) ReadFile(rel string) ([]byte, error) {
+	return fs.ReadFile(r.root.FS(), filepath.ToSlash(rel))
+}
+
+// Stat returns file info for a path relative to the root.
+func (r *RootedFS) Stat(rel string) (fs.FileInfo, error) {
+	return fs.Stat(r.root.FS(), filepath.ToSlash(rel))
+}
+
+// RelPath returns a slash-separated relative path when absPath is under the root.
+func (r *RootedFS) RelPath(absPath string) (string, error) {
+	abs, err := filepath.Abs(absPath)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	rel, err := filepath.Rel(r.absRoot, abs)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is outside root %q", abs, r.absRoot)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+// AbsPath joins absRoot with a slash-separated relative path from FS walks.
+func (r *RootedFS) AbsPath(rel string) string {
+	return filepath.Join(r.absRoot, filepath.FromSlash(rel))
+}

--- a/forst/internal/safefs/safefs_test.go
+++ b/forst/internal/safefs/safefs_test.go
@@ -1,0 +1,168 @@
+package safefs
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenRoot_readInside(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.ft")
+	if err := os.WriteFile(path, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, err := OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	if got := r.AbsRoot(); got != filepath.Clean(dir) {
+		t.Fatalf("AbsRoot=%q want %q", got, filepath.Clean(dir))
+	}
+
+	b, err := r.ReadFile("a.ft")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(b) != "package main\n" {
+		t.Fatalf("got %q", b)
+	}
+
+	info, err := r.Stat("a.ft")
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Name() != "a.ft" {
+		t.Fatalf("Stat name=%q", info.Name())
+	}
+}
+
+func TestOpenRoot_notDirectory(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := OpenRoot(file)
+	if err == nil {
+		t.Fatal("expected error opening file as root")
+	}
+}
+
+func TestOpenRoot_escapeDotDot(t *testing.T) {
+	dir := t.TempDir()
+	r, err := OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	_, err = r.ReadFile("../outside")
+	if err == nil {
+		t.Fatal("expected error reading outside root via ..")
+	}
+}
+
+func TestRelPath_insideAndOutside(t *testing.T) {
+	dir := t.TempDir()
+	r, err := OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	inside := filepath.Join(dir, "sub", "file.ft")
+	if err := os.MkdirAll(filepath.Dir(inside), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rel, err := r.RelPath(inside)
+	if err != nil {
+		t.Fatalf("RelPath inside: %v", err)
+	}
+	if rel != "sub/file.ft" && rel != "sub\\file.ft" {
+		// RelPath returns ToSlash
+		if filepath.ToSlash(rel) != "sub/file.ft" {
+			t.Fatalf("rel=%q", rel)
+		}
+	}
+
+	outside := filepath.Join(filepath.Dir(dir), "outside.ft")
+	_, err = r.RelPath(outside)
+	if err == nil {
+		t.Fatal("expected error for path outside root")
+	}
+}
+
+func TestWalkDir_collectsFt(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "pkg")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "a.ft"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	var ftPaths []string
+	err = fs.WalkDir(r.FS(), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(strings.ToLower(path), ".ft") {
+			ftPaths = append(ftPaths, r.AbsPath(path))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
+	if len(ftPaths) != 1 {
+		t.Fatalf("expected 1 .ft file, got %v", ftPaths)
+	}
+	want := filepath.Join(dir, "pkg", "a.ft")
+	if ftPaths[0] != want {
+		t.Fatalf("AbsPath via walk: got %q want %q", ftPaths[0], want)
+	}
+}
+
+func TestSymlinkEscape_unix(t *testing.T) {
+	if os.Getenv("GOOS") == "windows" {
+		t.Skip("symlink escape test on unix")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+	outsideFile := filepath.Join(outside, "secret")
+	if err := os.WriteFile(outsideFile, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(outsideFile, link); err != nil {
+		t.Skip("symlink not permitted")
+	}
+
+	r, err := OpenRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	_, err = r.ReadFile("link")
+	if err == nil {
+		t.Fatal("expected symlink escape to be blocked")
+	}
+}


### PR DESCRIPTION
Add `internal/httpbody` to enforce `Server.MaxRequestSize` on dev-server `/invoke` and LSP POST (413 when over limit; default 10MB). Clamp non-positive `maxRequestSize` at config load.

Add `internal/safefs` (`os.Root`) for symlink-safe reads and walks in compiler package discovery, ftconfig `FindForstFiles`, forstpkg `ParseForstFileFromRoot`, and LSP disk fallbacks.

Example (`ftconfig.json` — existing field now enforced):

```json
{
  "server": {
    "maxRequestSize": 10485760
  }
}
```

Oversized `POST /invoke` bodies receive HTTP 413; LSP uses the same default cap when no server config is wired.