### PR TITLE
feat(vscode-forst): publish extension to VS Code Marketplace

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -1,4 +1,5 @@
-# Build the VSIX, attach it to the GitHub Release, and publish to Open VSX.
+# Build the VSIX, attach it to the GitHub Release, publish to the VS Code Marketplace,
+# and publish to Open VSX.
 #
 # VSIX packaging uses `task build:vsix`: rewrites @forst/cli to a published semver, installs it from npm,
 # then restores package.json / bun.lockb (committed trees stay workspace:* for dev/CI).
@@ -9,8 +10,9 @@
 #
 # Tag prefix: `vscode-forst-` (packages/vscode-forst in .release-please-config.json).
 #
-# Secrets:
-# - OVSX_PAT: Open VSX publish token (optional; step skipped if unset).
+# Secrets (publish steps are skipped when unset):
+# - VSCE_PAT: Azure DevOps PAT with Marketplace → Manage scope for publisher forst
+# - OVSX_PAT: Open VSX publish token for publisher forst
 
 name: Publish VS Code extension
 
@@ -29,8 +31,8 @@ on:
         type: string
 
 jobs:
-  vsix-and-open-vsx:
-    name: VSIX + Open VSX
+  vsix-and-publish:
+    name: VSIX + Marketplace + Open VSX
     runs-on: ubuntu-latest
     if: startsWith(inputs.tag_name, 'vscode-forst-')
     permissions:
@@ -62,6 +64,20 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24.x"
+
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [ -z "${VSCE_PAT}" ]; then
+            echo "VSCE_PAT secret not set; skipping VS Code Marketplace publish."
+            echo "Create a PAT at https://dev.azure.com with Marketplace → Manage scope for publisher forst."
+            exit 0
+          fi
+          set -euo pipefail
+          VSIX=$(ls dist/forst-vscode-*.vsix | head -1)
+          test -f "${VSIX}"
+          npx --yes @vscode/vsce publish --packagePath "${VSIX}"
 
       - name: Publish to Open VSX
         env:

--- a/docs/resources/roadmap.mdx
+++ b/docs/resources/roadmap.mdx
@@ -63,7 +63,7 @@ Forst is under active development. This page is a **simplified** view. The canon
 | --- | --- | --- |
 | <Icon icon="circle-check" iconType="solid" size={16} color="#16A34A" /> | [`forst lsp` core (HTTP)](/workflow/editor) | Diagnostics, hover, completion, definition, references, rename, symbols, folding. |
 | <Icon icon="flask" iconType="solid" size={16} color="#7C3AED" /> | [LSP formatting and code lens](/workflow/editor) | Format document advertised; code lens and some code actions still minimal. |
-| <Icon icon="flask" iconType="solid" size={16} color="#7C3AED" /> | [VS Code extension](/workflow/editor) | In-repo extension on Open VSX; marketplace discoverability still open. |
+| <Icon icon="flask" iconType="solid" size={16} color="#7C3AED" /> | [VS Code extension](/workflow/editor) | Marketplace + Open VSX publish on `vscode-forst-v*` releases. |
 | <Icon icon="flask" iconType="solid" size={16} color="#7C3AED" /> | [`forst test`](/workflow/cli#forst-test) | Discover `Test*` in `*_test.ft`, emit Go tests and cross-package shims, run `go test`. Primary use: Providers wiring and cross-package integration. |
 | <Icon icon="circle-check" iconType="solid" size={16} color="#16A34A" /> | [CLI (`run`, `build`, `generate`, `dev`, `lsp`, `test`, `fmt`)](/workflow/cli) | Core compiler commands via native binary or `@forst/cli`. |
 | <Icon icon="flask" iconType="solid" size={16} color="#7C3AED" /> | Error message quality | Incremental improvements; diagnostics still vary by code path. |

--- a/docs/workflow/editor.mdx
+++ b/docs/workflow/editor.mdx
@@ -9,9 +9,9 @@ Use the **Forst VS Code extension** to edit `.ft` files with diagnostics, hover,
 
 ## 1. Install the extension
 
-Install [**Forst** on Open VSX](https://open-vsx.org/extension/forst/forst) in VS Code, Cursor, or another Open VSX compatible editor.
+In **VS Code**: **Extensions** → search **Forst** → **Install** ([Marketplace](https://marketplace.visualstudio.com/items?itemName=forst.forst)).
 
-In VS Code: **Extensions** → search **Forst** → **Install**. Or open the Open VSX page and click **Install**.
+In **Cursor**, **VSCodium**, or other Open VSX–compatible editors: install [**Forst on Open VSX](https://open-vsx.org/extension/forst/forst).
 
 ## 2. Open your project
 
@@ -63,8 +63,11 @@ Change these in **VS Code → Settings** when the defaults do not match your set
 ## Related
 
 <CardGroup cols={2}>
+  <Card title="Forst on Marketplace" icon="puzzle-piece" href="https://marketplace.visualstudio.com/items?itemName=forst.forst">
+    Install in VS Code.
+  </Card>
   <Card title="Forst on Open VSX" icon="puzzle-piece" href="https://open-vsx.org/extension/forst/forst">
-    Install or update the extension.
+    Install in Cursor, VSCodium, and other Open VSX editors.
   </Card>
   <Card title="CLI reference" icon="terminal" href="/workflow/cli">
     Run `forst` from the terminal, including `forst lsp`.

--- a/packages/vscode-forst/README.md
+++ b/packages/vscode-forst/README.md
@@ -68,8 +68,13 @@ When the extension activates, the status bar shows the configured LSP port (righ
 
 From the repo root: `task build:vscode` compiles this package. The same compile runs at the start of `task ci:test` (see [Taskfile.yml](../../Taskfile.yml)). GitHub Actions uses `package.json` `packageManager` with [setup-bun](https://github.com/oven-sh/setup-bun) to pin the Bun version.
 
-## Releases and Open VSX
+## Releases (VS Code Marketplace and Open VSX)
 
-The extension is versioned separately from the compiler: Release Please uses **`packages/vscode-forst`** and tags like **`vscode-forst-v0.0.19`**. When that GitHub Release is published, [`.github/workflows/publish-vscode-extension.yml`](../../.github/workflows/publish-vscode-extension.yml) builds `dist/forst-vscode-<version>.vsix`, uploads it to the release, and runs **`npx ovsx publish`** when the repository has an Actions secret **`OVSX_PAT`** (see [Auto publishing extensions](https://github.com/EclipseFdn/open-vsx.org/wiki/Auto-Publishing-Extensions)). If the secret is missing, Open VSX publish is skipped and the workflow still succeeds.
+The extension is versioned separately from the compiler: Release Please uses **`packages/vscode-forst`** and tags like **`vscode-forst-v0.0.19`**. When that GitHub Release is published, [`.github/workflows/publish-vscode-extension.yml`](../../.github/workflows/publish-vscode-extension.yml) builds `dist/forst-vscode-<version>.vsix`, uploads it to the release, and publishes the **same VSIX** to:
+
+- **VS Code Marketplace** when **`VSCE_PAT`** is set — Azure DevOps PAT with **Marketplace → Manage** for publisher **`forst`** ([create a PAT](https://dev.azure.com))
+- **Open VSX** when **`OVSX_PAT`** is set — publisher **`forst`** ([Open VSX token](https://open-vsx.org); see [Auto publishing extensions](https://github.com/EclipseFdn/open-vsx.org/wiki/Auto-Publishing-Extensions))
+
+If a secret is missing, that publish step is skipped and the workflow still succeeds.
 
 **`@forst/cli` dependency:** In git, `package.json` uses `workspace:*` so local development and `task build:vscode` / `task ci:test` resolve the CLI from the monorepo (with `task build:cli` producing `dist/` for types). **`task build:vsix`** (and the release workflow) rewrites that dependency to `^<cli semver>` from `packages/cli/package.json`, runs `bun install` so the CLI is installed from **npm**, packages the VSIX, then restores `package.json` and `bun.lockb`. The published VSIX therefore bundles the registry package, matching end-user installs. Building a production VSIX requires **`@forst/cli` to already exist on npm** at a version compatible with the `^` range (typically publish the CLI before or with the same release train).

--- a/packages/vscode-forst/package.json
+++ b/packages/vscode-forst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "forst",
   "displayName": "Forst",
-  "description": "Language support for Forst (.ft): HTTP LSP integration with the forst compiler",
+  "description": "Language support for Forst (.ft): HTTP LSP integration with the Forst compiler",
   "version": "0.3.1",
   "publisher": "forst",
   "private": true,

--- a/packages/vscode-forst/scripts/package-vsix-from-stage.mjs
+++ b/packages/vscode-forst/scripts/package-vsix-from-stage.mjs
@@ -87,9 +87,11 @@ try {
   if (!pkgJson.files.includes(cliFilesPattern)) {
     pkgJson.files.push(cliFilesPattern);
   }
+  // Marketplace rejects extensions marked private; monorepo keeps private: true for npm.
+  delete pkgJson.private;
   fs.writeFileSync(stagedPkgPath, `${JSON.stringify(pkgJson, null, 2)}\n`);
   console.log(
-    "package-vsix-from-stage: staged package.json — no vscode:prepublish; files include @forst/cli"
+    "package-vsix-from-stage: staged package.json — no vscode:prepublish; files include @forst/cli; not private"
   );
 
   const cliDest = path.join(stage, "node_modules", "@forst", "cli");


### PR DESCRIPTION
Release workflow publishes the same VSIX as Open VSX via `vsce` when `VSCE_PAT` is set (publisher `forst`). Staged VSIX packaging strips private: true so Marketplace accepts the bundle. Docs point VS Code users to Marketplace and Open VSX forks to open-vsx.org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The VS Code extension can now be published to both the VS Code Marketplace and Open VSX.
  * Installation guidance now includes separate steps for VS Code and other Open VSX-compatible editors.

* **Bug Fixes**
  * Improved extension packaging so release builds are prepared correctly for publishing.
  * Publishing now skips missing store credentials gracefully while still completing the workflow.

* **Documentation**
  * Updated release, roadmap, and editor docs to reflect the new publishing options and install paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->