### PR TITLE
feat(lsp): show hover for Go predeclared builtins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,5 @@ z_forst_gen_test.go
 
 # Local release backfill artifacts (never commit checksum files)
 scripts/backfill/
+
+.tmp/

--- a/forst/cmd/forst/lsp/hover_completion.go
+++ b/forst/cmd/forst/lsp/hover_completion.go
@@ -372,6 +372,9 @@ func hoverTextForToken(tc *typechecker.TypeChecker, tokens []ast.Token, tok *ast
 		if doc := guardIdentifierHoverMarkdown(tc, tokens, tok); doc != "" {
 			return doc
 		}
+		if md, ok := tc.GoHoverMarkdownPredeclaredBuiltin(tok.Value); ok && md != "" {
+			return md
+		}
 		vn := ast.VariableNode{
 			Ident: ast.Ident{ID: id, Span: ast.SpanFromToken(*tok)},
 		}

--- a/forst/cmd/forst/lsp/hover_completion_test.go
+++ b/forst/cmd/forst/lsp/hover_completion_test.go
@@ -270,6 +270,33 @@ func TestHoverTextForToken_builtinTypeNameIdentifier(t *testing.T) {
 	}
 }
 
+func TestHoverTextForToken_goPredeclaredLen(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	log.SetLevel(logrus.PanicLevel)
+	tc := typechecker.New(log, false)
+	if _, ok := tc.GoHoverMarkdownPredeclaredBuiltin("len"); !ok {
+		t.Skip("GOROOT builtin package not available")
+	}
+	tokens := []ast.Token{
+		{Type: ast.TokenIdentifier, Value: "println", Line: 1, Column: 1},
+		{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 8},
+		{Type: ast.TokenIdentifier, Value: "len", Line: 1, Column: 9},
+		{Type: ast.TokenLParen, Value: "(", Line: 1, Column: 12},
+		{Type: ast.TokenIdentifier, Value: "s", Line: 1, Column: 13},
+		{Type: ast.TokenRParen, Value: ")", Line: 1, Column: 14},
+		{Type: ast.TokenRParen, Value: ")", Line: 1, Column: 15},
+	}
+	tok := &tokens[2]
+	s := hoverTextForToken(tc, tokens, tok, nil)
+	if !strings.Contains(s, "predeclared `len`") {
+		t.Fatalf("expected predeclared len hover, got %q", s)
+	}
+	if !strings.Contains(s, "func len(") {
+		t.Fatalf("expected Go signature, got %q", s)
+	}
+}
+
 func TestHoverTextForToken_nilKeyword(t *testing.T) {
 	t.Parallel()
 	tc := typechecker.New(logrus.New(), false)

--- a/forst/internal/typechecker/builtin_doc.go
+++ b/forst/internal/typechecker/builtin_doc.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	goast "go/ast"
 	"go/doc"
+	"go/format"
+	"go/parser"
+	"go/token"
 	"go/types"
 	"strings"
 	"sync"
@@ -14,10 +17,17 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
+type builtinDocLoad struct {
+	docPkg   *doc.Package
+	goPkg    *packages.Package
+	rawFset  *token.FileSet
+	rawFiles []*goast.File
+}
+
 var (
-	builtinGoDocOnce sync.Once
-	builtinGoDocPkg  *doc.Package
-	builtinGoDocErr  error
+	builtinGoDocOnce  sync.Once
+	builtinDocCache   builtinDocLoad
+	builtinGoDocErr   error
 )
 
 // loadBuiltinGoDocPackage parses package builtin (Go's documented predeclared identifiers) via
@@ -35,18 +45,18 @@ func loadBuiltinGoDocPackage(log *logrus.Logger) (*doc.Package, error) {
 			}
 			return
 		}
-		if packages.PrintErrors(pkgs) > 0 {
+		if len(pkgs) == 0 || pkgs[0] == nil {
+			builtinGoDocErr = fmt.Errorf("no package builtin")
+			return
+		}
+		p := pkgs[0]
+		if packages.PrintErrors(pkgs) > 0 && len(p.Syntax) == 0 {
 			builtinGoDocErr = fmt.Errorf("load package builtin")
 			if log != nil {
 				log.WithError(builtinGoDocErr).Debug("load builtin package for doc")
 			}
 			return
 		}
-		if len(pkgs) == 0 || pkgs[0] == nil {
-			builtinGoDocErr = fmt.Errorf("no package builtin")
-			return
-		}
-		p := pkgs[0]
 		paths := p.CompiledGoFiles
 		if len(paths) == 0 {
 			paths = p.GoFiles
@@ -76,12 +86,125 @@ func loadBuiltinGoDocPackage(log *logrus.Logger) (*doc.Package, error) {
 			}
 			return
 		}
-		builtinGoDocPkg = docPkg
+		rawFset := token.NewFileSet()
+		rawFiles := make([]*goast.File, 0, len(paths))
+		for _, path := range paths {
+			if strings.HasSuffix(path, "_test.go") {
+				continue
+			}
+			rawFile, err := parser.ParseFile(rawFset, path, nil, parser.ParseComments)
+			if err != nil {
+				builtinGoDocErr = err
+				if log != nil {
+					log.WithError(err).Debug("parser.ParseFile for package builtin")
+				}
+				return
+			}
+			rawFiles = append(rawFiles, rawFile)
+		}
+		builtinDocCache = builtinDocLoad{
+			docPkg:   docPkg,
+			goPkg:    p,
+			rawFset:  rawFset,
+			rawFiles: rawFiles,
+		}
 	})
 	if builtinGoDocErr != nil {
 		return nil, builtinGoDocErr
 	}
-	return builtinGoDocPkg, nil
+	return builtinDocCache.docPkg, nil
+}
+
+// builtinGoFuncDoc returns documentation and a Go signature string for a predeclared builtin
+// function name from package builtin (go/doc first, then go/ast FuncDecl fallback).
+func builtinGoFuncDoc(log *logrus.Logger, name string) (docText, sigGo string, ok bool) {
+	if name == "" {
+		return "", "", false
+	}
+	docPkg, err := loadBuiltinGoDocPackage(log)
+	if err != nil || docPkg == nil {
+		return "", "", false
+	}
+	for _, f := range docPkg.Funcs {
+		if f.Name != name {
+			continue
+		}
+		docText = strings.TrimSpace(f.Doc)
+		if f.Decl != nil {
+			sigGo = formatFuncDeclSignature(builtinDocCache.goPkg.Fset, f.Decl)
+		}
+		if docText != "" || sigGo != "" {
+			return docText, sigGo, true
+		}
+	}
+	rawFset := builtinDocCache.rawFset
+	for _, f := range builtinDocCache.rawFiles {
+		if f == nil {
+			continue
+		}
+		for _, d := range f.Decls {
+			fd, isFunc := d.(*goast.FuncDecl)
+			if !isFunc || fd.Name == nil || fd.Name.Name != name {
+				continue
+			}
+			docText, sigGo = formatBuiltinFuncDecl(rawFset, f, fd)
+			if docText != "" || sigGo != "" {
+				return docText, sigGo, true
+			}
+		}
+	}
+	return "", "", false
+}
+
+func formatBuiltinFuncDecl(fset *token.FileSet, f *goast.File, fd *goast.FuncDecl) (docText, sigGo string) {
+	if fset == nil || fd == nil {
+		return "", ""
+	}
+	docText = docCommentForFuncDecl(f, fd)
+	sigGo = formatFuncDeclSignature(fset, fd)
+	return docText, sigGo
+}
+
+func formatFuncDeclSignature(fset *token.FileSet, fd *goast.FuncDecl) string {
+	if fset == nil || fd == nil {
+		return ""
+	}
+	var b strings.Builder
+	if err := format.Node(&b, fset, fd); err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(b.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "func ") {
+			return line
+		}
+	}
+	return ""
+}
+
+func docCommentForFuncDecl(f *goast.File, fd *goast.FuncDecl) string {
+	if fd == nil {
+		return ""
+	}
+	if fd.Doc != nil {
+		return strings.TrimSpace(fd.Doc.Text())
+	}
+	if f == nil {
+		return ""
+	}
+	declPos := fd.Pos()
+	var best *goast.CommentGroup
+	for _, cg := range f.Comments {
+		if cg.End() < declPos {
+			if best == nil || cg.End() > best.End() {
+				best = cg
+			}
+		}
+	}
+	if best == nil || declPos-best.End() > 1 {
+		return ""
+	}
+	return strings.TrimSpace(best.Text())
 }
 
 // builtinGoDocParagraph returns documentation text from the builtin package for a predeclared type

--- a/forst/internal/typechecker/builtin_doc_test.go
+++ b/forst/internal/typechecker/builtin_doc_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func TestBuiltinGoFuncDoc_len(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	if _, err := loadBuiltinGoDocPackage(log); err != nil {
+		t.Skip("GOROOT builtin package not available:", err)
+	}
+	docText, sig, ok := builtinGoFuncDoc(log, "len")
+	if !ok {
+		t.Fatal("expected len in package builtin")
+	}
+	if docText == "" {
+		t.Fatal("expected doc text for len")
+	}
+	if !strings.Contains(sig, "func len(") {
+		t.Fatalf("sig = %q", sig)
+	}
+}
+
 func TestForstBuiltinReceiverGoType_errorAndScalars(t *testing.T) {
 	t.Parallel()
 	if _, name, ok := forstBuiltinReceiverGoType(ast.TypeNode{Ident: ast.TypeError}); !ok || name != "error" {

--- a/forst/internal/typechecker/go_hover.go
+++ b/forst/internal/typechecker/go_hover.go
@@ -237,6 +237,47 @@ func (tc *TypeChecker) GoHoverMarkdownForForstReceiverMethod(receiverType ast.Ty
 	return b.String(), true
 }
 
+// GoHoverMarkdownPredeclaredBuiltin returns hover for a bare predeclared Go builtin call name
+// (e.g. len, min) when it is registered in BuiltinFunctions with an empty Package.
+// Documentation and signatures come from Go's package builtin via go/doc and go/ast.
+func (tc *TypeChecker) GoHoverMarkdownPredeclaredBuiltin(name string) (string, bool) {
+	if tc == nil || name == "" {
+		return "", false
+	}
+	bfn, ok := BuiltinFunctions[name]
+	if !ok || bfn.Package != "" {
+		return "", false
+	}
+	docText, sigGo, ok := builtinGoFuncDoc(tc.log, name)
+	if !ok {
+		return "", false
+	}
+	if docText != "" {
+		var cdocParser comment.Parser
+		var pr comment.Printer
+		docText = strings.TrimSpace(string(pr.Markdown(cdocParser.Parse(docText))))
+	}
+
+	var b strings.Builder
+	b.WriteString("**Go** (predeclared `")
+	b.WriteString(name)
+	b.WriteString("` — [package builtin](https://pkg.go.dev/builtin))\n\n")
+	if docText != "" {
+		b.WriteString(docText)
+		b.WriteString("\n\n")
+	}
+	if sigGo != "" {
+		b.WriteString("```go\n")
+		b.WriteString(sigGo)
+		b.WriteString("\n```\n\n")
+	}
+	b.WriteString("**Forst return** `")
+	b.WriteString(tc.FormatTypeNodeDisplay(bfn.ReturnType))
+	b.WriteString("`")
+
+	return b.String(), true
+}
+
 func goSignatureReturnsToForst(sig *types.Signature) []ast.TypeNode {
 	res := sig.Results()
 	if res.Len() == 0 {

--- a/forst/internal/typechecker/go_hover_test.go
+++ b/forst/internal/typechecker/go_hover_test.go
@@ -198,6 +198,66 @@ func TestGoHoverMarkdownForForstReceiverMethod_wrongReceiver(t *testing.T) {
 	}
 }
 
+func TestGoHoverMarkdownPredeclaredBuiltin_len(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	log.SetLevel(logrus.PanicLevel)
+	if _, err := loadBuiltinGoDocPackage(log); err != nil {
+		t.Skip("GOROOT builtin package not available:", err)
+	}
+	tc := New(log, false)
+	md, ok := tc.GoHoverMarkdownPredeclaredBuiltin("len")
+	if !ok {
+		t.Fatal("expected hover for predeclared len")
+	}
+	if !strings.Contains(md, "predeclared `len`") {
+		t.Fatalf("expected predeclared len header, got %q", md)
+	}
+	if !strings.Contains(md, "pkg.go.dev/builtin") {
+		t.Fatalf("expected link to package builtin docs, got %q", md)
+	}
+	if !strings.Contains(strings.ToLower(md), "built-in") {
+		t.Fatalf("expected built-in doc excerpt, got %q", md)
+	}
+	if !strings.Contains(md, "func len(") {
+		t.Fatalf("expected Go signature for len, got %q", md)
+	}
+	if !strings.Contains(md, "**Forst return** `Int`") {
+		t.Fatalf("expected Forst Int return, got %q", md)
+	}
+}
+
+func TestGoHoverMarkdownPredeclaredBuiltin_min(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	log.SetLevel(logrus.PanicLevel)
+	if _, err := loadBuiltinGoDocPackage(log); err != nil {
+		t.Skip("GOROOT builtin package not available:", err)
+	}
+	tc := New(log, false)
+	md, ok := tc.GoHoverMarkdownPredeclaredBuiltin("min")
+	if !ok {
+		t.Fatal("expected hover for predeclared min")
+	}
+	if !strings.Contains(strings.ToLower(md), "ordered") {
+		t.Fatalf("expected ordered-type doc excerpt from Go, got %q", md)
+	}
+	if !strings.Contains(md, "func min[T") {
+		t.Fatalf("expected Go signature for min, got %q", md)
+	}
+}
+
+func TestGoHoverMarkdownPredeclaredBuiltin_unknownOrImported(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	if _, ok := tc.GoHoverMarkdownPredeclaredBuiltin("not_a_builtin"); ok {
+		t.Fatal("unexpected hover for unknown name")
+	}
+	if _, ok := tc.GoHoverMarkdownPredeclaredBuiltin("Println"); ok {
+		t.Fatal("fmt.Println local name should not match predeclared table")
+	}
+}
+
 func TestGoHoverMarkdown_packageOnly(t *testing.T) {
 	t.Parallel()
 	dir := moduleRootFromWD(t)


### PR DESCRIPTION
Load docs and signatures from Go's package builtin via go/doc and go/ast, then surface them in LSP hover for names registered as predeclared builtins (len, min, max, etc.). Includes Go doc text, signature, and Forst return type from the builtin registry.

Example:

```forst
func main(): Void {
  s: String = "ab"
  println(len(s))   // hover `len` → Go builtin docs + `Int` return
  println(min(1, 2))
}
```