### PR TITLE
refactor: synctest watch debounce and Go 1.26 stdlib cleanups

### DIFF
--- a/forst/cmd/forst/dev_server.go
+++ b/forst/cmd/forst/dev_server.go
@@ -39,9 +39,9 @@ type InvokeRequest struct {
 // DevServerResponse represents a response to the client
 type DevServerResponse struct {
 	Success bool            `json:"success"`
-	Output  string          `json:"output,omitempty"`
-	Error   string          `json:"error,omitempty"`
-	Result  json.RawMessage `json:"result,omitempty"`
+	Output  string          `json:"output,omitzero"`
+	Error   string          `json:"error,omitzero"`
+	Result  json.RawMessage `json:"result,omitzero"`
 }
 
 // DevServer handles HTTP communication for Forst applications

--- a/forst/cmd/forst/lsp/server.go
+++ b/forst/cmd/forst/lsp/server.go
@@ -29,22 +29,22 @@ type LSPRequest struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      any             `json:"id"`
 	Method  string          `json:"method"`
-	Params  json.RawMessage `json:"params,omitempty"`
+	Params  json.RawMessage `json:"params,omitzero"`
 }
 
 // LSPResponse represents an LSP response
 type LSPServerResponse struct {
 	JSONRPC string    `json:"jsonrpc"`
 	ID      any       `json:"id"`
-	Result  any       `json:"result,omitempty"`
-	Error   *LSPError `json:"error,omitempty"`
+	Result  any       `json:"result,omitzero"`
+	Error   *LSPError `json:"error,omitzero"`
 }
 
 // LSPError represents an LSP error
 type LSPError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
-	Data    any    `json:"data,omitempty"`
+	Data    any    `json:"data,omitzero"`
 }
 
 // LSPServer represents the LSP server

--- a/forst/internal/ast/shape_format.go
+++ b/forst/internal/ast/shape_format.go
@@ -1,6 +1,9 @@
 package ast
 
-import "sort"
+import (
+	"maps"
+	"slices"
+)
 
 // FormatShapeMemberName formats one shape field for typedef / contract source emission.
 // Method contracts omit the colon: `info(msg String)`. Data fields use `name: rhs`.
@@ -21,12 +24,7 @@ func ShapeFieldNamesInOrder(fields map[string]ShapeFieldNode, fieldOrder []strin
 	if len(fieldOrder) > 0 {
 		return fieldOrder
 	}
-	names := make([]string, 0, len(fields))
-	for name := range fields {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
+	return slices.Sorted(maps.Keys(fields))
 }
 
 // ShapeFieldNamesForCompositeEmit orders payload fields for Go composite literals: shape
@@ -49,7 +47,7 @@ func ShapeFieldNamesForCompositeEmit(payloadFields map[string]ShapeFieldNode, sh
 			}
 			rest = append(rest, name)
 		}
-		sort.Strings(rest)
+		slices.Sort(rest)
 		return append(out, rest...)
 	}
 	return ShapeFieldNamesInOrder(payloadFields, nil)

--- a/forst/internal/compiler/watch.go
+++ b/forst/internal/compiler/watch.go
@@ -40,10 +40,7 @@ func (c *Compiler) WatchFile() error {
 			if event.Op&fsnotify.Write != fsnotify.Write {
 				continue
 			}
-			if debounceTimer != nil {
-				debounceTimer.Stop()
-			}
-			debounceTimer = time.AfterFunc(100*time.Millisecond, func() {
+			watchDebounce(&debounceTimer, 100*time.Millisecond, func() {
 				c.log.Info("File changed, recompiling...")
 				c.compileAndRunOnce()
 			})
@@ -51,6 +48,13 @@ func (c *Compiler) WatchFile() error {
 			c.log.Error("Error watching file:", err)
 		}
 	}
+}
+
+func watchDebounce(timer **time.Timer, d time.Duration, fn func()) {
+	if *timer != nil {
+		(*timer).Stop()
+	}
+	*timer = time.AfterFunc(d, fn)
 }
 
 func (c *Compiler) validateWatchConfig() error {

--- a/forst/internal/compiler/watch_test.go
+++ b/forst/internal/compiler/watch_test.go
@@ -4,8 +4,38 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
+	"time"
 )
+
+func TestWatchDebounce_synctest(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var timer *time.Timer
+		var count atomic.Int32
+		watchDebounce(&timer, 100*time.Millisecond, func() { count.Add(1) })
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+		if count.Load() != 1 {
+			t.Fatalf("after first debounce count=%d want 1", count.Load())
+		}
+
+		count.Store(0)
+		watchDebounce(&timer, 100*time.Millisecond, func() { count.Add(1) })
+		watchDebounce(&timer, 100*time.Millisecond, func() { count.Add(1) })
+		time.Sleep(50 * time.Millisecond)
+		synctest.Wait()
+		if count.Load() != 0 {
+			t.Fatalf("after reschedule before fire count=%d want 0", count.Load())
+		}
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+		if count.Load() != 1 {
+			t.Fatalf("after reschedule count=%d want 1", count.Load())
+		}
+	})
+}
 
 func TestWatchFile_rejectsPackageRoot(t *testing.T) {
 	c := New(Args{

--- a/forst/internal/discovery/discovery.go
+++ b/forst/internal/discovery/discovery.go
@@ -30,13 +30,13 @@ type FunctionInfo struct {
 	ReturnTypes        []string        `json:"returnTypes"`        // Track all return types
 	HasMultipleReturns bool            `json:"hasMultipleReturns"` // Whether function returns multiple values
 	// Providers lists root contract idents in Providers(f) (ordered); empty when runnable.
-	Providers []string `json:"providers,omitempty"`
+	Providers []string `json:"providers,omitzero"`
 	// Runnable is true iff Providers(f) is empty — eligible for TS/sidecar export.
-	Runnable bool `json:"runnable,omitempty"`
+	Runnable bool `json:"runnable,omitzero"`
 	// IsResult and the result* fields apply when the sole return type is Result(Success, Failure).
-	IsResult          bool   `json:"isResult,omitempty"`
-	ResultSuccessType string `json:"resultSuccessType,omitempty"`
-	ResultFailureType string `json:"resultFailureType,omitempty"`
+	IsResult          bool   `json:"isResult,omitzero"`
+	ResultSuccessType string `json:"resultSuccessType,omitzero"`
+	ResultFailureType string `json:"resultFailureType,omitzero"`
 	FilePath          string `json:"filePath"`
 }
 

--- a/forst/internal/printer/printer.go
+++ b/forst/internal/printer/printer.go
@@ -3,7 +3,8 @@ package printer
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 
 	"forst/internal/ast"
@@ -1029,12 +1030,7 @@ func shapeFieldNamesForPrint(s ast.ShapeNode) []string {
 }
 
 func sortedShapeFieldNames(fields map[string]ast.ShapeFieldNode) []string {
-	names := make([]string, 0, len(fields))
-	for name := range fields {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
+	return slices.Sorted(maps.Keys(fields))
 }
 
 func (p *printer) printShape(s ast.ShapeNode) (string, error) {

--- a/forst/internal/transformer/ts/type_mapping.go
+++ b/forst/internal/transformer/ts/type_mapping.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"forst/internal/ast"
 	"forst/internal/typechecker"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 )
 
@@ -56,12 +57,7 @@ func sortedFieldNames(fields map[string]ast.ShapeFieldNode) []string {
 	if len(fields) == 0 {
 		return nil
 	}
-	names := make([]string, 0, len(fields))
-	for n := range fields {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	return names
+	return slices.Sorted(maps.Keys(fields))
 }
 
 // extractInlineShapeFromAssertion returns a nested shape from parser/typechecker


### PR DESCRIPTION
Extract `watchDebounce` from `WatchFile` and add `TestWatchDebounce_synctest` using `testing/synctest` to verify timer reschedule cancels a pending fire.

Replace manual map-key collection with `slices.Sorted(maps.Keys(...))` in shape field ordering (ast, printer, TS type mapping). Switch optional JSON fields to omitzero on dev server responses, discovery FunctionInfo, and LSP wire structs.

Example:
```go
return slices.Sorted(maps.Keys(fields))
```