### PR TITLE
fix: wire ensure-or fallback and raise Go coverage

### DIFF
--- a/.cursor/skills/generate-commit-message/SKILL.md
+++ b/.cursor/skills/generate-commit-message/SKILL.md
@@ -2,10 +2,8 @@
 name: generate-commit-message
 description: >-
   Produces a conventional semantic commit message from staged changes by reading
-  git diff --cached. When the change is a feature or bugfix, adds a minimal
-  illustrative snippet (e.g. Forst, Go, or config) that demonstrates the change.
-  Use when the user asks for a commit message, semantic commit, or summary of
-  staged files, or invokes /generate-commit-message.
+  git diff --cached. Use when the user asks for a commit message, semantic commit,
+  or summary of staged files, or invokes /generate-commit-message.
 ---
 
 ## Introduction
@@ -19,7 +17,7 @@ Use this skill to generate a **commit message from staged changes**. The agent m
 
 The header grammar is always `type` → optional `(scope)` → optional `!` → `: ` → description. Invalid examples: `feat!(scope):` (bang before scope) or `feat:(scope)!` (colon before scope). Valid with scope: `feat(scope)!: summary`.
 
-For any feature or bugfix in the commit, provide a **minimal illustrative example** (using Forst or another relevant language) when it helps clarify the change.
+**Do not include code examples** in commit messages — no fenced blocks, no inline snippets, no "Example:" sections. Describe behavior in prose only.
 
 ## Workflow
 
@@ -41,31 +39,18 @@ For any feature or bugfix in the commit, provide a **minimal illustrative exampl
 
 3. **Body** (when useful): Describe motivation, behavior, and rationale. Do not simply repeat the title. If the commit uses `!` in the header but no `BREAKING CHANGE:` footer, the **title line’s description** should still make the break clear (per the spec). Prefer a `BREAKING CHANGE:` footer when you need migration steps or multi-sentence detail.
 
-4. **Minimal code example (when applicable):**
-   - For each `feat` or `fix` entry, append an Example section with a short snippet that illustrates the relevant behavior.
-   - Use the project's main language (e.g., Forst `.ft`) or another relevant format (Go, TypeScript, JSON, etc.).
-   - Keep the example very short (approx. 3–12 lines); illustrate a single function, type, or config.
-   - Examples must use triple backticks in the output, and those backticks must be **escaped as \`\`\`** (no additional slashes, just one backslash per backtick), so that the message remains inside the outer code block.
-     - For example:
-         \`\`\`forst
-         func MyExample(): String {
-           return "preview"
-         }
-         \`\`\`
-   - Omit the example for non-feature/fix changes unless the user explicitly requests to include one.
-
-5. **Never** fabricate or assume diff content, or claim changes to files without reading `git diff --cached`.
+4. **Never** fabricate or assume diff content, or claim changes to files without reading `git diff --cached`.
 
 ## Output Format
 
-**Present the entire commit message in a single code block.**  
-- For multiple `feat` or `fix` areas within a single commit, each should receive its own semantic title and body (and example if appropriate) within the same code block, separated by a blank line.
+**Present the entire commit message in a single code block.**
+- For multiple `feat` or `fix` areas within a single commit, each should receive its own semantic title and body within the same code block, separated by a blank line.
 - For breaking changes: use `type!:` or `type(scope)!:` and/or a `BREAKING CHANGE:` footer as specified above (not a lowercase `breaking change:` footer token).
-- Example blocks must use escaped backticks (`\`\`\``) *without* extra slashes—just a single backslash per backtick—to avoid breaking the outer code block.
+- **No code examples** — title, body, and optional footer only.
 
 ## Common Mistakes to Avoid
 
 - Vague titles like `Update code`, `Fix stuff`, `WIP`
 - Repeating the title in the body with no extra info
-- Including full files or overly long examples—keep it concise and directly illustrative
+- **Including code examples, fenced blocks, or "Example:" sections** — use prose only
 - **Wrong breaking-change syntax:** `feat!(scope):` or `feat:(scope)!` — the `!` must appear only immediately before `:` (`feat(scope)!:`). **Wrong footer:** `Breaking change:` — the footer token must be **`BREAKING CHANGE:`** (uppercase) or **`BREAKING-CHANGE:`**

--- a/forst/cmd/forst/config_test.go
+++ b/forst/cmd/forst/config_test.go
@@ -335,6 +335,25 @@ func TestLoadConfigForGenerate_findsConfigWalkingUpFromFileDir(t *testing.T) {
 	}
 }
 
+func TestForstConfig_matchesExcludePatterns(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Files.Exclude = []string{"**/skip/**"}
+	if !cfg.matchesExcludePatterns("/proj/skip/hidden.ft") {
+		t.Fatal("expected exclude match")
+	}
+	if cfg.matchesExcludePatterns("/proj/keep/ok.ft") {
+		t.Fatal("expected non-excluded path")
+	}
+}
+
+func TestForstConfig_matchesIncludePatterns_noMatch(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Files.Include = []string{"**/only/**"}
+	if cfg.matchesIncludePatterns("/proj/other/file.ft") {
+		t.Fatal("expected no include match")
+	}
+}
+
 func TestLoadConfigForGenerate_usesDefaultWhenNoConfigFile(t *testing.T) {
 	dir := t.TempDir()
 	ftFile := filepath.Join(dir, "only.ft")

--- a/forst/cmd/forst/dev_server_http_test.go
+++ b/forst/cmd/forst/dev_server_http_test.go
@@ -112,6 +112,20 @@ func TestHandleFunctions_discoveryFailure_returns500(t *testing.T) {
 	}
 }
 
+func TestHandleInvoke_readBodyError(t *testing.T) {
+	s := testDevServer(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/invoke", io.NopCloser(failReader{}))
+	s.handleInvoke(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d body %s", rr.Code, rr.Body.String())
+	}
+}
+
+type failReader struct{}
+
+func (failReader) Read([]byte) (int, error) { return 0, fmt.Errorf("read failed") }
+
 func TestHandleInvoke_wrongMethod(t *testing.T) {
 	s := testDevServer(t)
 	rr := httptest.NewRecorder()

--- a/forst/cmd/forst/generate.go
+++ b/forst/cmd/forst/generate.go
@@ -260,7 +260,7 @@ export class ForstClient {
 
 	// Initialize package properties
 	for _, export := range exports {
-		clientClass.WriteString(fmt.Sprintf("    this.%s = %s(this.client);\n", export, export))
+		fmt.Fprintf(&clientClass, "    this.%s = %s(this.client);\n", export, export)
 	}
 
 	clientClass.WriteString("  }\n}\n")

--- a/forst/cmd/forst/lsp/diagnostic.go
+++ b/forst/cmd/forst/lsp/diagnostic.go
@@ -297,9 +297,9 @@ func (ld *LSPDebugger) convertSeverityToLSP(errorInfo *ErrorInfo) LSPDiagnosticS
 // ConvertDebugEventToHover converts a debug event to an LSP hover.
 func (ld *LSPDebugger) ConvertDebugEventToHover(event DebugEvent) LSPHover {
 	var content strings.Builder
-	content.WriteString(fmt.Sprintf("**%s**\n\n", event.EventType))
-	content.WriteString(fmt.Sprintf("**Phase:** %s\n", event.Phase))
-	content.WriteString(fmt.Sprintf("**Message:** %s\n", event.Message))
+	fmt.Fprintf(&content, "**%s**\n\n", event.EventType)
+	fmt.Fprintf(&content, "**Phase:** %s\n", event.Phase)
+	fmt.Fprintf(&content, "**Message:** %s\n", event.Message)
 
 	if event.Function != "" {
 		content.WriteString(fmt.Sprintf("**Function:** %s\n", event.Function))

--- a/forst/cmd/forst/lsp/providers_lsp_test.go
+++ b/forst/cmd/forst/lsp/providers_lsp_test.go
@@ -94,7 +94,7 @@ func main() {
 	}
 }
 
-func analyzeNodesForTest(t *testing.T, nodes []ast.Node, toks []ast.Token, src string) (*forstDocumentContext, bool) {
+func analyzeNodesForTest(t *testing.T, _ []ast.Node, _ []ast.Token, src string) (*forstDocumentContext, bool) {
 	t.Helper()
 	s := NewLSPServer("8080", logrus.New())
 	dir := t.TempDir()

--- a/forst/cmd/forst/run_main_test.go
+++ b/forst/cmd/forst/run_main_test.go
@@ -215,3 +215,85 @@ func TestRunMain_run_exitsZeroWhenGoRunSucceeds(t *testing.T) {
 		t.Fatalf("want exit 0, got %d", code)
 	}
 }
+
+func TestRunMain_dev_rootNotDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if code := runMain([]string{"forst", "dev", "-root", file}); code != 1 {
+		t.Fatalf("want exit 1, got %d", code)
+	}
+}
+
+func TestRunMain_test_subcommand(t *testing.T) {
+	dir := t.TempDir()
+	writeForstTestFixtureForRunMain(t, dir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if code := runMain([]string{"forst", "test", "./auth"}); code != 0 {
+		t.Fatalf("want exit 0, got %d", code)
+	}
+}
+
+func TestRunMain_dump_writeError(t *testing.T) {
+	tmp := t.TempDir()
+	ftPath := filepath.Join(tmp, "sample.ft")
+	if err := os.WriteFile(ftPath, []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := dumpCommandStdout
+	dumpCommandStdout = writeFailer{}
+	t.Cleanup(func() { dumpCommandStdout = old })
+	if code := runMain([]string{"forst", "dump", "--file", ftPath}); code != 1 {
+		t.Fatalf("want exit 1, got %d", code)
+	}
+}
+
+type writeFailer struct{}
+
+func (writeFailer) Write([]byte) (int, error) { return 0, fmt.Errorf("write failed") }
+
+func writeForstTestFixtureForRunMain(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module testmod\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	authDir := filepath.Join(dir, "auth")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth.ft"), []byte(`package auth
+
+type Logger = { info(msg String) }
+type NopLogger = {}
+
+func (NopLogger) info(msg String) {}
+
+func expireToken() {
+	use logger: Logger
+	logger.info("ok")
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth_test.ft"), []byte(`package auth
+
+import "testing"
+
+func TestExpireWithWiring(t *testing.T) {
+	with { Logger: &NopLogger {} } {
+		expireToken()
+	}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/forst/cmd/forst/run_main_test.go
+++ b/forst/cmd/forst/run_main_test.go
@@ -237,7 +237,7 @@ func TestRunMain_test_subcommand(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 	if code := runMain([]string{"forst", "test", "./auth"}); code != 0 {
 		t.Fatalf("want exit 0, got %d", code)
 	}

--- a/forst/cmd/forst/test.go
+++ b/forst/cmd/forst/test.go
@@ -10,8 +10,15 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
+var (
+	runTestCommandGetwd    = os.Getwd
+	runTestCommandPathAbs  = filepath.Abs
+	runTestCommandPathRel  = filepath.Rel
+	runTestCommandRunner   = testrunner.Run
+)
+
 func runTestCommand(args []string, log *logrus.Logger) int {
-	cwd, err := os.Getwd()
+	cwd, err := runTestCommandGetwd()
 	if err != nil {
 		log.Error(err)
 		return 2
@@ -26,7 +33,7 @@ func runTestCommand(args []string, log *logrus.Logger) int {
 		if p == "." {
 			candidate = cwd
 		}
-		abs, err := filepath.Abs(candidate)
+		abs, err := runTestCommandPathAbs(candidate)
 		if err != nil {
 			log.Error(err)
 			return 2
@@ -38,7 +45,7 @@ func runTestCommand(args []string, log *logrus.Logger) int {
 				return 2
 			}
 			root = modRoot
-			rel, err := filepath.Rel(modRoot, abs)
+			rel, err := runTestCommandPathRel(modRoot, abs)
 			if err != nil {
 				log.Error(err)
 				return 2
@@ -53,7 +60,7 @@ func runTestCommand(args []string, log *logrus.Logger) int {
 	}
 	root = goload.FindModuleRoot(root)
 
-	code, err := testrunner.Run(testrunner.Options{
+	code, err := runTestCommandRunner(testrunner.Options{
 		ModuleRoot: root,
 		Paths:      paths,
 		GoTestArgs: goTestArgs,

--- a/forst/cmd/forst/test_test.go
+++ b/forst/cmd/forst/test_test.go
@@ -65,7 +65,7 @@ func TestRunTestCommand_success(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	code := runTestCommand([]string{"./auth"}, testCmdLogger())
 	if code != testrunner.ExitSuccess.Int() {
@@ -95,7 +95,7 @@ func F(): Int { return 1 }
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	code := runTestCommand(nil, testCmdLogger())
 	if code != testrunner.ExitError.Int() {
@@ -112,7 +112,7 @@ func TestRunTestCommand_invalidModuleRoot(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	// Path outside any go.mod — goload.ModuleRootWithGoMod fails for explicit dir arg.
 	code := runTestCommand([]string{"./missing"}, testCmdLogger())
@@ -132,7 +132,7 @@ func TestRunTestCommand_resolvesModuleRootFromSubdir(t *testing.T) {
 	if err := os.Chdir(authDir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	code := runTestCommand([]string{"."}, testCmdLogger())
 	if code != testrunner.ExitSuccess.Int() {
@@ -150,7 +150,7 @@ func TestRunTestCommand_passesGoTestArgs(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	// -run=NonExistent skips the only test → go test exits 0 with no tests run.
 	code := runTestCommand([]string{"--", "-run=NoSuchTest"}, testCmdLogger())
@@ -189,7 +189,7 @@ func TestBroken(t *testing.T) {}
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	code := runTestCommand([]string{"./bad"}, testCmdLogger())
 	if code != testrunner.ExitFailure.Int() {
@@ -207,7 +207,7 @@ func TestRunTestCommand_relDotNormalizesPaths(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	var captured []string
 	orig := runTestCommandRunner
@@ -245,7 +245,7 @@ func TestRunTestCommand_pathAbsError(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	orig := runTestCommandPathAbs
 	runTestCommandPathAbs = func(string) (string, error) { return "", os.ErrInvalid }
@@ -266,7 +266,7 @@ func TestRunTestCommand_pathRelError(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	orig := runTestCommandPathRel
 	runTestCommandPathRel = func(string, string) (string, error) { return "", os.ErrInvalid }
@@ -290,7 +290,7 @@ func TestRunTestCommand_dirWithoutGoMod(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	if code := runTestCommand([]string{"plain"}, testCmdLogger()); code != 2 {
 		t.Fatalf("exit code = %d, want 2 for directory without go.mod", code)
@@ -329,7 +329,7 @@ func TestRunTestCommand_skipsEmptyPathEntry(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWd)
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
 	code := runTestCommand([]string{"", "./auth"}, testCmdLogger())
 	if code != testrunner.ExitSuccess.Int() {

--- a/forst/cmd/forst/test_test.go
+++ b/forst/cmd/forst/test_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"forst/internal/testmod"
+	"forst/internal/testrunner"
+
+	"github.com/sirupsen/logrus"
+)
+
+func testCmdLogger() *logrus.Logger {
+	log := logrus.New()
+	log.SetOutput(os.Stderr)
+	log.SetLevel(logrus.PanicLevel)
+	return log
+}
+
+func writeForstTestFixture(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("testmod")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	authDir := filepath.Join(dir, "auth")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth.ft"), []byte(`package auth
+
+type Logger = { info(msg String) }
+type NopLogger = {}
+
+func (NopLogger) info(msg String) {}
+
+func expireToken() {
+	use logger: Logger
+	logger.info("ok")
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth_test.ft"), []byte(`package auth
+
+import "testing"
+
+func TestExpireWithWiring(t *testing.T) {
+	with { Logger: &NopLogger {} } {
+		expireToken()
+	}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunTestCommand_success(t *testing.T) {
+	dir := t.TempDir()
+	writeForstTestFixture(t, dir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	code := runTestCommand([]string{"./auth"}, testCmdLogger())
+	if code != testrunner.ExitSuccess.Int() {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+}
+
+func TestRunTestCommand_noTestsFound(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("testmod")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	libDir := filepath.Join(dir, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "lib.ft"), []byte(`package lib
+
+func F(): Int { return 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	code := runTestCommand(nil, testCmdLogger())
+	if code != testrunner.ExitError.Int() {
+		t.Fatalf("exit code = %d, want 2 when no *_test.ft packages", code)
+	}
+}
+
+func TestRunTestCommand_invalidModuleRoot(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	// Path outside any go.mod — goload.ModuleRootWithGoMod fails for explicit dir arg.
+	code := runTestCommand([]string{"./missing"}, testCmdLogger())
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 for setup error", code)
+	}
+}
+
+func TestRunTestCommand_resolvesModuleRootFromSubdir(t *testing.T) {
+	dir := t.TempDir()
+	writeForstTestFixture(t, dir)
+	authDir := filepath.Join(dir, "auth")
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(authDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	code := runTestCommand([]string{"."}, testCmdLogger())
+	if code != testrunner.ExitSuccess.Int() {
+		t.Fatalf("exit code = %d from subdir", code)
+	}
+}
+
+func TestRunTestCommand_passesGoTestArgs(t *testing.T) {
+	dir := t.TempDir()
+	writeForstTestFixture(t, dir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	// -run=NonExistent skips the only test → go test exits 0 with no tests run.
+	code := runTestCommand([]string{"--", "-run=NoSuchTest"}, testCmdLogger())
+	if code != testrunner.ExitSuccess.Int() {
+		t.Fatalf("exit code = %d", code)
+	}
+}
+
+func TestRunTestCommand_typecheckFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("testmod")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	badDir := filepath.Join(dir, "bad")
+	if err := os.MkdirAll(badDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, "bad.ft"), []byte(`package bad
+
+func broken(): Int { return "not int" }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, "bad_test.ft"), []byte(`package bad
+
+import "testing"
+
+func TestBroken(t *testing.T) {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	code := runTestCommand([]string{"./bad"}, testCmdLogger())
+	if code != testrunner.ExitFailure.Int() {
+		t.Fatalf("exit code = %d, want 1 for typecheck failure", code)
+	}
+}
+
+func TestRunTestCommand_relDotNormalizesPaths(t *testing.T) {
+	dir := t.TempDir()
+	writeForstTestFixture(t, dir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	var captured []string
+	orig := runTestCommandRunner
+	runTestCommandRunner = func(opts testrunner.Options) (testrunner.ExitCode, error) {
+		captured = opts.Paths
+		return testrunner.ExitSuccess, nil
+	}
+	t.Cleanup(func() { runTestCommandRunner = orig })
+
+	code := runTestCommand([]string{"."}, testCmdLogger())
+	if code != testrunner.ExitSuccess.Int() {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if len(captured) != 1 || captured[0] != "." {
+		t.Fatalf("paths = %v, want [\".\"]", captured)
+	}
+}
+
+func TestRunTestCommand_getwdError(t *testing.T) {
+	orig := runTestCommandGetwd
+	runTestCommandGetwd = func() (string, error) { return "", os.ErrInvalid }
+	t.Cleanup(func() { runTestCommandGetwd = orig })
+	if code := runTestCommand(nil, testCmdLogger()); code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+}
+
+func TestRunTestCommand_pathAbsError(t *testing.T) {
+	dir := t.TempDir()
+	writeForstTestFixture(t, dir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	orig := runTestCommandPathAbs
+	runTestCommandPathAbs = func(string) (string, error) { return "", os.ErrInvalid }
+	t.Cleanup(func() { runTestCommandPathAbs = orig })
+
+	if code := runTestCommand([]string{"./auth"}, testCmdLogger()); code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+}
+
+func TestRunTestCommand_pathRelError(t *testing.T) {
+	dir := t.TempDir()
+	writeForstTestFixture(t, dir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	orig := runTestCommandPathRel
+	runTestCommandPathRel = func(string, string) (string, error) { return "", os.ErrInvalid }
+	t.Cleanup(func() { runTestCommandPathRel = orig })
+
+	if code := runTestCommand([]string{"./auth"}, testCmdLogger()); code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+}
+
+func TestRunTestCommand_dirWithoutGoMod(t *testing.T) {
+	dir := t.TempDir()
+	noMod := filepath.Join(dir, "plain")
+	if err := os.MkdirAll(noMod, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	if code := runTestCommand([]string{"plain"}, testCmdLogger()); code != 2 {
+		t.Fatalf("exit code = %d, want 2 for directory without go.mod", code)
+	}
+}
+
+func TestRunTestCommand_runnerErrorWithSuccessCode(t *testing.T) {
+	orig := runTestCommandRunner
+	runTestCommandRunner = func(testrunner.Options) (testrunner.ExitCode, error) {
+		return testrunner.ExitSuccess, os.ErrInvalid
+	}
+	t.Cleanup(func() { runTestCommandRunner = orig })
+	if code := runTestCommand(nil, testCmdLogger()); code != testrunner.ExitError.Int() {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+}
+
+func TestRunTestCommand_runnerErrorWithFailureCode(t *testing.T) {
+	orig := runTestCommandRunner
+	runTestCommandRunner = func(testrunner.Options) (testrunner.ExitCode, error) {
+		return testrunner.ExitFailure, os.ErrInvalid
+	}
+	t.Cleanup(func() { runTestCommandRunner = orig })
+	if code := runTestCommand(nil, testCmdLogger()); code != testrunner.ExitFailure.Int() {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+}
+
+func TestRunTestCommand_skipsEmptyPathEntry(t *testing.T) {
+	dir := t.TempDir()
+	writeForstTestFixture(t, dir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	code := runTestCommand([]string{"", "./auth"}, testCmdLogger())
+	if code != testrunner.ExitSuccess.Int() {
+		t.Fatalf("exit code = %d", code)
+	}
+}

--- a/forst/internal/astwalk/walk_test.go
+++ b/forst/internal/astwalk/walk_test.go
@@ -160,3 +160,54 @@ func TestWalkStmtsContaining_skipsWithOutsidePosition(t *testing.T) {
 		t.Fatalf("hits = %d, want 0 outside span", hits)
 	}
 }
+
+func TestWalkStmtsContaining_hitsInsideSpan(t *testing.T) {
+	t.Parallel()
+	with := ast.WithNode{
+		Span: ast.SourceSpan{StartLine: 10, StartCol: 1, EndLine: 12, EndCol: 2},
+	}
+	var hits int
+	WalkStmtsContaining([]ast.Node{with}, 11, 1, StmtVisitor{
+		OnWith: func(ast.WithNode) bool { hits++; return true },
+	})
+	if hits != 1 {
+		t.Fatalf("hits = %d, want 1 inside span", hits)
+	}
+}
+
+func TestWalkNode_topLevelFunction(t *testing.T) {
+	t.Parallel()
+	call := ast.FunctionCallNode{Function: ast.Ident{ID: "f"}}
+	fn := ast.FunctionNode{Body: []ast.Node{call}}
+	var fnHits int
+	WalkNode(fn, StmtVisitor{
+		OnFunction: func(ast.FunctionNode) bool { fnHits++; return true },
+		OnCall:     func(ast.FunctionCallNode) bool { return true },
+	})
+	if fnHits != 1 {
+		t.Fatalf("fnHits = %d", fnHits)
+	}
+}
+
+func TestWalkNode_ifWithInit(t *testing.T) {
+	t.Parallel()
+	call := ast.FunctionCallNode{Function: ast.Ident{ID: "f"}}
+	ifNode := ast.IfNode{
+		Init: ast.AssignmentNode{
+			IsShort: true,
+			LValues: []ast.ExpressionNode{ast.VariableNode{Ident: ast.Ident{ID: "x"}}},
+			RValues: []ast.ExpressionNode{ast.IntLiteralNode{Value: 1}},
+		},
+		Condition: ast.BoolLiteralNode{Value: true},
+		Body:      []ast.Node{call},
+	}
+	var ifHits int
+	WalkNode(ifNode, StmtVisitor{
+		OnIf:   func(ast.IfNode) bool { ifHits++; return true },
+		OnCall: func(ast.FunctionCallNode) bool { return true },
+	})
+	if ifHits != 1 {
+		t.Fatalf("ifHits = %d", ifHits)
+	}
+}
+

--- a/forst/internal/compiler/args_test.go
+++ b/forst/internal/compiler/args_test.go
@@ -93,3 +93,57 @@ func TestParseArgs_rootWithWatchRejected(t *testing.T) {
 		t.Fatalf("expected root+watch error, got %q", buf.String())
 	}
 }
+
+func TestParseArgs_runSuccess(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	args := ParseArgsFrom([]string{
+		"forst", "run",
+		"-loglevel", "debug",
+		"-report-memory-usage",
+		"-report-phases",
+		"-export-struct-fields",
+		"-root", "/tmp/pkg",
+		"main.ft",
+	}, log)
+	if args.Command != "run" || args.FilePath != "main.ft" {
+		t.Fatalf("got %+v", args)
+	}
+	if args.LogLevel != "debug" || !args.ReportMemoryUsage || !args.ReportPhases || !args.ExportStructFields {
+		t.Fatalf("flags: %+v", args)
+	}
+	if args.PackageRoot == "" {
+		t.Fatal("expected abs package root")
+	}
+}
+
+func TestParseArgs_buildSuccess(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	args := ParseArgsFrom([]string{"forst", "build", "-o", "out.go", "main.ft"}, log)
+	if args.Command != "build" || args.OutputPath != "out.go" || args.FilePath != "main.ft" {
+		t.Fatalf("got %+v", args)
+	}
+}
+
+func TestParseArgs_runWatchSuccess(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	args := ParseArgsFrom([]string{"forst", "run", "-watch", "-o", "out.go", "main.ft"}, log)
+	if args.Command != "run" || !args.Watch || args.OutputPath != "out.go" {
+		t.Fatalf("got %+v", args)
+	}
+}
+
+func TestParseArgs_missingFileArg(t *testing.T) {
+	var buf bytes.Buffer
+	log := logrus.New()
+	log.SetOutput(&buf)
+	args := ParseArgsFrom([]string{"forst", "run"}, log)
+	if args.Command != "" {
+		t.Fatalf("expected empty, got %+v", args)
+	}
+	if !strings.Contains(buf.String(), "Usage:") {
+		t.Fatalf("got %q", buf.String())
+	}
+}

--- a/forst/internal/forstpkg/forstpkg.go
+++ b/forst/internal/forstpkg/forstpkg.go
@@ -18,12 +18,7 @@ import (
 func ParseForstFile(log *logrus.Logger, path string) (nodes []ast.Node, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			if pe, ok := r.(*parser.ParseError); ok {
-				err = pe
-				nodes = nil
-				return
-			}
-			err = fmt.Errorf("parse panic in %s: %v", path, r)
+			err = parseRecoverToError(path, r)
 			nodes = nil
 		}
 	}()
@@ -42,12 +37,7 @@ func ParseForstFile(log *logrus.Logger, path string) (nodes []ast.Node, err erro
 func ParseForstFileFromRoot(log *logrus.Logger, root *safefs.RootedFS, relPath, displayPath string) (nodes []ast.Node, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			if pe, ok := r.(*parser.ParseError); ok {
-				err = pe
-				nodes = nil
-				return
-			}
-			err = fmt.Errorf("parse panic in %s: %v", displayPath, r)
+			err = parseRecoverToError(displayPath, r)
 			nodes = nil
 		}
 	}()

--- a/forst/internal/forstpkg/forstpkg_test.go
+++ b/forst/internal/forstpkg/forstpkg_test.go
@@ -175,3 +175,76 @@ func TestParseAndMergePackage_emptyPaths(t *testing.T) {
 		t.Fatalf("expected empty, got merged=%d byPath=%d", len(merged), len(byPath))
 	}
 }
+
+func TestParseForstFile_missingFile(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(nil)
+	_, err := ParseForstFile(log, filepath.Join(t.TempDir(), "missing.ft"))
+	if err == nil {
+		t.Fatal("expected read error for missing file")
+	}
+}
+
+func TestParseAndMergePackage_parseError(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.ft")
+	if err := os.WriteFile(bad, []byte("not valid forst {{{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	log := logrus.New()
+	log.SetOutput(nil)
+	_, _, err := ParseAndMergePackage(log, []string{bad})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestParseForstFileFromRoot_missingFile(t *testing.T) {
+	t.Parallel()
+	root, err := safefs.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	log := logrus.New()
+	log.SetOutput(nil)
+	_, err = ParseForstFileFromRoot(log, root, "missing.ft", "/display/missing.ft")
+	if err == nil {
+		t.Fatal("expected read error")
+	}
+}
+
+func TestParseForstFileFromRoot_parsePanicRecovery(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	absPath := filepath.Join(dir, "bad.ft")
+	if err := os.WriteFile(absPath, []byte("package main\nfunc main() {"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root, err := safefs.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	log := logrus.New()
+	log.SetOutput(nil)
+	_, err = ParseForstFileFromRoot(log, root, "bad.ft", absPath)
+	if err == nil {
+		t.Fatal("expected parse error from panic recovery")
+	}
+}
+
+func TestParseForstFile_parsePanicRecovery(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.ft")
+	if err := os.WriteFile(path, []byte("package main\nfunc main() {"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	log := logrus.New()
+	log.SetOutput(nil)
+	_, err := ParseForstFile(log, path)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}

--- a/forst/internal/forstpkg/forstpkg_test.go
+++ b/forst/internal/forstpkg/forstpkg_test.go
@@ -105,7 +105,7 @@ func F(): Int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer root.Close()
+	t.Cleanup(func() { _ = root.Close() })
 
 	log := logrus.New()
 	log.SetOutput(nil)
@@ -205,7 +205,7 @@ func TestParseForstFileFromRoot_missingFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer root.Close()
+	t.Cleanup(func() { _ = root.Close() })
 	log := logrus.New()
 	log.SetOutput(nil)
 	_, err = ParseForstFileFromRoot(log, root, "missing.ft", "/display/missing.ft")
@@ -225,7 +225,7 @@ func TestParseForstFileFromRoot_parsePanicRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer root.Close()
+	t.Cleanup(func() { _ = root.Close() })
 	log := logrus.New()
 	log.SetOutput(nil)
 	_, err = ParseForstFileFromRoot(log, root, "bad.ft", absPath)

--- a/forst/internal/forstpkg/import_paths.go
+++ b/forst/internal/forstpkg/import_paths.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// buildImportPathsRel is overridden in tests to exercise rel-error handling.
+var buildImportPathsRel = filepath.Rel
+
 // BuildForstPackageImportPaths maps Go import paths to Forst package names for packages
 // discovered under moduleRoot (modulePath is the go.mod module path, e.g. "example.com/app").
 // forstPkgToFiles maps Forst package name -> absolute .ft file paths (one dir per package).
@@ -16,7 +19,7 @@ func BuildForstPackageImportPaths(moduleRoot, modulePath string, forstPkgToFiles
 			continue
 		}
 		dir := filepath.Dir(files[0])
-		rel, err := filepath.Rel(moduleRoot, dir)
+		rel, err := buildImportPathsRel(moduleRoot, dir)
 		if err != nil {
 			continue
 		}

--- a/forst/internal/forstpkg/import_paths_test.go
+++ b/forst/internal/forstpkg/import_paths_test.go
@@ -1,0 +1,59 @@
+package forstpkg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildForstPackageImportPaths(t *testing.T) {
+	root := filepath.Clean("/proj")
+	paths := map[string][]string{
+		"alpha": {filepath.Join(root, "alpha", "alpha.ft")},
+		"beta":  {filepath.Join(root, "beta", "beta.ft")},
+		"empty": {},
+	}
+	got := BuildForstPackageImportPaths(root, "example.com/app", paths)
+	if got["example.com/app/alpha"] != "alpha" {
+		t.Fatalf("alpha path: %v", got)
+	}
+	if got["example.com/app/beta"] != "beta" {
+		t.Fatalf("beta path: %v", got)
+	}
+	if _, ok := got["example.com/app/empty"]; ok {
+		t.Fatalf("empty file list should be skipped: %v", got)
+	}
+}
+
+func TestBuildForstPackageImportPaths_rootPackage(t *testing.T) {
+	root := filepath.Clean("/proj")
+	paths := map[string][]string{
+		"main": {filepath.Join(root, "main.ft")},
+	}
+	got := BuildForstPackageImportPaths(root, "example.com/app", paths)
+	if got["example.com/app"] != "main" {
+		t.Fatalf("root package import path: %v", got)
+	}
+}
+
+func TestBuildForstPackageImportPaths_skipsEmptyFileList(t *testing.T) {
+	got := BuildForstPackageImportPaths("/proj", "example.com/app", map[string][]string{
+		"empty": {},
+	})
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %v", got)
+	}
+}
+
+func TestBuildForstPackageImportPaths_skipsRelError(t *testing.T) {
+	orig := buildImportPathsRel
+	buildImportPathsRel = func(string, string) (string, error) { return "", os.ErrInvalid }
+	t.Cleanup(func() { buildImportPathsRel = orig })
+
+	got := BuildForstPackageImportPaths("/proj", "example.com/app", map[string][]string{
+		"pkg": {filepath.Join("/proj", "pkg", "file.ft")},
+	})
+	if len(got) != 0 {
+		t.Fatalf("expected rel error to skip entry, got %v", got)
+	}
+}

--- a/forst/internal/forstpkg/parse_recover.go
+++ b/forst/internal/forstpkg/parse_recover.go
@@ -1,0 +1,14 @@
+package forstpkg
+
+import (
+	"fmt"
+
+	"forst/internal/parser"
+)
+
+func parseRecoverToError(displayPath string, r any) error {
+	if pe, ok := r.(*parser.ParseError); ok {
+		return pe
+	}
+	return fmt.Errorf("parse panic in %s: %v", displayPath, r)
+}

--- a/forst/internal/forstpkg/parse_recover_test.go
+++ b/forst/internal/forstpkg/parse_recover_test.go
@@ -1,0 +1,24 @@
+package forstpkg
+
+import (
+	"errors"
+	"testing"
+
+	"forst/internal/parser"
+)
+
+func TestParseRecoverToError_parseError(t *testing.T) {
+	t.Parallel()
+	pe := &parser.ParseError{Msg: "bad syntax"}
+	if err := parseRecoverToError("f.ft", pe); err != pe {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestParseRecoverToError_genericPanic(t *testing.T) {
+	t.Parallel()
+	err := parseRecoverToError("f.ft", errors.New("boom"))
+	if err == nil || err.Error() != "parse panic in f.ft: boom" {
+		t.Fatalf("got %v", err)
+	}
+}

--- a/forst/internal/generators/go.go
+++ b/forst/internal/generators/go.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 )
 
+var formatGoNode = format.Node
+
 // GenerateGoCode generates Go code from a Go AST with consistent ordering
 func GenerateGoCode(goFile *goast.File) (string, error) {
 	var buf bytes.Buffer
@@ -20,7 +22,7 @@ func GenerateGoCode(goFile *goast.File) (string, error) {
 	sortDeclarations(goFile)
 	sortStructFields(goFile)
 
-	if err := format.Node(&buf, fset, goFile); err != nil {
+	if err := formatGoNode(&buf, fset, goFile); err != nil {
 		return "", fmt.Errorf("failed to format Go code: %w", err)
 	}
 	return buf.String(), nil

--- a/forst/internal/generators/go_test.go
+++ b/forst/internal/generators/go_test.go
@@ -1,8 +1,10 @@
 package generators
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
+	"io"
 	"strings"
 	"testing"
 )
@@ -115,5 +117,215 @@ func TestGenerateGoCode_declarationOrderGroups(t *testing.T) {
 	}
 	if iConst >= iType || iType >= iFunc {
 		t.Fatalf("expected const then type then func, got:\n%s", out)
+	}
+}
+
+func TestGenerateGoCode_sortsVarDeclsAndImports(t *testing.T) {
+	t.Parallel()
+	f := &ast.File{
+		Name: ast.NewIdent("p"),
+		Decls: []ast.Decl{
+			&ast.GenDecl{
+				Tok: token.VAR,
+				Specs: []ast.Spec{
+					&ast.ValueSpec{
+						Names:  []*ast.Ident{ast.NewIdent("zebra")},
+						Values: []ast.Expr{&ast.BasicLit{Kind: token.INT, Value: "1"}},
+					},
+				},
+			},
+			&ast.GenDecl{
+				Tok: token.VAR,
+				Specs: []ast.Spec{
+					&ast.ValueSpec{
+						Names:  []*ast.Ident{ast.NewIdent("apple")},
+						Values: []ast.Expr{&ast.BasicLit{Kind: token.INT, Value: "2"}},
+					},
+				},
+			},
+			&ast.GenDecl{
+				Tok: token.IMPORT,
+				Specs: []ast.Spec{
+					&ast.ImportSpec{Path: &ast.BasicLit{Kind: token.STRING, Value: `"fmt"`}},
+				},
+			},
+		},
+	}
+	out, err := GenerateGoCode(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `import "fmt"`) {
+		t.Fatalf("missing import:\n%s", out)
+	}
+	iApple := strings.Index(out, "apple")
+	iZebra := strings.Index(out, "zebra")
+	if iApple == -1 || iZebra == -1 || iApple >= iZebra {
+		t.Fatalf("expected sorted var decl groups:\n%s", out)
+	}
+}
+
+func TestGenerateGoCode_sortsNestedStructInStructField(t *testing.T) {
+	t.Parallel()
+	f := &ast.File{
+		Name: ast.NewIdent("p"),
+		Decls: []ast.Decl{
+			&ast.GenDecl{
+				Tok: token.TYPE,
+				Specs: []ast.Spec{
+					&ast.TypeSpec{
+						Name: ast.NewIdent("Outer"),
+						Type: &ast.StructType{
+							Fields: &ast.FieldList{
+								List: []*ast.Field{
+									{
+										Names: []*ast.Ident{ast.NewIdent("items")},
+										Type: &ast.ArrayType{
+											Elt: &ast.StructType{
+												Fields: &ast.FieldList{
+													List: []*ast.Field{
+														{Names: []*ast.Ident{ast.NewIdent("z")}, Type: ast.NewIdent("int")},
+														{Names: []*ast.Ident{ast.NewIdent("a")}, Type: ast.NewIdent("int")},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	out, err := GenerateGoCode(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	iA := strings.Index(out, "a int")
+	iZ := strings.Index(out, "z int")
+	if iA == -1 || iZ == -1 || iA >= iZ {
+		t.Fatalf("expected nested struct fields sorted:\n%s", out)
+	}
+}
+
+func TestSortStructTypeFields_nilFieldsNoPanic(t *testing.T) {
+	t.Parallel()
+	sortStructTypeFields(&ast.StructType{})
+}
+
+func TestSortStructTypeFields_mapValueNestedStruct(t *testing.T) {
+	t.Parallel()
+	outer := &ast.StructType{
+		Fields: &ast.FieldList{
+			List: []*ast.Field{
+				{
+					Names: []*ast.Ident{ast.NewIdent("m")},
+					Type: &ast.MapType{
+						Key: ast.NewIdent("string"),
+						Value: &ast.StructType{
+							Fields: &ast.FieldList{
+								List: []*ast.Field{
+									{Names: []*ast.Ident{ast.NewIdent("z")}, Type: ast.NewIdent("int")},
+									{Names: []*ast.Ident{ast.NewIdent("a")}, Type: ast.NewIdent("int")},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	sortStructTypeFields(outer)
+	names := []string{
+		outer.Fields.List[0].Type.(*ast.MapType).Value.(*ast.StructType).Fields.List[0].Names[0].Name,
+		outer.Fields.List[0].Type.(*ast.MapType).Value.(*ast.StructType).Fields.List[1].Names[0].Name,
+	}
+	if names[0] != "a" || names[1] != "z" {
+		t.Fatalf("got field order %#v", names)
+	}
+}
+
+func TestSortStructTypeFields_anonymousFieldsSortByType(t *testing.T) {
+	t.Parallel()
+	st := &ast.StructType{
+		Fields: &ast.FieldList{
+			List: []*ast.Field{
+				{Type: ast.NewIdent("string")},
+				{Type: ast.NewIdent("int")},
+			},
+		},
+	}
+	sortStructTypeFields(st)
+	if fmt.Sprint(st.Fields.List[0].Type) > fmt.Sprint(st.Fields.List[1].Type) {
+		t.Fatalf("expected anonymous fields sorted by type string")
+	}
+}
+
+func TestSortStructTypeFields_arrayElementNestedStruct(t *testing.T) {
+	t.Parallel()
+	outer := &ast.StructType{
+		Fields: &ast.FieldList{
+			List: []*ast.Field{
+				{
+					Names: []*ast.Ident{ast.NewIdent("xs")},
+					Type: &ast.ArrayType{
+						Elt: &ast.StructType{
+							Fields: &ast.FieldList{
+								List: []*ast.Field{
+									{Names: []*ast.Ident{ast.NewIdent("z")}, Type: ast.NewIdent("int")},
+									{Names: []*ast.Ident{ast.NewIdent("a")}, Type: ast.NewIdent("int")},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	sortStructTypeFields(outer)
+	inner := outer.Fields.List[0].Type.(*ast.ArrayType).Elt.(*ast.StructType)
+	if inner.Fields.List[0].Names[0].Name != "a" || inner.Fields.List[1].Names[0].Name != "z" {
+		t.Fatalf("got %#v", inner.Fields.List)
+	}
+}
+
+func TestSortStructTypeFields_directNestedStructField(t *testing.T) {
+	t.Parallel()
+	outer := &ast.StructType{
+		Fields: &ast.FieldList{
+			List: []*ast.Field{
+				{
+					Names: []*ast.Ident{ast.NewIdent("inner")},
+					Type: &ast.StructType{
+						Fields: &ast.FieldList{
+							List: []*ast.Field{
+								{Names: []*ast.Ident{ast.NewIdent("z")}, Type: ast.NewIdent("int")},
+								{Names: []*ast.Ident{ast.NewIdent("a")}, Type: ast.NewIdent("int")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	sortStructTypeFields(outer)
+	inner := outer.Fields.List[0].Type.(*ast.StructType)
+	if inner.Fields.List[0].Names[0].Name != "a" {
+		t.Fatalf("got %#v", inner.Fields.List)
+	}
+}
+
+func TestGenerateGoCode_formatError(t *testing.T) {
+	t.Parallel()
+	orig := formatGoNode
+	formatGoNode = func(io.Writer, *token.FileSet, interface{}) error {
+		return fmt.Errorf("format failed")
+	}
+	t.Cleanup(func() { formatGoNode = orig })
+	f := &ast.File{Name: ast.NewIdent("main")}
+	if _, err := GenerateGoCode(f); err == nil {
+		t.Fatal("expected format error")
 	}
 }

--- a/forst/internal/goload/load.go
+++ b/forst/internal/goload/load.go
@@ -19,6 +19,9 @@ type loadByPkgPathCacheEntry struct {
 
 var loadByPkgPathCache sync.Map
 
+// packagesLoadFn loads packages; overridden in tests.
+var packagesLoadFn = packages.Load
+
 // ClearLoadCacheForTest drops cached LoadByPkgPath results (for tests that mutate module dirs).
 func ClearLoadCacheForTest() {
 	loadByPkgPathCache = sync.Map{}
@@ -110,7 +113,7 @@ func loadByPkgPathUncached(dir string, importPaths []string) (map[string]*packag
 		Dir:  dir,
 		Env:  loadPackagesEnv(dir),
 	}
-	pkgs, err := packages.Load(cfg, importPaths...)
+	pkgs, err := packagesLoadFn(cfg, importPaths...)
 	if err != nil {
 		return nil, err
 	}

--- a/forst/internal/goload/load_test.go
+++ b/forst/internal/goload/load_test.go
@@ -8,6 +8,8 @@ import (
 	"forst/internal/testmod"
 
 	"golang.org/x/tools/go/packages"
+	"go/types"
+	"strings"
 )
 
 func moduleRootFromWD(t *testing.T) string {
@@ -202,6 +204,176 @@ func TestLoadByPkgPath_modulePackageWithoutGoSources(t *testing.T) {
 	}
 	if m["testmod/sub"] != nil {
 		t.Fatal("expected testmod/sub omitted when directory has no Go files")
+	}
+}
+
+func TestPackageHasGoSources(t *testing.T) {
+	t.Parallel()
+	if packageHasGoSources(nil) {
+		t.Fatal("nil package")
+	}
+	if packageHasGoSources(&packages.Package{}) {
+		t.Fatal("empty package")
+	}
+	p := &packages.Package{GoFiles: []string{"a.go"}}
+	if !packageHasGoSources(p) {
+		t.Fatal("expected GoFiles to count")
+	}
+	p = &packages.Package{CompiledGoFiles: []string{"a.go"}}
+	if !packageHasGoSources(p) {
+		t.Fatal("expected CompiledGoFiles to count")
+	}
+}
+
+func TestPackageLoadOKAt_rejectsWrongPath(t *testing.T) {
+	t.Parallel()
+	dir := moduleRootFromWD(t)
+	m, err := LoadByPkgPath(dir, []string{"fmt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packageLoadOKAt(m["fmt"], "strings", dir) {
+		t.Fatal("expected path mismatch to fail")
+	}
+}
+
+func TestImportPathFromForst_barePath(t *testing.T) {
+	t.Parallel()
+	if got := ImportPathFromForst("fmt"); got != "fmt" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestLoadByPkgPath_cachesErrors(t *testing.T) {
+	dir := moduleRootFromWD(t)
+	ClearLoadCacheForTest()
+	_, err1 := LoadByPkgPath(dir, []string{"forst/nonexistent/pkg/xyz"})
+	_, err2 := LoadByPkgPath(dir, []string{"forst/nonexistent/pkg/xyz"})
+	if err1 == nil {
+		t.Skip("loader returned success unexpectedly")
+	}
+	if err2 == nil || err1.Error() != err2.Error() {
+		t.Fatalf("expected cached error, err1=%v err2=%v", err1, err2)
+	}
+}
+
+func TestModulePath_missingGoModReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	if got := ModulePath(t.TempDir()); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestModulePath_goModWithoutModuleLine(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("go 1.22\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := ModulePath(dir); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestModuleRootWithGoMod_fromFilePath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module testmod\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(root, "pkg", "x.go")
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("package pkg\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ModuleRootWithGoMod(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != root {
+		t.Fatalf("got %q want %q", got, root)
+	}
+}
+
+func TestPackageLoadOKAt_acceptsModuleSubpackageWithGoSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("loadok")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p := &packages.Package{
+		Types:   mustLoadokSubTypes(t),
+		GoFiles: []string{filepath.Join(dir, "sub", "sub.go")},
+	}
+	if !packageLoadOKAt(p, "loadok/sub", dir) {
+		t.Fatal("expected module subpackage with Go sources to pass")
+	}
+}
+
+func mustLoadokSubTypes(t *testing.T) *types.Package {
+	t.Helper()
+	return types.NewPackage("loadok/sub", "sub")
+}
+
+func TestLoadByPkgPath_packagesLoadError(t *testing.T) {
+	dir := moduleRootFromWD(t)
+	ClearLoadCacheForTest()
+	_, err := LoadByPkgPath(dir, []string{"\x00invalid/path"})
+	if err == nil {
+		t.Fatal("expected load error")
+	}
+}
+
+func TestStoreLoadCache_skipsEmptyPathKey(t *testing.T) {
+	dir := moduleRootFromWD(t)
+	ClearLoadCacheForTest()
+	p := &packages.Package{Types: mustLoadokSubTypes(t)}
+	storeLoadCache(dir, []string{"fmt", "strings"}, map[string]*packages.Package{
+		"fmt":     p,
+		"strings": p,
+		"":        p,
+	}, nil)
+	single, err := LoadByPkgPath(dir, []string{"fmt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if single["fmt"] == nil {
+		t.Fatal("expected fmt cached despite empty path key in batch")
+	}
+}
+
+func TestLoadByPkgPath_noTypedPackagesWithoutMessages(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("ghostonly")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ClearLoadCacheForTest()
+	_, err := LoadByPkgPath(dir, []string{"ghostonly/sub"})
+	if err == nil {
+		t.Fatal("expected error when no typed packages resolve")
+	}
+	if !strings.Contains(err.Error(), "no typed packages") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadByPkgPathUncached_noTypedPackagesWithoutErrorMessages(t *testing.T) {
+	orig := packagesLoadFn
+	packagesLoadFn = func(*packages.Config, ...string) ([]*packages.Package, error) {
+		return []*packages.Package{{ID: "ghost"}}, nil
+	}
+	t.Cleanup(func() { packagesLoadFn = orig })
+
+	_, err := loadByPkgPathUncached(t.TempDir(), []string{"ghost"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no typed packages for [ghost]") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/forst/internal/hasher/hasher_test.go
+++ b/forst/internal/hasher/hasher_test.go
@@ -766,3 +766,29 @@ func TestStructuralHasher_ElseIfAndElseBlockNodes(t *testing.T) {
 		t.Fatalf("*ElseBlockNode: %v", err)
 	}
 }
+
+func TestStructuralHasher_nilNodeAndOptionalFields(t *testing.T) {
+	t.Parallel()
+	h := New()
+	if _, err := h.HashNode(nil); err != nil {
+		t.Fatalf("nil node: %v", err)
+	}
+	var nilFn *ast.FunctionNode
+	if _, err := h.HashNode(nilFn); err != nil {
+		t.Fatalf("nil pointer node: %v", err)
+	}
+	ifNode := ast.IfNode{
+		Condition: ast.BoolLiteralNode{Value: true},
+		Body:      []ast.Node{ast.IntLiteralNode{Value: 1}},
+	}
+	if _, err := h.HashNode(ifNode); err != nil {
+		t.Fatalf("IfNode without init/else: %v", err)
+	}
+	forNode := &ast.ForNode{
+		Cond: ast.BoolLiteralNode{Value: false},
+		Body: []ast.Node{&ast.BreakNode{}},
+	}
+	if _, err := h.HashNode(forNode); err != nil {
+		t.Fatalf("ForNode without init/post: %v", err)
+	}
+}

--- a/forst/internal/modulecheck/deferred_wiring_unknown_key_test.go
+++ b/forst/internal/modulecheck/deferred_wiring_unknown_key_test.go
@@ -16,13 +16,16 @@ func TestCheckModuleProviders_unknownWiringKeyRejectedAfterMerge(t *testing.T) {
 import "testing"
 
 type Logger = { info(msg String) }
+type NopLogger = {}
+
+func (NopLogger) info(msg String) {}
 
 func expireToken() {
 	use logger: Logger
 }
 
 func TestX(t *testing.T) {
-	with { BadKey: 1 } {
+	with { BadKey: &NopLogger {} } {
 		expireToken()
 	}
 }

--- a/forst/internal/modulecheck/find_forst_files_test.go
+++ b/forst/internal/modulecheck/find_forst_files_test.go
@@ -1,0 +1,226 @@
+package modulecheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"forst/internal/testmod"
+)
+
+func TestModuleResult_nilSafeAccessors(t *testing.T) {
+	t.Parallel()
+	var r *ModuleResult
+	if r.ImportPathToForstPkg() != nil {
+		t.Fatal("nil ImportPathToForstPkg should return nil")
+	}
+	if r.ForstPackageTypeChecker("x") != nil {
+		t.Fatal("nil ForstPackageTypeChecker should return nil")
+	}
+}
+
+func TestFindForstFiles_skipsVendorGitNodeModules(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	for _, dir := range []string{".git", "vendor", "node_modules"} {
+		p := filepath.Join(root, dir, "hidden.ft")
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("package main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	keep := filepath.Join(root, "keep.ft")
+	if err := os.WriteFile(keep, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := findForstFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || filepath.Base(got[0]) != "keep.ft" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestFindForstFiles_skipsSkipFtSuffix(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ok.ft"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "broken.skip.ft"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := findForstFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || filepath.Base(got[0]) != "ok.ft" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestFindForstFiles_skipsNestedGoMod(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	nested := filepath.Join(root, "nested")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "go.mod"), []byte(testmod.GoModContent("nestedmod")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "skip.ft"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "root.ft"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := findForstFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || filepath.Base(got[0]) != "root.ft" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestCloneSlots_emptyReturnsEmptyMap(t *testing.T) {
+	t.Parallel()
+	got := cloneSlots(nil)
+	if len(got) != 0 {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestCheckModuleProviders_packageFilter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("filtmod")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	alphaDir := filepath.Join(dir, "alpha")
+	if err := os.MkdirAll(alphaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeModuleFile(t, filepath.Join(alphaDir, "a.ft"), `package alpha
+
+func A() {}
+`)
+	writeModuleFile(t, filepath.Join(dir, "beta.ft"), `package beta
+
+func B() {}
+`)
+	result, err := CheckModuleProviders(nil, Options{
+		ModuleRoot:    dir,
+		PackageFilter: map[string]struct{}{"alpha": {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ForstPackageTypeChecker("beta") != nil {
+		t.Fatal("beta should be filtered out")
+	}
+	if result.ForstPackageTypeChecker("alpha") == nil {
+		t.Fatal("alpha should be included")
+	}
+}
+
+func TestCheckModuleProviders_skipsUnparseableFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("skipmod")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeModuleFile(t, filepath.Join(dir, "good.ft"), `package main
+
+func main() {}
+`)
+	writeModuleFile(t, filepath.Join(dir, "bad.ft"), `not valid {{{`)
+	result, err := CheckModuleProviders(nil, Options{ModuleRoot: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.ForstPkgToFiles) != 1 {
+		t.Fatalf("expected only good.ft package, got %v", result.ForstPkgToFiles)
+	}
+}
+
+func TestCheckModuleProviders_typecheckErrorReturnsResult(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("errmod")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeModuleFile(t, filepath.Join(dir, "bad.ft"), `package main
+
+func Broken(): String {
+	return 1
+}
+`)
+	_, err := CheckModuleProviders(nil, Options{ModuleRoot: dir})
+	if err == nil {
+		t.Fatal("expected typecheck error")
+	}
+}
+
+func TestCheckModuleProviders_missingRootErrors(t *testing.T) {
+	t.Parallel()
+	_, err := CheckModuleProviders(nil, Options{
+		ModuleRoot: filepath.Join(t.TempDir(), "missing-subdir"),
+	})
+	if err == nil {
+		t.Fatal("expected findForstFiles error")
+	}
+}
+
+func TestCheckModuleProviders_revalidateDeferredWiringErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("revmod")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeModuleFile(t, filepath.Join(dir, "host.ft"), `package host
+
+import "testing"
+
+type Logger = { info(msg String) }
+type NopLogger = {}
+
+func (NopLogger) info(msg String) {}
+
+func TestHost(t *testing.T) {
+	with { BadKey: &NopLogger {} } {
+	}
+}
+`)
+	_, err := CheckModuleProviders(nil, Options{ModuleRoot: dir})
+	if err == nil {
+		t.Fatal("expected deferred wiring revalidation error")
+	}
+}
+
+func TestFindForstFiles_walkPermissionError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root can read chmod 000 directories")
+	}
+	root := t.TempDir()
+	secret := filepath.Join(root, "secret")
+	if err := os.Mkdir(secret, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o755) })
+	_, err := findForstFiles(root)
+	if err == nil {
+		t.Fatal("expected walk error for unreadable directory")
+	}
+}
+
+func writeModuleFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/forst/internal/modulecheck/module_providers.go
+++ b/forst/internal/modulecheck/module_providers.go
@@ -108,10 +108,8 @@ func CheckModuleProviders(log *logrus.Logger, opts Options) (*ModuleResult, erro
 	}
 
 	typechecker.MergeModuleKnownRoots(result.PerPackage)
-	for _, tc := range result.PerPackage {
-		if err := tc.RevalidateDeferredWiringKeysAfterModuleMerge(); err != nil {
-			return nil, err
-		}
+	if err := revalidateDeferredWiringKeys(result.PerPackage); err != nil {
+		return nil, err
 	}
 
 	moduleGraph := providersgraph.NewModuleGraph(perPkgProviders)

--- a/forst/internal/modulecheck/module_revalidate.go
+++ b/forst/internal/modulecheck/module_revalidate.go
@@ -1,0 +1,12 @@
+package modulecheck
+
+import "forst/internal/typechecker"
+
+func revalidateDeferredWiringKeys(perPackage map[string]*typechecker.TypeChecker) error {
+	for _, tc := range perPackage {
+		if err := tc.RevalidateDeferredWiringKeysAfterModuleMerge(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/forst/internal/modulecheck/module_revalidate_test.go
+++ b/forst/internal/modulecheck/module_revalidate_test.go
@@ -1,0 +1,17 @@
+package modulecheck
+
+import (
+	"testing"
+
+	"forst/internal/typechecker"
+)
+
+func TestRevalidateDeferredWiringKeys_emptyPackages(t *testing.T) {
+	t.Parallel()
+	if err := revalidateDeferredWiringKeys(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := revalidateDeferredWiringKeys(map[string]*typechecker.TypeChecker{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/forst/internal/parser/ensure.go
+++ b/forst/internal/parser/ensure.go
@@ -111,7 +111,11 @@ func (p *Parser) parseEnsureStatement() ast.EnsureNode {
 	if !p.context.IsMainFunction() && p.current().Type == ast.TokenOr {
 		p.expect(ast.TokenOr) // Expect `or`
 
-		errorType := p.expect(ast.TokenIdentifier).Value
+		errorTok := p.expect(ast.TokenIdentifier)
+		if !isCapitalCase(errorTok.Value) {
+			p.FailWithParseError(errorTok, "ensure `or` error handler must start with an uppercase letter")
+		}
+		errorType := errorTok.Value
 		var err ast.EnsureErrorNode
 		if p.current().Type == ast.TokenLParen {
 			p.advance() // Consume left paren

--- a/forst/internal/parser/ensure.go
+++ b/forst/internal/parser/ensure.go
@@ -112,9 +112,6 @@ func (p *Parser) parseEnsureStatement() ast.EnsureNode {
 		p.expect(ast.TokenOr) // Expect `or`
 
 		errorTok := p.expect(ast.TokenIdentifier)
-		if !isCapitalCase(errorTok.Value) {
-			p.FailWithParseError(errorTok, "ensure `or` error handler must start with an uppercase letter")
-		}
 		errorType := errorTok.Value
 		var err ast.EnsureErrorNode
 		if p.current().Type == ast.TokenLParen {

--- a/forst/internal/parser/negative_integration_test.go
+++ b/forst/internal/parser/negative_integration_test.go
@@ -44,24 +44,6 @@ func run(x Int): Result(Int, Error) {
 	}
 }
 
-func TestParseFile_ensureOr_errorHandlerMustBeUppercase(t *testing.T) {
-	t.Parallel()
-	src := `package main
-
-func f(x Int): Result(Int, Error) {
-	ensure x is GreaterThan(1) or bad("nope")
-	return x
-}
-`
-	err := parseShouldFail(src)
-	if err == nil {
-		t.Fatal("expected parse error for lowercase ensure-or handler")
-	}
-	if !strings.Contains(err.Error(), "uppercase") {
-		t.Fatalf("expected uppercase requirement in error, got: %v", err)
-	}
-}
-
 func TestParseFile_elseIfMissingBlock_reportsTokenLocation(t *testing.T) {
 	t.Parallel()
 	src := `package main

--- a/forst/internal/parser/negative_integration_test.go
+++ b/forst/internal/parser/negative_integration_test.go
@@ -44,6 +44,24 @@ func run(x Int): Result(Int, Error) {
 	}
 }
 
+func TestParseFile_ensureOr_errorHandlerMustBeUppercase(t *testing.T) {
+	t.Parallel()
+	src := `package main
+
+func f(x Int): Result(Int, Error) {
+	ensure x is GreaterThan(1) or bad("nope")
+	return x
+}
+`
+	err := parseShouldFail(src)
+	if err == nil {
+		t.Fatal("expected parse error for lowercase ensure-or handler")
+	}
+	if !strings.Contains(err.Error(), "uppercase") {
+		t.Fatalf("expected uppercase requirement in error, got: %v", err)
+	}
+}
+
 func TestParseFile_elseIfMissingBlock_reportsTokenLocation(t *testing.T) {
 	t.Parallel()
 	src := `package main

--- a/forst/internal/parser/parse_constraint_negative_int_test.go
+++ b/forst/internal/parser/parse_constraint_negative_int_test.go
@@ -11,12 +11,12 @@ func TestParseFile_ensureWithOrClause_negativeIntConstraint(t *testing.T) {
 
 import "errors"
 
-func invalidMove(msg String): Error {
+func InvalidMove(msg String): Error {
 	return errors.New(msg)
 }
 
 func f(row Int): Result(String, Error) {
-	ensure row is GreaterThan(-1) or invalidMove("bad")
+	ensure row is GreaterThan(-1) or InvalidMove("bad")
 	return ""
 }
 `

--- a/forst/internal/providersgraph/edge_test.go
+++ b/forst/internal/providersgraph/edge_test.go
@@ -1,0 +1,81 @@
+package providersgraph
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestCallEdge_IsCrossPackage(t *testing.T) {
+	intra := CallEdge{CalleePkg: ""}
+	if intra.IsCrossPackage() {
+		t.Fatal("intra-package edge should not be cross-package")
+	}
+	cross := CallEdge{CalleePkg: "alpha"}
+	if !cross.IsCrossPackage() {
+		t.Fatal("expected cross-package edge")
+	}
+}
+
+func TestCallEdge_ToModuleCallEdge(t *testing.T) {
+	scope := ProviderScopeSnapshot{"Logger": {Ident: "Logger"}}
+	e := CallEdge{
+		CallerPkg:   "beta",
+		CallerFn:    "Handle",
+		CalleePkg:   "alpha",
+		CalleeFn:    "ExpireToken",
+		Scope:       scope,
+	}
+	got := e.ToModuleCallEdge()
+	if got.CallerPkg != "beta" || got.CallerFn != "Handle" {
+		t.Fatalf("caller fields: %+v", got)
+	}
+	if got.TargetPkg != "alpha" || got.TargetFn != "ExpireToken" {
+		t.Fatalf("target fields: %+v", got)
+	}
+	if got.ProviderScope["Logger"].Ident != "Logger" {
+		t.Fatalf("scope: %+v", got.ProviderScope)
+	}
+}
+
+func TestIntraEdgesFromCallEdges_filtersCrossPackage(t *testing.T) {
+	edges := []CallEdge{
+		{CallerFn: "a", CalleeFn: "b"},
+		{CallerFn: "c", CalleeFn: "d", CalleePkg: "other"},
+	}
+	got := IntraEdgesFromCallEdges(edges)
+	if len(got) != 1 {
+		t.Fatalf("expected one intra edge, got %d", len(got))
+	}
+	if got[0].Caller != "a" || got[0].Callee != "b" {
+		t.Fatalf("intra edge: %+v", got[0])
+	}
+}
+
+func TestModuleEdgesFromCallEdges_filtersIntraPackage(t *testing.T) {
+	scope := ProviderScopeSnapshot{"K": {Ident: "K"}}
+	edges := []CallEdge{
+		{CallerFn: "a", CalleeFn: "b"},
+		{
+			CallerPkg:   "beta",
+			CallerFn:    "Handle",
+			CalleePkg:   "alpha",
+			CalleeFn:    "ExpireToken",
+			Scope:       scope,
+		},
+	}
+	got := ModuleEdgesFromCallEdges(edges)
+	if len(got) != 1 {
+		t.Fatalf("expected one module edge, got %d", len(got))
+	}
+	if got[0].TargetPkg != "alpha" || got[0].TargetFn != "ExpireToken" {
+		t.Fatalf("module edge: %+v", got[0])
+	}
+}
+
+func TestModuleEdgesFromCallEdges_emptyCalleePkgSkipped(t *testing.T) {
+	got := ModuleEdgesFromCallEdges([]CallEdge{{CallerFn: ast.Identifier("x"), CalleeFn: "y"}})
+	if len(got) != 0 {
+		t.Fatalf("expected no module edges, got %v", got)
+	}
+}

--- a/forst/internal/providersgraph/graph_test.go
+++ b/forst/internal/providersgraph/graph_test.go
@@ -79,6 +79,80 @@ func TestGraphInvalidate_transitiveCallers(t *testing.T) {
 	}
 }
 
+func TestGraph_SetDirectAndSlots(t *testing.T) {
+	g := New()
+	g.SetDirect("fn", map[string]Slot{
+		"Logger": {RootIdent: "Logger", Key: "Logger"},
+	})
+	if len(g.direct["fn"]) != 1 {
+		t.Fatalf("direct slots: %v", g.direct["fn"])
+	}
+	g.SetDirect("empty", nil)
+	if _, ok := g.direct["empty"]; ok {
+		t.Fatal("empty direct map should not be stored")
+	}
+	g.ComputeIntraFixedPoint(ProviderScopeKeyPresent)
+	if len(g.Slots("fn")) != 1 {
+		t.Fatalf("Slots(fn) = %v", g.Slots("fn"))
+	}
+	all := g.AllSlots()
+	if len(all["fn"]) != 1 {
+		t.Fatalf("AllSlots = %v", all)
+	}
+}
+
+func TestGraph_AddModuleCallAndIntraCall(t *testing.T) {
+	g := New()
+	g.AddIntraCall("caller", "callee", ProviderScopeSnapshot{"K": {Ident: "K"}})
+	if len(g.intraEdges) != 1 {
+		t.Fatalf("intra edges: %v", g.intraEdges)
+	}
+	g.AddModuleCall(ModuleCallEdge{
+		CallerPkg: "beta",
+		CallerFn:  "Handle",
+		TargetPkg: "alpha",
+		TargetFn:  "ExpireToken",
+	})
+	if len(g.moduleEdges) != 1 {
+		t.Fatalf("module edges: %v", g.moduleEdges)
+	}
+}
+
+func TestModuleGraph_AllPackages(t *testing.T) {
+	perPkg := map[string]map[ast.Identifier][]Slot{
+		"alpha": {"F": {{RootIdent: "Logger", Key: "Logger"}}},
+	}
+	mg := NewModuleGraph(perPkg)
+	all := mg.AllPackages()
+	if len(all["alpha"]["F"]) != 1 {
+		t.Fatalf("AllPackages = %v", all)
+	}
+	all["alpha"]["F"][0].RootIdent = "mutated"
+	if mg.PerPackage("alpha")["F"][0].RootIdent != "Logger" {
+		t.Fatal("AllPackages should return a deep copy")
+	}
+}
+
+func TestModuleGraph_emptyPackageClone(t *testing.T) {
+	mg := NewModuleGraph(map[string]map[ast.Identifier][]Slot{
+		"empty": {},
+	})
+	all := mg.AllPackages()
+	if len(all["empty"]) != 0 {
+		t.Fatalf("expected empty fn map, got %v", all["empty"])
+	}
+}
+
+func TestGraph_Invalidate_skipsDuplicateCallers(t *testing.T) {
+	g := New()
+	g.AddIntraCall("a", "b", nil)
+	g.AddIntraCall("a", "b", nil)
+	invalid := g.Invalidate("b")
+	if len(invalid) != 2 {
+		t.Fatalf("got %v", invalid)
+	}
+}
+
 func TestModuleGraph_fixedPoint(t *testing.T) {
 	perPkg := map[string]map[ast.Identifier][]Slot{
 		"alpha": {"ExpireToken": {{RootIdent: "Logger", Key: "Logger"}}},

--- a/forst/internal/providersgraph/propagate_test.go
+++ b/forst/internal/providersgraph/propagate_test.go
@@ -105,7 +105,7 @@ func TestPropagateIntraPackageFixedPoint_customSatisfiesSkips(t *testing.T) {
 		Callee:        "callee",
 		ProviderScope: ProviderScopeSnapshot{"Logger": {Ident: "Logger"}},
 	}}
-	satisfies := func(slot Slot, scope map[string]ast.TypeNode) bool { return true }
+	satisfies := func(_ Slot, _ map[string]ast.TypeNode) bool { return true }
 	PropagateIntraPackageFixedPoint(slots, direct, edges, satisfies)
 	if len(slots["caller"]) != 0 {
 		t.Fatalf("expected satisfied scope to skip propagation, got %v", slots["caller"])

--- a/forst/internal/providersgraph/propagate_test.go
+++ b/forst/internal/providersgraph/propagate_test.go
@@ -1,0 +1,113 @@
+package providersgraph
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestPropagateModuleFixedPoint_emptyEdgesNoOp(t *testing.T) {
+	t.Parallel()
+	perPkg := map[string]map[ast.Identifier][]Slot{
+		"alpha": {"F": {{RootIdent: "Logger", Key: "Logger"}}},
+	}
+	PropagateModuleFixedPoint(perPkg, nil, nil)
+	if len(perPkg["alpha"]["F"]) != 1 {
+		t.Fatalf("unexpected mutation: %v", perPkg)
+	}
+}
+
+func TestPropagateModuleFixedPoint_nilSatisfiesUsesDefault(t *testing.T) {
+	t.Parallel()
+	perPkg := map[string]map[ast.Identifier][]Slot{
+		"alpha": {"Callee": {{RootIdent: "Logger", Key: "Logger"}}},
+		"beta":  {"Caller": nil},
+	}
+	PropagateModuleFixedPoint(perPkg, []ModuleCallEdge{{
+		CallerPkg: "beta",
+		CallerFn:  "Caller",
+		TargetPkg: "alpha",
+		TargetFn:  "Callee",
+	}}, nil)
+	if len(perPkg["beta"]["Caller"]) != 1 {
+		t.Fatalf("got %v", perPkg["beta"]["Caller"])
+	}
+}
+
+func TestPropagateModuleFixedPoint_skipsCalleeWithNoSlots(t *testing.T) {
+	t.Parallel()
+	perPkg := map[string]map[ast.Identifier][]Slot{
+		"alpha": {"Callee": nil},
+		"beta":  {"Caller": nil},
+	}
+	PropagateModuleFixedPoint(perPkg, []ModuleCallEdge{{
+		CallerPkg: "beta",
+		CallerFn:  "Caller",
+		TargetPkg: "alpha",
+		TargetFn:  "Callee",
+	}}, ProviderScopeKeyPresent)
+	if len(perPkg["beta"]["Caller"]) != 0 {
+		t.Fatalf("expected no propagation from empty callee slots, got %v", perPkg["beta"]["Caller"])
+	}
+}
+
+func TestPropagateModuleFixedPoint_createsCallerPackageMap(t *testing.T) {
+	t.Parallel()
+	perPkg := map[string]map[ast.Identifier][]Slot{
+		"alpha": {
+			"ExpireToken": {{RootIdent: "Logger", Key: "Logger", SourcePkg: "alpha"}},
+		},
+	}
+	PropagateModuleFixedPoint(perPkg, []ModuleCallEdge{{
+		CallerPkg: "beta",
+		CallerFn:  "Handle",
+		TargetPkg: "alpha",
+		TargetFn:  "ExpireToken",
+	}}, ProviderScopeKeyPresent)
+	if len(perPkg["beta"]["Handle"]) != 1 {
+		t.Fatalf("got %v", perPkg["beta"]["Handle"])
+	}
+}
+
+func TestPropagateModuleFixedPoint_multiHopPropagation(t *testing.T) {
+	t.Parallel()
+	perPkg := map[string]map[ast.Identifier][]Slot{
+		"alpha": {"Leaf": {{RootIdent: "Clock", Key: "Clock"}}},
+		"beta":  {"Mid": nil},
+		"gamma": {"Root": nil},
+	}
+	edges := []ModuleCallEdge{
+		{CallerPkg: "beta", CallerFn: "Mid", TargetPkg: "alpha", TargetFn: "Leaf"},
+		{CallerPkg: "gamma", CallerFn: "Root", TargetPkg: "beta", TargetFn: "Mid"},
+	}
+	PropagateModuleFixedPoint(perPkg, edges, ProviderScopeKeyPresent)
+	if len(perPkg["gamma"]["Root"]) != 1 || perPkg["gamma"]["Root"][0].RootIdent != "Clock" {
+		t.Fatalf("got %v", perPkg["gamma"]["Root"])
+	}
+}
+
+func TestPropagateIntraPackageFixedPoint_nilSlotsMap(t *testing.T) {
+	t.Parallel()
+	direct := map[ast.Identifier]map[string]Slot{
+		"f": {"Logger": {RootIdent: "Logger", Key: "Logger"}},
+	}
+	PropagateIntraPackageFixedPoint(nil, direct, nil, ProviderScopeKeyPresent)
+}
+
+func TestPropagateIntraPackageFixedPoint_customSatisfiesSkips(t *testing.T) {
+	t.Parallel()
+	slots := make(map[ast.Identifier][]Slot)
+	direct := map[ast.Identifier]map[string]Slot{
+		"callee": { "Logger": {RootIdent: "Logger", Key: "Logger"} },
+	}
+	edges := []IntraPackageEdge{{
+		Caller:        "caller",
+		Callee:        "callee",
+		ProviderScope: ProviderScopeSnapshot{"Logger": {Ident: "Logger"}},
+	}}
+	satisfies := func(slot Slot, scope map[string]ast.TypeNode) bool { return true }
+	PropagateIntraPackageFixedPoint(slots, direct, edges, satisfies)
+	if len(slots["caller"]) != 0 {
+		t.Fatalf("expected satisfied scope to skip propagation, got %v", slots["caller"])
+	}
+}

--- a/forst/internal/providersgraph/slot_test.go
+++ b/forst/internal/providersgraph/slot_test.go
@@ -53,6 +53,37 @@ func TestRootIdentsFromSlots_emptyReturnsNil(t *testing.T) {
 	}
 }
 
+func TestRootIdentsFromSlots_returnsOrderedIdents(t *testing.T) {
+	t.Parallel()
+	got := RootIdentsFromSlots([]Slot{
+		{RootIdent: "Logger"},
+		{RootIdent: "Clock"},
+	})
+	if len(got) != 2 || got[0] != "Logger" || got[1] != "Clock" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestOrderSlots_singleElementPassthrough(t *testing.T) {
+	t.Parallel()
+	in := []Slot{{Key: "Only", RootIdent: "Only"}}
+	got := OrderSlots(in)
+	if len(got) != 1 || got[0].Key != "Only" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestSlotsFromDirectMap_ordersKeys(t *testing.T) {
+	t.Parallel()
+	got := SlotsFromDirectMap(map[string]Slot{
+		"B": {Key: "B", RootIdent: "B"},
+		"A": {Key: "A", RootIdent: "A"},
+	})
+	if len(got) != 2 || got[0].Key != "A" || got[1].Key != "B" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
 func TestProviderScopeKeyPresent(t *testing.T) {
 	t.Parallel()
 	slot := Slot{RootIdent: "Logger"}

--- a/forst/internal/safefs/safefs.go
+++ b/forst/internal/safefs/safefs.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+var (
+	safefsPathAbs = filepath.Abs
+	safefsPathRel = filepath.Rel
+	safefsOpenRoot = os.OpenRoot
+)
+
 // RootedFS confines file operations to one directory tree using os.Root.
 type RootedFS struct {
 	root    *os.Root
@@ -17,7 +23,7 @@ type RootedFS struct {
 
 // OpenRoot opens absRoot as the filesystem root. absRoot must be an existing directory.
 func OpenRoot(absRoot string) (*RootedFS, error) {
-	abs, err := filepath.Abs(absRoot)
+	abs, err := safefsPathAbs(absRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +35,7 @@ func OpenRoot(absRoot string) (*RootedFS, error) {
 	if !info.IsDir() {
 		return nil, fmt.Errorf("safefs: not a directory: %s", abs)
 	}
-	root, err := os.OpenRoot(abs)
+	root, err := safefsOpenRoot(abs)
 	if err != nil {
 		return nil, err
 	}
@@ -63,12 +69,12 @@ func (r *RootedFS) Stat(rel string) (fs.FileInfo, error) {
 
 // RelPath returns a slash-separated relative path when absPath is under the root.
 func (r *RootedFS) RelPath(absPath string) (string, error) {
-	abs, err := filepath.Abs(absPath)
+	abs, err := safefsPathAbs(absPath)
 	if err != nil {
 		return "", err
 	}
 	abs = filepath.Clean(abs)
-	rel, err := filepath.Rel(r.absRoot, abs)
+	rel, err := safefsPathRel(r.absRoot, abs)
 	if err != nil {
 		return "", err
 	}

--- a/forst/internal/safefs/safefs_test.go
+++ b/forst/internal/safefs/safefs_test.go
@@ -66,6 +66,80 @@ func TestOpenRoot_escapeDotDot(t *testing.T) {
 	}
 }
 
+func TestOpenRoot_missingDirectory(t *testing.T) {
+	_, err := OpenRoot(filepath.Join(t.TempDir(), "missing-subdir"))
+	if err == nil {
+		t.Fatal("expected error for missing directory")
+	}
+}
+
+func TestRelPath_dotDotSegmentRejected(t *testing.T) {
+	dir := t.TempDir()
+	r, err := OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	parent := filepath.Dir(dir)
+	_, err = r.RelPath(parent)
+	if err == nil {
+		t.Fatal("expected outside-root error")
+	}
+}
+
+func TestOpenRoot_invalidPath(t *testing.T) {
+	orig := safefsPathAbs
+	safefsPathAbs = func(string) (string, error) { return "", os.ErrInvalid }
+	t.Cleanup(func() { safefsPathAbs = orig })
+	_, err := OpenRoot("any")
+	if err == nil {
+		t.Fatal("expected error for invalid path")
+	}
+}
+
+func TestOpenRoot_openRootError(t *testing.T) {
+	dir := t.TempDir()
+	orig := safefsOpenRoot
+	safefsOpenRoot = func(string) (*os.Root, error) { return nil, os.ErrInvalid }
+	t.Cleanup(func() { safefsOpenRoot = orig })
+	_, err := OpenRoot(dir)
+	if err == nil {
+		t.Fatal("expected OpenRoot error")
+	}
+}
+
+func TestRelPath_invalidAbsPath(t *testing.T) {
+	dir := t.TempDir()
+	r, err := OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	orig := safefsPathAbs
+	safefsPathAbs = func(string) (string, error) { return "", os.ErrInvalid }
+	t.Cleanup(func() { safefsPathAbs = orig })
+	_, err = r.RelPath("any")
+	if err == nil {
+		t.Fatal("expected abs error")
+	}
+}
+
+func TestRelPath_relError(t *testing.T) {
+	dir := t.TempDir()
+	r, err := OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	orig := safefsPathRel
+	safefsPathRel = func(string, string) (string, error) { return "", os.ErrInvalid }
+	t.Cleanup(func() { safefsPathRel = orig })
+	_, err = r.RelPath(filepath.Join(dir, "inside.ft"))
+	if err == nil {
+		t.Fatal("expected rel error")
+	}
+}
+
 func TestRelPath_insideAndOutside(t *testing.T) {
 	dir := t.TempDir()
 	r, err := OpenRoot(dir)

--- a/forst/internal/safefs/safefs_test.go
+++ b/forst/internal/safefs/safefs_test.go
@@ -18,7 +18,7 @@ func TestOpenRoot_readInside(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	t.Cleanup(func() { _ = r.Close() })
 
 	if got := r.AbsRoot(); got != filepath.Clean(dir) {
 		t.Fatalf("AbsRoot=%q want %q", got, filepath.Clean(dir))
@@ -58,7 +58,7 @@ func TestOpenRoot_escapeDotDot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	t.Cleanup(func() { _ = r.Close() })
 
 	_, err = r.ReadFile("../outside")
 	if err == nil {
@@ -79,7 +79,7 @@ func TestRelPath_dotDotSegmentRejected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	t.Cleanup(func() { _ = r.Close() })
 	parent := filepath.Dir(dir)
 	_, err = r.RelPath(parent)
 	if err == nil {
@@ -114,7 +114,7 @@ func TestRelPath_invalidAbsPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	t.Cleanup(func() { _ = r.Close() })
 	orig := safefsPathAbs
 	safefsPathAbs = func(string) (string, error) { return "", os.ErrInvalid }
 	t.Cleanup(func() { safefsPathAbs = orig })
@@ -130,7 +130,7 @@ func TestRelPath_relError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	t.Cleanup(func() { _ = r.Close() })
 	orig := safefsPathRel
 	safefsPathRel = func(string, string) (string, error) { return "", os.ErrInvalid }
 	t.Cleanup(func() { safefsPathRel = orig })
@@ -146,7 +146,7 @@ func TestRelPath_insideAndOutside(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	t.Cleanup(func() { _ = r.Close() })
 
 	inside := filepath.Join(dir, "sub", "file.ft")
 	if err := os.MkdirAll(filepath.Dir(inside), 0o755); err != nil {
@@ -187,7 +187,7 @@ func TestWalkDir_collectsFt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	t.Cleanup(func() { _ = r.Close() })
 
 	var ftPaths []string
 	err = fs.WalkDir(r.FS(), ".", func(path string, d fs.DirEntry, err error) error {
@@ -233,7 +233,7 @@ func TestSymlinkEscape_unix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	t.Cleanup(func() { _ = r.Close() })
 
 	_, err = r.ReadFile("link")
 	if err == nil {

--- a/forst/internal/testmod/testmod_test.go
+++ b/forst/internal/testmod/testmod_test.go
@@ -44,6 +44,6 @@ type stubFatal struct {
 
 func (s *stubFatal) Helper() {}
 
-func (s *stubFatal) Fatal(args ...interface{}) {
+func (s *stubFatal) Fatal(_ ...interface{}) {
 	s.failed = true
 }

--- a/forst/internal/testrunner/exit_code_test.go
+++ b/forst/internal/testrunner/exit_code_test.go
@@ -1,0 +1,19 @@
+package testrunner
+
+import "testing"
+
+func TestExitCode_Int(t *testing.T) {
+	cases := []struct {
+		code ExitCode
+		want int
+	}{
+		{ExitSuccess, 0},
+		{ExitFailure, 1},
+		{ExitError, 2},
+	}
+	for _, tc := range cases {
+		if got := tc.code.Int(); got != tc.want {
+			t.Fatalf("ExitCode(%d).Int() = %d, want %d", tc.code, got, tc.want)
+		}
+	}
+}

--- a/forst/internal/testrunner/runner_test.go
+++ b/forst/internal/testrunner/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"forst/internal/modulecheck"
 	"forst/internal/testmod"
 
 	"github.com/sirupsen/logrus"
@@ -125,6 +126,59 @@ func TestRun_providersWithWiringPasses(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "auth", generatedTestGoName)); !os.IsNotExist(err) {
 		t.Fatal("expected generated test file removed after run")
+	}
+}
+
+func TestRelPath(t *testing.T) {
+	moduleRoot := filepath.Clean("/proj")
+	if got := relPath(moduleRoot, filepath.Join(moduleRoot, "auth")); got != "auth" {
+		t.Fatalf("relPath = %q", got)
+	}
+	if got := relPath(moduleRoot, moduleRoot); got != "." {
+		t.Fatalf("same dir relPath = %q", got)
+	}
+}
+
+func TestIndexOf(t *testing.T) {
+	if indexOf([]string{"a", "--", "b"}, "--") != 1 {
+		t.Fatal("expected index 1")
+	}
+	if indexOf([]string{"a"}, "--") != -1 {
+		t.Fatal("expected -1")
+	}
+}
+
+func TestEmitDependencyPackages_writesLibraryGo(t *testing.T) {
+	dir := t.TempDir()
+	writeProvidersTestFixture(t, dir)
+	libDir := filepath.Join(dir, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "lib.ft"), []byte(`package lib
+
+func Helper(): Int { return 1 }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	log := logrus.New()
+	log.SetOutput(os.Stderr)
+	log.SetLevel(logrus.PanicLevel)
+	modResult, err := modulecheck.CheckModuleProviders(log, modulecheck.Options{ModuleRoot: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDirs := map[string]struct{}{filepath.Join(dir, "auth"): {}}
+	if err := emitDependencyPackages(dir, modResult, testDirs, log); err != nil {
+		t.Fatal(err)
+	}
+	genPath := filepath.Join(libDir, "z_forst_gen.go")
+	data, err := os.ReadFile(genPath)
+	if err != nil {
+		t.Fatalf("expected generated lib Go: %v", err)
+	}
+	if !strings.Contains(string(data), "Helper") {
+		t.Fatalf("generated code missing Helper:\n%s", data)
 	}
 }
 

--- a/forst/internal/transformer/go/compound_assign_test.go
+++ b/forst/internal/transformer/go/compound_assign_test.go
@@ -1,0 +1,54 @@
+package transformergo
+
+import (
+	"go/token"
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestCompoundAssignGoToken(t *testing.T) {
+	cases := []struct {
+		op   ast.TokenIdent
+		want token.Token
+	}{
+		{ast.TokenPlusEq, token.ADD_ASSIGN},
+		{ast.TokenMinusEq, token.SUB_ASSIGN},
+		{ast.TokenStarEq, token.MUL_ASSIGN},
+		{ast.TokenDivideEq, token.QUO_ASSIGN},
+		{ast.TokenModuloEq, token.REM_ASSIGN},
+		{ast.TokenBitwiseAndEq, token.AND_ASSIGN},
+		{ast.TokenBitwiseOrEq, token.OR_ASSIGN},
+	}
+	for _, tc := range cases {
+		got, ok := compoundAssignGoToken(tc.op)
+		if !ok || got != tc.want {
+			t.Fatalf("%s: got %v ok=%v", tc.op, got, ok)
+		}
+	}
+	if _, ok := compoundAssignGoToken(ast.TokenIdent("??=")); ok {
+		t.Fatal("expected false for unknown op")
+	}
+}
+
+func TestAssignmentGoToken(t *testing.T) {
+	short := ast.AssignmentNode{IsShort: true}
+	tok, err := assignmentGoToken(short)
+	if err != nil || tok != token.DEFINE {
+		t.Fatalf("short decl: %v %v", tok, err)
+	}
+	regular := ast.AssignmentNode{}
+	tok, err = assignmentGoToken(regular)
+	if err != nil || tok != token.ASSIGN {
+		t.Fatalf("regular assign: %v %v", tok, err)
+	}
+	compound := ast.AssignmentNode{CompoundOp: ast.TokenPlusEq}
+	tok, err = assignmentGoToken(compound)
+	if err != nil || tok != token.ADD_ASSIGN {
+		t.Fatalf("compound assign: %v %v", tok, err)
+	}
+	_, err = assignmentGoToken(ast.AssignmentNode{CompoundOp: ast.TokenIdent("??=")})
+	if err == nil {
+		t.Fatal("expected error for unsupported compound op")
+	}
+}

--- a/forst/internal/transformer/go/cross_pkg_module_test.go
+++ b/forst/internal/transformer/go/cross_pkg_module_test.go
@@ -1,0 +1,160 @@
+package transformergo
+
+import (
+	"bytes"
+	"go/format"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/forstpkg"
+	"forst/internal/modulecheck"
+	"forst/internal/testmod"
+	"forst/internal/typechecker"
+)
+
+func writeCrossPkgModule(t *testing.T, dir string) {
+	t.Helper()
+	testmod.WriteGoMod(t, dir, "xpkg")
+	alphaDir := filepath.Join(dir, "alpha")
+	betaDir := filepath.Join(dir, "beta")
+	for _, d := range []string{alphaDir, betaDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(alphaDir, "log.ft"), `package alpha
+
+type Logger = { Info(msg String) }
+type NopLogger = {}
+
+func (NopLogger) Info(msg String) {}
+
+func LogExpiry(id String) {
+	use logger: Logger
+	logger.Info("expire " + id)
+}
+`)
+	writeFile(t, filepath.Join(betaDir, "handle.ft"), `package beta
+
+import "xpkg/alpha"
+
+type Logger = { Info(msg String) }
+
+func Handle(id String) {
+	alpha.LogExpiry(id)
+}
+`)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func transformBetaPackage(t *testing.T, moduleRoot string) string {
+	t.Helper()
+	modResult, err := modulecheck.CheckModuleProviders(nil, modulecheck.Options{ModuleRoot: moduleRoot})
+	if err != nil {
+		t.Fatalf("CheckModuleProviders: %v", err)
+	}
+	betaTC := modResult.ForstPackageTypeChecker("beta")
+	if betaTC == nil {
+		t.Fatal("missing beta typechecker")
+	}
+	betaPath := filepath.Join(moduleRoot, "beta", "handle.ft")
+	merged, _, err := forstpkg.ParseAndMergePackage(nil, []string{betaPath})
+	if err != nil {
+		t.Fatalf("parse beta: %v", err)
+	}
+	log := ast.SetupTestLogger(nil)
+	log.SetOutput(bytes.NewBuffer(nil))
+	tr := New(betaTC, log)
+	tr.SetModuleResult(modResult)
+	goFile, err := tr.TransformForstFileToGo(merged)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := format.Node(&buf, token.NewFileSet(), goFile); err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	return buf.String()
+}
+
+func TestCrossPkgModule_HandleForwardsProvidersToAlpha(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeCrossPkgModule(t, dir)
+	out := transformBetaPackage(t, dir)
+	for _, sub := range []string{
+		`func Handle(providers`,
+		`Providers_`,
+		`alpha.LogExpiry(`,
+		`alpha.Providers_`,
+		`Logger:`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("missing %q in:\n%s", sub, out)
+		}
+	}
+	assertGoParses(t, out)
+}
+
+func TestBuildCrossPackageProvidersLiteral_unit(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tr := setupTransformer(tc, log)
+	tr.currentFnProvidersName = "providers_"
+	slots := []typechecker.ProviderSlot{{RootIdent: "Logger", ContractType: ast.TypeNode{Ident: "Logger"}}}
+	lit, err := tr.buildCrossPackageProvidersLiteral("alpha", slots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := goExprString(t, lit)
+	if !strings.Contains(s, "alpha.Providers_") || !strings.Contains(s, "providers_.Logger") {
+		t.Fatalf("got %s", s)
+	}
+}
+
+func TestImportLocalForForstPkg_viaModuleResult(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeCrossPkgModule(t, dir)
+	modResult, err := modulecheck.CheckModuleProviders(nil, modulecheck.Options{ModuleRoot: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	betaTC := modResult.ForstPackageTypeChecker("beta")
+	if betaTC == nil {
+		t.Fatal("missing beta tc")
+	}
+	got := importLocalForForstPkg(betaTC, modResult, "alpha")
+	if got != "alpha" {
+		t.Fatalf("import local = %q, want alpha", got)
+	}
+}
+
+func TestCalleeProviderSlots_crossPackageQualified(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeCrossPkgModule(t, dir)
+	modResult, err := modulecheck.CheckModuleProviders(nil, modulecheck.Options{ModuleRoot: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	betaTC := modResult.ForstPackageTypeChecker("beta")
+	log := setupTestLogger(nil)
+	tr := New(betaTC, log)
+	tr.SetModuleResult(modResult)
+	slots := tr.calleeProviderSlots("alpha.LogExpiry")
+	if len(slots) != 1 || slots[0].RootIdent != "Logger" {
+		t.Fatalf("slots = %#v", slots)
+	}
+}

--- a/forst/internal/transformer/go/emit_validation_coverage_test.go
+++ b/forst/internal/transformer/go/emit_validation_coverage_test.go
@@ -243,3 +243,242 @@ func main() {
 	}
 	assertGoParses(t, out)
 }
+
+func TestEmitValidation_nominalErrorConstructor(t *testing.T) {
+	src := `package main
+
+error NotFound {
+	id: String
+}
+
+func main() {
+	e := NotFound({ id: "x" })
+	println(e.id)
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `type NotFound`) || !strings.Contains(out, `NotFound{`) {
+		t.Fatalf("expected nominal error emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_compoundAssignPlusEq(t *testing.T) {
+	src := `package main
+
+func main() {
+	n := 1
+	n += 2
+	println(n)
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `+=`) {
+		t.Fatalf("expected += emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_ensureTypeGuardCall(t *testing.T) {
+	src := `package main
+
+is (n Int) Positive {
+	ensure n is GreaterThan(0)
+}
+
+func main() {
+	x := 5
+	ensure x is Positive()
+	println(x)
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `func G_`) || !strings.Contains(out, `os.Exit`) {
+		t.Fatalf("expected type guard ensure emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_stringBuiltinBool(t *testing.T) {
+	src := `package main
+
+func main() {
+	b := true
+	println(string(b))
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `strconv.FormatBool`) {
+		t.Fatalf("expected FormatBool for string(bool):\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_providersCrossFunctionCall(t *testing.T) {
+	src := `package main
+
+type Logger = { info(msg String) }
+type NopLogger = {}
+
+func (NopLogger) info(msg String) {}
+
+func callee() {
+	use logger: Logger
+	logger.info("callee")
+}
+
+func main() {
+	with { Logger: NopLogger{} } {
+		callee()
+	}
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `callee(providers`) {
+		t.Fatalf("expected providers param on callee:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_typedefAssertionAlias(t *testing.T) {
+	src := `package main
+
+type Slug = String.Min(1).Max(64)
+
+func main() {
+	s: Slug = "hello"
+	println(s)
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `type Slug`) {
+		t.Fatalf("expected Slug typedef emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_receiverMethod(t *testing.T) {
+	src := `package main
+
+type Counter = { n: Int }
+
+func (Counter) bump(): Counter {
+	return { n: 1 }
+}
+
+func main() {
+	c := Counter{ n: 0 }
+	c = c.bump()
+	println(string(c.n))
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `func (Counter) bump`) {
+		t.Fatalf("expected receiver method emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_resultAssign(t *testing.T) {
+	src := `package main
+
+func f(): Result(Int, Error) {
+	return 1
+}
+
+func main() {
+	x := f()
+	println(x)
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `x, xErr :=`) {
+		t.Fatalf("expected Result assign emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_typeAliasWithConstraints(t *testing.T) {
+	src := `package main
+
+type Slug = String.Min(1).Max(64)
+type Label = Slug
+
+func main() {
+	s: Label = "hello"
+	println(s)
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `type Slug`) || !strings.Contains(out, `type Label`) {
+		t.Fatalf("expected alias emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_deferAndGoStmt(t *testing.T) {
+	src := `package main
+
+func cleanup() {}
+
+func main() {
+	defer cleanup()
+	go cleanup()
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `defer cleanup()`) || !strings.Contains(out, `go cleanup()`) {
+		t.Fatalf("expected defer/go emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_postfixIncDec(t *testing.T) {
+	src := `package main
+
+func main() {
+	i := 0
+	i++
+	i--
+	println(string(i))
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `i++`) || !strings.Contains(out, `i--`) {
+		t.Fatalf("expected inc/dec emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_compoundAssignForPost(t *testing.T) {
+	src := `package main
+
+func main() {
+	for i := 0; i < 3; i += 1 {
+		println(string(i))
+	}
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `i += 1`) {
+		t.Fatalf("expected compound assign in for post:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestEmitValidation_rangeTwoVars(t *testing.T) {
+	src := `package main
+
+func main() {
+	xs := [10, 20]
+	for i, v := range xs {
+		println(string(i) + string(v))
+	}
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `range xs`) {
+		t.Fatalf("expected range emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}

--- a/forst/internal/transformer/go/emit_validation_examples_test.go
+++ b/forst/internal/transformer/go/emit_validation_examples_test.go
@@ -1,0 +1,43 @@
+package transformergo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEmitValidation_examplesBundle compiles representative examples/in/*.ft through the full pipeline.
+func TestEmitValidation_examplesBundle(t *testing.T) {
+	t.Parallel()
+	rel := []string{
+		"basic.ft",
+		"loop.ft",
+		"echo.ft",
+		"basic_function.ft",
+		"result_if.ft",
+		"result_ensure.ft",
+		"generics.ft",
+		"go_builtins.ft",
+		"ensure.ft",
+		"pointers.ft",
+		"union_error_types.ft",
+		"union_error_narrowing.ft",
+		"nominal_error.ft",
+		"map_catalog.ft",
+		"rfc/guard/basic_guard.ft",
+		"rfc/guard/shape_guard.ft",
+	}
+	root := examplesInRoot(t)
+	for _, name := range rel {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			p := filepath.Join(root, name)
+			src, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			out := compileForstPipeline(t, string(src))
+			assertGoParses(t, out)
+		})
+	}
+}

--- a/forst/internal/transformer/go/ensure_builtins_test.go
+++ b/forst/internal/transformer/go/ensure_builtins_test.go
@@ -155,6 +155,112 @@ func TestTransformBuiltinConstraint_numericComparators(t *testing.T) {
 	}
 }
 
+func TestTransformBuiltinConstraint_stringMinMaxAndBool(t *testing.T) {
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tr := setupTransformer(tc, log)
+	at := NewAssertionTransformer(tr)
+
+	minExpr, err := at.TransformBuiltinConstraint(
+		ast.TypeString,
+		ast.VariableNode{Ident: ast.Ident{ID: "name"}},
+		ast.ConstraintNode{
+			Name: string(MinConstraint),
+			Args: []ast.ConstraintArgumentNode{
+				{Value: new(ast.ValueNode(ast.IntLiteralNode{Value: 3}))},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("string Min: %v", err)
+	}
+	if bin, ok := minExpr.(*goast.BinaryExpr); !ok || bin.Op != token.LSS {
+		t.Fatalf("string Min: got %#v", minExpr)
+	}
+
+	maxExpr, err := at.TransformBuiltinConstraint(
+		ast.TypeString,
+		ast.VariableNode{Ident: ast.Ident{ID: "name"}},
+		ast.ConstraintNode{
+			Name: string(MaxConstraint),
+			Args: []ast.ConstraintArgumentNode{
+				{Value: new(ast.ValueNode(ast.IntLiteralNode{Value: 10}))},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("string Max: %v", err)
+	}
+	if bin, ok := maxExpr.(*goast.BinaryExpr); !ok || bin.Op != token.GTR {
+		t.Fatalf("string Max: got %#v", maxExpr)
+	}
+
+	trueExpr, err := at.TransformBuiltinConstraint(
+		ast.TypeBool,
+		ast.VariableNode{Ident: ast.Ident{ID: "ok"}},
+		ast.ConstraintNode{Name: string(TrueConstraint)},
+	)
+	if err != nil {
+		t.Fatalf("bool True: %v", err)
+	}
+	if _, ok := trueExpr.(*goast.UnaryExpr); !ok {
+		t.Fatalf("bool True: expected negation, got %T", trueExpr)
+	}
+
+	falseExpr, err := at.TransformBuiltinConstraint(
+		ast.TypeBool,
+		ast.VariableNode{Ident: ast.Ident{ID: "ok"}},
+		ast.ConstraintNode{Name: string(FalseConstraint)},
+	)
+	if err != nil {
+		t.Fatalf("bool False: %v", err)
+	}
+	if _, ok := falseExpr.(*goast.UnaryExpr); ok {
+		t.Fatalf("bool False: expected direct variable expr, got negation")
+	}
+}
+
+func TestTransformBuiltinConstraint_arrayMinMax(t *testing.T) {
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tr := setupTransformer(tc, log)
+	at := NewAssertionTransformer(tr)
+
+	minExpr, err := at.TransformBuiltinConstraint(
+		ast.TypeArray,
+		ast.VariableNode{Ident: ast.Ident{ID: "xs"}},
+		ast.ConstraintNode{
+			Name: string(MinConstraint),
+			Args: []ast.ConstraintArgumentNode{
+				{Value: new(ast.ValueNode(ast.IntLiteralNode{Value: 2}))},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bin, ok := minExpr.(*goast.BinaryExpr); !ok || bin.Op != token.LSS {
+		t.Fatalf("array Min: got %#v", minExpr)
+	}
+
+	maxExpr, err := at.TransformBuiltinConstraint(
+		ast.TypeArray,
+		ast.VariableNode{Ident: ast.Ident{ID: "xs"}},
+		ast.ConstraintNode{
+			Name: string(MaxConstraint),
+			Args: []ast.ConstraintArgumentNode{
+				{Value: new(ast.ValueNode(ast.IntLiteralNode{Value: 5}))},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bin, ok := maxExpr.(*goast.BinaryExpr); !ok || bin.Op != token.GTR {
+		t.Fatalf("array Max: got %#v", maxExpr)
+	}
+}
+
 func TestTransformBuiltinConstraint_nilAndPresent(t *testing.T) {
 	log := setupTestLogger(nil)
 	tc := setupTypeChecker(log)

--- a/forst/internal/transformer/go/ensure_builtins_test.go
+++ b/forst/internal/transformer/go/ensure_builtins_test.go
@@ -8,11 +8,6 @@ import (
 	"forst/internal/ast"
 )
 
-//go:fix inline
-func valueNode(v ast.ValueNode) *ast.ValueNode {
-	return new(v)
-}
-
 func TestTransformBuiltinConstraint_stringContains_emitsNegatedStringsContains(t *testing.T) {
 	log := setupTestLogger(nil)
 	tc := setupTypeChecker(log)

--- a/forst/internal/transformer/go/ensure_test.go
+++ b/forst/internal/transformer/go/ensure_test.go
@@ -8,11 +8,6 @@ import (
 	"testing"
 )
 
-//go:fix inline
-func newValueNode(v ast.ValueNode) *ast.ValueNode {
-	return new(v)
-}
-
 func TestAssertionTransformer(t *testing.T) {
 	log := setupTestLogger(nil)
 	tc := setupTypeChecker(log)

--- a/forst/internal/transformer/go/expression_string_alias.go
+++ b/forst/internal/transformer/go/expression_string_alias.go
@@ -14,15 +14,22 @@ func (t *Transformer) coerceGoStringAliasExpr(expr goast.Expr, node ast.Node) go
 	return t.coerceGoStringAliasExprForType(expr, types[0])
 }
 
+func (t *Transformer) typeIsStringAlias(ident ast.TypeIdent) bool {
+	if ident == ast.TypeString {
+		return true
+	}
+	return t.TypeChecker.UnderlyingBuiltinTypeOfAliasAssertion(ident) == ast.TypeString
+}
+
 func (t *Transformer) coerceGoStringAliasExprForType(expr goast.Expr, tn ast.TypeNode) goast.Expr {
 	if tn.Ident == ast.TypeString {
 		return expr
 	}
-	if t.TypeChecker.UnderlyingBuiltinTypeOfAliasAssertion(tn.Ident) == ast.TypeString {
+	if t.typeIsStringAlias(tn.Ident) {
 		return &goast.CallExpr{Fun: goast.NewIdent("string"), Args: []goast.Expr{expr}}
 	}
 	if tn.Assertion != nil && tn.Assertion.BaseType != nil {
-		if t.TypeChecker.UnderlyingBuiltinTypeOfAliasAssertion(*tn.Assertion.BaseType) == ast.TypeString {
+		if t.typeIsStringAlias(*tn.Assertion.BaseType) {
 			return &goast.CallExpr{Fun: goast.NewIdent("string"), Args: []goast.Expr{expr}}
 		}
 	}

--- a/forst/internal/transformer/go/pipeline_emit_ensure_test.go
+++ b/forst/internal/transformer/go/pipeline_emit_ensure_test.go
@@ -39,7 +39,7 @@ func main() {
 	}
 }
 
-// "or NotOk(...)" is still lowered via an error return + errors.New today (nominal constructor not in failure path yet).
+// ensure-or with a nominal error payload lowers to returning the composite literal.
 func TestPipeline_ensureOrNominalPayload_emitsErrorReturningFunc(t *testing.T) {
 	t.Parallel()
 	src := `package main
@@ -62,7 +62,7 @@ func main() {
 		`type NotOk struct`,
 		`func check() error`,
 		`n <= 0`,
-		`return errors.New("assertion failed: Int.GreaterThan(0)")`,
+		`return NotOk{msg: "bad"}`,
 		`package main`,
 	} {
 		if !strings.Contains(out, sub) {

--- a/forst/internal/transformer/go/pipeline_integration_test.go
+++ b/forst/internal/transformer/go/pipeline_integration_test.go
@@ -352,12 +352,12 @@ func main() {
 
 import "errors"
 
-func bad(msg String): Error {
+func Bad(msg String): Error {
 	return errors.New(msg)
 }
 
 func f(row Int): Result(String, Error) {
-	ensure row is GreaterThan(-1) or bad("x")
+	ensure row is GreaterThan(-1) or Bad("x")
 	return "ok"
 }
 

--- a/forst/internal/transformer/go/statement_ensure.go
+++ b/forst/internal/transformer/go/statement_ensure.go
@@ -180,8 +180,26 @@ func (t *Transformer) transformErrorStatement(fn ast.FunctionNode, stmt ast.Ensu
 		}
 	}
 
-	// For void functions or functions with no return values, use panic
+	// For void functions or functions with no return values, use panic (or invoke custom fallback).
 	if len(returnTypes) == 0 || (len(returnTypes) == 1 && returnTypes[0].Ident == ast.TypeVoid) {
+		if stmt.Error != nil {
+			errExpr, err := t.transformEnsureErrorFallback(*stmt.Error)
+			if err != nil {
+				return &goast.ExprStmt{
+					X: &goast.CallExpr{
+						Fun: goast.NewIdent("panic"),
+						Args: []goast.Expr{
+							&goast.BasicLit{Kind: token.STRING, Value: "\"assertion failed\""},
+						},
+					},
+				}
+			}
+			return &goast.AssignStmt{
+				Tok: token.ASSIGN,
+				Lhs: []goast.Expr{goast.NewIdent("_")},
+				Rhs: []goast.Expr{errExpr},
+			}
+		}
 		return &goast.ExprStmt{
 			X: &goast.CallExpr{
 				Fun: goast.NewIdent("panic"),
@@ -203,19 +221,9 @@ func (t *Transformer) transformErrorStatement(fn ast.FunctionNode, stmt ast.Ensu
 		if err != nil {
 			zeroSucc = t.buildZeroCompositeLiteral(&succT)
 		}
-		t.Output.EnsureImport("errors")
-		assertionMsg := t.getAssertionStringForError(&stmt.Assertion)
-		errExpr := &goast.CallExpr{
-			Fun: &goast.SelectorExpr{
-				X:   goast.NewIdent("errors"),
-				Sel: goast.NewIdent("New"),
-			},
-			Args: []goast.Expr{
-				&goast.BasicLit{
-					Kind:  token.STRING,
-					Value: fmt.Sprintf("\"assertion failed: %s\"", assertionMsg),
-				},
-			},
+		errExpr, err := t.ensureFailureErrorExpr(stmt)
+		if err != nil {
+			errExpr = t.defaultAssertionErrorExpr(&stmt.Assertion)
 		}
 		return &goast.ReturnStmt{
 			Results: []goast.Expr{zeroSucc, errExpr},
@@ -237,24 +245,11 @@ func (t *Transformer) transformErrorStatement(fn ast.FunctionNode, stmt ast.Ensu
 
 		var result goast.Expr
 		if returnType.IsError() {
-			// For error types, return an error with the assertion message
-			assertionMsg := t.getAssertionStringForError(&stmt.Assertion)
-
-			// Ensure the errors package is imported
-			t.Output.EnsureImport("errors")
-
-			result = &goast.CallExpr{
-				Fun: &goast.SelectorExpr{
-					X:   goast.NewIdent("errors"),
-					Sel: goast.NewIdent("New"),
-				},
-				Args: []goast.Expr{
-					&goast.BasicLit{
-						Kind:  token.STRING,
-						Value: fmt.Sprintf("\"assertion failed: %s\"", assertionMsg),
-					},
-				},
+			errExpr, err := t.ensureFailureErrorExpr(stmt)
+			if err != nil {
+				errExpr = t.defaultAssertionErrorExpr(&stmt.Assertion)
 			}
+			result = errExpr
 		} else {
 			// For non-error types, always use the function's declared return type (including hash-based types)
 			// Never structurally alias to a user-defined type for error returns

--- a/forst/internal/transformer/go/statement_ensure_fallback_test.go
+++ b/forst/internal/transformer/go/statement_ensure_fallback_test.go
@@ -1,0 +1,112 @@
+package transformergo
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	goast "go/ast"
+)
+
+func TestTransformEnsureErrorFallback_callAndVar(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tr := setupTransformer(tc, log)
+
+	call, err := tr.transformEnsureErrorFallback(ast.EnsureErrorCall{
+		ErrorType: "bad",
+		ErrorArgs: []ast.ExpressionNode{ast.StringLiteralNode{Value: "nope"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	callS := goExprString(t, call)
+	if !strings.Contains(callS, `bad("nope")`) {
+		t.Fatalf("call: %s", callS)
+	}
+
+	v, err := tr.transformEnsureErrorFallback(ast.EnsureErrorVar("errVar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id, ok := v.(*goast.Ident); !ok || id.Name != "errVar" {
+		t.Fatalf("var: %#v", v)
+	}
+}
+
+func TestEnsureFailureErrorExpr_customOrGeneric(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tr := setupTransformer(setupTypeChecker(log), log)
+
+	var errNode ast.EnsureErrorNode = ast.EnsureErrorCall{
+		ErrorType: "bad",
+		ErrorArgs: []ast.ExpressionNode{ast.StringLiteralNode{Value: "x"}},
+	}
+	custom, err := tr.ensureFailureErrorExpr(ast.EnsureNode{
+		Assertion: ast.AssertionNode{BaseType: typeIdentPtr(string(ast.TypeInt))},
+		Error:     &errNode,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := goExprString(t, custom); !strings.Contains(s, `bad("x")`) {
+		t.Fatalf("custom: %s", s)
+	}
+
+	generic, err := tr.ensureFailureErrorExpr(ast.EnsureNode{
+		Assertion: ast.AssertionNode{
+			BaseType: typeIdentPtr(string(ast.TypeInt)),
+			Constraints: []ast.ConstraintNode{{
+				Name: "GreaterThan",
+				Args: []ast.ConstraintArgumentNode{{Value: intLiteralNodePtr(1)}},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := goExprString(t, generic); !strings.Contains(s, `errors.New`) || !strings.Contains(s, `assertion failed`) {
+		t.Fatalf("generic: %s", s)
+	}
+}
+
+func TestTransformEnsureErrorFallback_nominalErrorPayload(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["NotOk"] = ast.TypeDefNode{
+		Ident: "NotOk",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"msg": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	got, err := tr.transformEnsureErrorFallback(ast.EnsureErrorCall{
+		ErrorType: "NotOk",
+		ErrorArgs: []ast.ExpressionNode{
+			ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"msg": {Node: ast.StringLiteralNode{Value: "bad"}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := goExprString(t, got)
+	if !strings.Contains(s, `NotOk{msg: "bad"}`) || strings.Contains(s, `NotOk(NotOk`) {
+		t.Fatalf("nominal fallback: %s", s)
+	}
+}
+
+func intLiteralNodePtr(v int64) *ast.ValueNode {
+	var n ast.ValueNode = ast.IntLiteralNode{Value: v}
+	return &n
+}

--- a/forst/internal/transformer/go/statement_ensure_fallback_test.go
+++ b/forst/internal/transformer/go/statement_ensure_fallback_test.go
@@ -15,14 +15,14 @@ func TestTransformEnsureErrorFallback_callAndVar(t *testing.T) {
 	tr := setupTransformer(tc, log)
 
 	call, err := tr.transformEnsureErrorFallback(ast.EnsureErrorCall{
-		ErrorType: "bad",
+		ErrorType: "Bad",
 		ErrorArgs: []ast.ExpressionNode{ast.StringLiteralNode{Value: "nope"}},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	callS := goExprString(t, call)
-	if !strings.Contains(callS, `bad("nope")`) {
+	if !strings.Contains(callS, `Bad("nope")`) {
 		t.Fatalf("call: %s", callS)
 	}
 
@@ -41,7 +41,7 @@ func TestEnsureFailureErrorExpr_customOrGeneric(t *testing.T) {
 	tr := setupTransformer(setupTypeChecker(log), log)
 
 	var errNode ast.EnsureErrorNode = ast.EnsureErrorCall{
-		ErrorType: "bad",
+		ErrorType: "Bad",
 		ErrorArgs: []ast.ExpressionNode{ast.StringLiteralNode{Value: "x"}},
 	}
 	custom, err := tr.ensureFailureErrorExpr(ast.EnsureNode{
@@ -51,7 +51,7 @@ func TestEnsureFailureErrorExpr_customOrGeneric(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := goExprString(t, custom); !strings.Contains(s, `bad("x")`) {
+	if s := goExprString(t, custom); !strings.Contains(s, `Bad("x")`) {
 		t.Fatalf("custom: %s", s)
 	}
 

--- a/forst/internal/transformer/go/statement_helpers.go
+++ b/forst/internal/transformer/go/statement_helpers.go
@@ -1,8 +1,70 @@
 package transformergo
 
 import (
+	"fmt"
+
 	"forst/internal/ast"
+	goast "go/ast"
+	"go/token"
 )
+
+// transformEnsureErrorFallback lowers `ensure … or bad("msg")` / `or errVar` to a Go expression.
+func (t *Transformer) transformEnsureErrorFallback(errorNode ast.EnsureErrorNode) (goast.Expr, error) {
+	switch e := errorNode.(type) {
+	case ast.EnsureErrorCall:
+		if len(e.ErrorArgs) == 1 {
+			if def, ok := t.TypeChecker.Defs[ast.TypeIdent(e.ErrorType)].(ast.TypeDefNode); ok {
+				if _, ok := def.Expr.(ast.TypeDefErrorExpr); ok {
+					if shape, ok := e.ErrorArgs[0].(ast.ShapeNode); ok {
+						expected := &ast.TypeNode{Ident: def.Ident}
+						return t.transformShapeNodeWithExpectedType(&shape, expected)
+					}
+				}
+			}
+		}
+		args := make([]goast.Expr, len(e.ErrorArgs))
+		for i, arg := range e.ErrorArgs {
+			ex, err := t.transformExpression(arg)
+			if err != nil {
+				return nil, fmt.Errorf("ensure error fallback arg %d: %w", i, err)
+			}
+			args[i] = ex
+		}
+		return &goast.CallExpr{
+			Fun:  goast.NewIdent(e.ErrorType),
+			Args: args,
+		}, nil
+	case ast.EnsureErrorVar:
+		return goast.NewIdent(string(e)), nil
+	default:
+		return nil, fmt.Errorf("unsupported ensure error fallback: %T", errorNode)
+	}
+}
+
+func (t *Transformer) defaultAssertionErrorExpr(assertion *ast.AssertionNode) goast.Expr {
+	t.Output.EnsureImport("errors")
+	assertionMsg := t.getAssertionStringForError(assertion)
+	return &goast.CallExpr{
+		Fun: &goast.SelectorExpr{
+			X:   goast.NewIdent("errors"),
+			Sel: goast.NewIdent("New"),
+		},
+		Args: []goast.Expr{
+			&goast.BasicLit{
+				Kind:  token.STRING,
+				Value: fmt.Sprintf("\"assertion failed: %s\"", assertionMsg),
+			},
+		},
+	}
+}
+
+// ensureFailureErrorExpr returns the Go expression used on ensure failure (custom or generic).
+func (t *Transformer) ensureFailureErrorExpr(stmt ast.EnsureNode) (goast.Expr, error) {
+	if stmt.Error != nil {
+		return t.transformEnsureErrorFallback(*stmt.Error)
+	}
+	return t.defaultAssertionErrorExpr(&stmt.Assertion), nil
+}
 
 // getAssertionStringForError returns a properly qualified assertion string for error messages
 func (t *Transformer) getAssertionStringForError(assertion *ast.AssertionNode) string {

--- a/forst/internal/transformer/go/statement_helpers.go
+++ b/forst/internal/transformer/go/statement_helpers.go
@@ -8,7 +8,7 @@ import (
 	"go/token"
 )
 
-// transformEnsureErrorFallback lowers `ensure … or bad("msg")` / `or errVar` to a Go expression.
+// transformEnsureErrorFallback lowers `ensure … or Bad("msg")` / `or errVar` to a Go expression.
 func (t *Transformer) transformEnsureErrorFallback(errorNode ast.EnsureErrorNode) (goast.Expr, error) {
 	switch e := errorNode.(type) {
 	case ast.EnsureErrorCall:

--- a/forst/internal/transformer/go/statement_return_zero_helpers_test.go
+++ b/forst/internal/transformer/go/statement_return_zero_helpers_test.go
@@ -68,3 +68,101 @@ func TestZeroValueExprForASTType_builtinAndNamedShape(t *testing.T) {
 		t.Fatalf("expected composite literal for named shape zero value, got %T", expr)
 	}
 }
+
+func TestGetZeroValue_additionalBranches(t *testing.T) {
+	t.Parallel()
+	if lit, ok := getZeroValue(goast.NewIdent("int")).(*goast.BasicLit); !ok || lit.Value != "0" {
+		t.Fatalf("int zero: %#v", getZeroValue(goast.NewIdent("int")))
+	}
+	if ident, ok := getZeroValue(&goast.ArrayType{Elt: goast.NewIdent("int")}).(*goast.Ident); !ok || ident.Name != "nil" {
+		t.Fatalf("array zero: %#v", getZeroValue(&goast.ArrayType{Elt: goast.NewIdent("int")}))
+	}
+	if ident, ok := getZeroValue(&goast.InterfaceType{}).(*goast.Ident); !ok || ident.Name != "nil" {
+		t.Fatalf("interface zero: %#v", getZeroValue(&goast.InterfaceType{}))
+	}
+	if ident, ok := getZeroValue(goast.NewIdent("CustomType")).(*goast.Ident); !ok || ident.Name != "nil" {
+		t.Fatalf("custom ident zero: %#v", getZeroValue(goast.NewIdent("CustomType")))
+	}
+}
+
+func TestBuildCompositeLiteralForReturn_multiField(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["Pair"] = ast.TypeDefNode{
+		Ident: "Pair",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"a": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+					"b": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	lit := tr.buildCompositeLiteralForReturn(&ast.TypeNode{Ident: "Pair"}, "v")
+	comp, ok := lit.(*goast.CompositeLit)
+	if !ok || len(comp.Elts) != 2 {
+		t.Fatalf("expected 2-field composite, got %#v", lit)
+	}
+}
+
+func TestWrapVariableInNamedStruct_mapsVariableToField(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["Wrap"] = ast.TypeDefNode{
+		Ident: "Wrap",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"msg": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+					"n":   {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	expr, err := tr.wrapVariableInNamedStruct(
+		&ast.TypeNode{Ident: "Wrap"},
+		ast.VariableNode{Ident: ast.Ident{ID: "msg"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := expr.(*goast.CompositeLit); !ok {
+		t.Fatalf("expected composite literal, got %T", expr)
+	}
+}
+
+func TestBuildZeroCompositeLiteral_nestedUserDefinedField(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["Inner"] = ast.TypeDefNode{
+		Ident: "Inner",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	}
+	tc.Defs["Outer"] = ast.TypeDefNode{
+		Ident: "Outer",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"inner": {Type: &ast.TypeNode{Ident: "Inner", TypeKind: ast.TypeKindUserDefined}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	lit := tr.buildZeroCompositeLiteral(&ast.TypeNode{Ident: "Outer", TypeKind: ast.TypeKindUserDefined})
+	if _, ok := lit.(*goast.CompositeLit); !ok {
+		t.Fatalf("expected composite literal, got %T", lit)
+	}
+}

--- a/forst/internal/transformer/go/transformer_pipeline_coverage_test.go
+++ b/forst/internal/transformer/go/transformer_pipeline_coverage_test.go
@@ -1,0 +1,292 @@
+package transformergo
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/typechecker"
+)
+
+func TestPipeline_pointerReturnStructLiteral(t *testing.T) {
+	src := `package main
+
+type Point = { x: Int, y: Int }
+
+func origin(): *Point {
+	p := Point{ x: 0, y: 1 }
+	return &p
+}
+
+func main() {
+	p := origin()
+	println(string(p.x))
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{`type Point`, `*Point`, `return &`} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("missing %q in:\n%s", sub, out)
+		}
+	}
+	assertGoParses(t, out)
+}
+
+func TestPipeline_functionParamStringAlias(t *testing.T) {
+	src := `package main
+
+type Tag = String
+
+func echo(s: String): String {
+	return s
+}
+
+func main() {
+	println(echo("hi"))
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `func echo(s string)`) {
+		t.Fatalf("expected string param:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestPipeline_destructuredParamInFunctionDecl(t *testing.T) {
+	src := `package main
+
+func pair({x, y}: { x: Int, y: Int }): Int {
+	return x + y
+}
+
+func main() {
+	println(string(pair({ x: 1, y: 2 })))
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `func pair(x int, y int)`) {
+		t.Fatalf("expected flattened destructured params:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestPipeline_functionWithExplicitErrorReturn(t *testing.T) {
+	src := `package main
+
+func fail(): Error {
+	return errors.New("boom")
+}
+
+func main() {}
+`
+	out := compileForstPipelineExt(t, src, pipelineOpts{goWorkspaceDir: moduleRootFromWD(t)})
+	if !strings.Contains(out, `return errors.New`) {
+		t.Fatalf("expected error return emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestPipeline_nestedWithBlock(t *testing.T) {
+	src := `package main
+
+type Logger = { info(msg String) }
+type Clock = { now(): Int }
+type NopLogger = {}
+type FakeClock = { fixedMs: Int }
+
+func (NopLogger) info(msg String) {}
+func (c FakeClock) now(): Int { return c.fixedMs }
+
+func work() {
+	use logger: Logger
+	logger.info("ok")
+}
+
+func main() {
+	with { Logger: NopLogger{} } {
+		with { Clock: FakeClock{ fixedMs: 1 } } {
+			work()
+		}
+	}
+}
+`
+	out := compileForstPipelineExt(t, src, pipelineOpts{goWorkspaceDir: moduleRootFromWD(t)})
+	if !strings.Contains(out, `Providers_`) {
+		t.Fatalf("expected nested with providers emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestPipeline_typedefUnionMembers(t *testing.T) {
+	src := `package main
+
+type ParseError = { message: String }
+type IoError = { code: Int }
+type AppError = ParseError | IoError
+
+func main() {
+	var e: AppError = ParseError{ message: "x" }
+	println("ok")
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{`type ParseError`, `type IoError`, `type AppError`, `message`} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("missing %q in:\n%s", sub, out)
+		}
+	}
+	assertGoParses(t, out)
+}
+
+func TestPipeline_mapAndSliceTypeFields(t *testing.T) {
+	src := `package main
+
+type Config = {
+	labels: []String,
+	scores: map[String]Int,
+}
+
+func main() {
+	c := Config{ labels: ["a"], scores: map[String]Int{ "k": 1 } }
+	println(string(len(c.labels)))
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{`[]string`, `map[string]int`, `type Config`} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("missing %q in:\n%s", sub, out)
+		}
+	}
+	assertGoParses(t, out)
+}
+
+func TestPipeline_ensureBoolFalse(t *testing.T) {
+	src := `package main
+
+func main() {
+	ok := false
+	ensure ok is False()
+	println("done")
+}
+`
+	out := compileForstPipeline(t, src)
+	if strings.Contains(out, `!ok`) {
+		t.Fatalf("False() should not negate subject, got:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestPipeline_stringAliasCoercionInPrintln(t *testing.T) {
+	src := `package main
+
+type Slug = String.Min(1)
+
+func main() {
+	s: Slug = "hello"
+	println(s)
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `type Slug`) {
+		t.Fatalf("expected Slug typedef:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestPipeline_shapeLiteralWithExplicitBaseType(t *testing.T) {
+	src := `package main
+
+type Point = { x: Int, y: Int }
+
+func main() {
+	p := Point{ x: 1, y: 2 }
+	println(string(p.x))
+}
+`
+	out := compileForstPipeline(t, src)
+	if !strings.Contains(out, `Point{`) {
+		t.Fatalf("expected Point composite literal:\n%s", out)
+	}
+	assertGoParses(t, out)
+}
+
+func TestTransformType_mapChannelPointer(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tr := setupTransformer(tc, log)
+
+	mapExpr, err := tr.transformType(ast.TypeNode{
+		Ident:      ast.TypeMap,
+		TypeParams: []ast.TypeNode{{Ident: ast.TypeString}, {Ident: ast.TypeInt}},
+	})
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if s := goExprString(t, mapExpr); !strings.Contains(s, "map[") {
+		t.Fatalf("map type: %s", s)
+	}
+
+	sliceExpr, err := tr.transformType(ast.TypeNode{
+		Ident:      ast.TypeArray,
+		TypeParams: []ast.TypeNode{{Ident: ast.TypeString}},
+	})
+	if err != nil {
+		t.Fatalf("slice: %v", err)
+	}
+	if s := goExprString(t, sliceExpr); !strings.Contains(s, "[]") {
+		t.Fatalf("slice type: %s", s)
+	}
+
+	ptrExpr, err := tr.transformType(ast.TypeNode{
+		Ident:      ast.TypePointer,
+		TypeParams: []ast.TypeNode{{Ident: "Point"}},
+	})
+	if err != nil {
+		t.Fatalf("pointer: %v", err)
+	}
+	if s := goExprString(t, ptrExpr); !strings.HasPrefix(s, "*") {
+		t.Fatalf("pointer type: %s", s)
+	}
+
+	chanExpr, err := tr.transformType(ast.TypeNode{
+		Ident:      ast.TypeChannel,
+		TypeParams: []ast.TypeNode{{Ident: ast.TypeInt}},
+	})
+	if err != nil {
+		t.Fatalf("channel: %v", err)
+	}
+	if s := goExprString(t, chanExpr); !strings.Contains(s, "chan") {
+		t.Fatalf("channel type: %s", s)
+	}
+}
+
+func TestTransformProviderSlotType_localContract(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["Logger"] = ast.TypeDefNode{
+		Ident: "Logger",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"info": {IsMethod: true, MethodParams: []ast.ParamNode{
+						ast.SimpleParamNode{Ident: ast.Ident{ID: "msg"}, Type: ast.TypeNode{Ident: ast.TypeString}},
+					}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	slot := typechecker.ProviderSlot{
+		RootIdent:    "Logger",
+		ContractType: ast.TypeNode{Ident: "Logger"},
+	}
+	expr, err := tr.transformProviderSlotType(slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if goExprString(t, expr) != "Logger" {
+		t.Fatalf("got %s", goExprString(t, expr))
+	}
+}

--- a/forst/internal/transformer/go/transformer_shape_wiring_coverage_test.go
+++ b/forst/internal/transformer/go/transformer_shape_wiring_coverage_test.go
@@ -1,0 +1,246 @@
+package transformergo
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	goast "go/ast"
+)
+
+func TestBuildWiringFrame_shapeAndCall(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tr := setupTransformer(setupTypeChecker(log), log)
+
+	shapeFrame, err := tr.buildWiringFrame(ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"Logger": {Node: ast.StringLiteralNode{Value: "x"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("shape wiring: %v", err)
+	}
+	if len(shapeFrame.fields) != 1 {
+		t.Fatalf("fields = %#v", shapeFrame.fields)
+	}
+
+	callFrame, err := tr.buildWiringFrame(ast.FunctionCallNode{
+		Function: ast.Ident{ID: "services"},
+	})
+	if err != nil {
+		t.Fatalf("call wiring: %v", err)
+	}
+	if callFrame.baseExpr == nil {
+		t.Fatal("expected baseExpr from call wiring")
+	}
+}
+
+func TestWiringFieldExpr_fieldOverrideAndBaseSelector(t *testing.T) {
+	t.Parallel()
+	tr := setupTransformer(setupTypeChecker(setupTestLogger(nil)), setupTestLogger(nil))
+	tr.wiringStack = []wiringFrame{
+		{
+			baseExpr: goast.NewIdent("svc"),
+			fields: map[string]goast.Expr{
+				"Clock": goast.NewIdent("clockImpl"),
+			},
+		},
+	}
+	if s := goExprString(t, tr.wiringFieldExpr("Clock")); s != "clockImpl" {
+		t.Fatalf("field override: %s", s)
+	}
+	if s := goExprString(t, tr.wiringFieldExpr("Logger")); s != "svc.Logger" {
+		t.Fatalf("base selector: %s", s)
+	}
+	tr.wiringStack = nil
+	if tr.wiringFieldExpr("Missing") != nil {
+		t.Fatal("expected nil for missing wiring")
+	}
+}
+
+func TestTransformShapeNodeWithExpectedType_namedAndHashFallback(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["Point"] = ast.TypeDefNode{
+		Ident: "Point",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+					"y": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	shape := &ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"x": {Node: ast.IntLiteralNode{Value: 1}},
+			"y": {Node: ast.IntLiteralNode{Value: 2}},
+		},
+	}
+	named, err := tr.transformShapeNodeWithExpectedType(shape, &ast.TypeNode{Ident: "Point", TypeKind: ast.TypeKindUserDefined})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := goExprString(t, named); !strings.Contains(s, `Point{`) {
+		t.Fatalf("named literal: %s", s)
+	}
+
+	hash, err := tr.transformShapeNodeWithExpectedType(shape, &ast.TypeNode{Ident: "T_abc", TypeKind: ast.TypeKindHashBased})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := goExprString(t, hash); !strings.Contains(s, `T_abc{`) {
+		t.Fatalf("hash literal: %s", s)
+	}
+}
+
+func TestFindExistingTypeForShape_baseTypeAndStructuralMatch(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["Pair"] = ast.TypeDefNode{
+		Ident: "Pair",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"a": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+					"b": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+
+	base := ast.TypeIdent("User")
+	shape := &ast.ShapeNode{
+		BaseType: &base,
+		Fields:   map[string]ast.ShapeFieldNode{},
+	}
+	if got, ok := tr.findExistingTypeForShape(shape, nil); !ok || got != "User" {
+		t.Fatalf("base type: got %q ok=%v", got, ok)
+	}
+
+	lit := &ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"a": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			"b": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+		},
+	}
+	if got, ok := tr.findExistingTypeForShape(lit, nil); !ok || got != "Pair" {
+		t.Fatalf("structural match: got %q ok=%v", got, ok)
+	}
+}
+
+func TestShapesMatch_comparesFieldTypes(t *testing.T) {
+	t.Parallel()
+	tr := setupTransformer(setupTypeChecker(setupTestLogger(nil)), setupTestLogger(nil))
+	a := &ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+		},
+	}
+	b := &ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+		},
+	}
+	c := &ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"x": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+		},
+	}
+	if !tr.shapesMatch(a, b) {
+		t.Fatal("expected match")
+	}
+	if tr.shapesMatch(a, c) {
+		t.Fatal("expected mismatch")
+	}
+}
+
+func TestCoerceGoStringAliasExprForType_assertionBaseString(t *testing.T) {
+	t.Parallel()
+	tr := setupTransformer(setupTypeChecker(setupTestLogger(nil)), setupTestLogger(nil))
+	expr := goast.NewIdent("slugVar")
+	got := tr.coerceGoStringAliasExprForType(expr, ast.TypeNode{
+		Ident: "Slug",
+		Assertion: &ast.AssertionNode{
+			BaseType: typeIdentPtr(string(ast.TypeString)),
+		},
+	})
+	if s := goExprString(t, got); s != `string(slugVar)` {
+		t.Fatalf("got %s", s)
+	}
+}
+
+func TestTransformFunctionParamField_assertionBaseTypeOnly(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["User"] = ast.TypeDefNode{
+		Ident: "User",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"name": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	base := ast.TypeIdent("User")
+	field, err := tr.transformFunctionParamField("u", ast.TypeNode{
+		Assertion: &ast.AssertionNode{BaseType: &base},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if field.Type.(*goast.Ident).Name != "User" {
+		t.Fatalf("field = %#v", field)
+	}
+}
+
+func TestEnsureErrMissingMapKeyDecl_idempotent(t *testing.T) {
+	var out TransformerOutput
+	out.EnsureImport("errors")
+	out.EnsureErrMissingMapKeyDecl()
+	out.EnsureErrMissingMapKeyDecl()
+	if len(out.valueDecls) != 1 {
+		t.Fatalf("value decls: %d", len(out.valueDecls))
+	}
+}
+
+func TestPipeline_withCallExpressionWiring(t *testing.T) {
+	src := `package main
+
+type Logger = { info(msg String) }
+type NopLogger = {}
+
+func (NopLogger) info(msg String) {}
+
+func services(): { Logger: NopLogger } {
+	return { Logger: NopLogger{} }
+}
+
+func work() {
+	use logger: Logger
+	logger.info("ok")
+}
+
+func main() {
+	with services() {
+		work()
+	}
+}
+`
+	out := compileForstPipelineExt(t, src, pipelineOpts{goWorkspaceDir: moduleRootFromWD(t)})
+	for _, sub := range []string{`services()`, `.Logger`} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("missing %q in:\n%s", sub, out)
+		}
+	}
+	assertGoParses(t, out)
+}

--- a/forst/internal/transformer/go/transformer_unit_coverage_test.go
+++ b/forst/internal/transformer/go/transformer_unit_coverage_test.go
@@ -1,0 +1,112 @@
+package transformergo
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	goast "go/ast"
+)
+
+func TestTransformFunctionParamField_userShapeType(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["User"] = ast.TypeDefNode{
+		Ident: "User",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"name": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	field, err := tr.transformFunctionParamField("u", ast.TypeNode{Ident: "User", TypeKind: ast.TypeKindUserDefined})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if field.Names[0].Name != "u" || field.Type.(*goast.Ident).Name != "User" {
+		t.Fatalf("field = %#v", field)
+	}
+}
+
+func TestTransformShapeFieldType_emitsReferencedUserType(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["Address"] = ast.TypeDefNode{
+		Ident: "Address",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"city": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	expr, err := tr.transformShapeFieldType(ast.ShapeFieldNode{
+		Type: &ast.TypeNode{Ident: "Address", TypeKind: ast.TypeKindUserDefined},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if goExprString(t, *expr) != "Address" {
+		t.Fatalf("got %s", goExprString(t, *expr))
+	}
+}
+
+func TestFindExistingTypeForShape_matchesRegisteredDef(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["Point"] = ast.TypeDefNode{
+		Ident: "Point",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+					"y": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	}
+	tr := setupTransformer(tc, log)
+	shape := &ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			"y": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+		},
+	}
+	got, ok := tr.findExistingTypeForShape(shape, nil)
+	if !ok || got != "Point" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
+
+func TestPipeline_ensureWithOrFallback(t *testing.T) {
+	src := `package main
+
+import "errors"
+
+func bad(msg String): Error {
+	return errors.New(msg)
+}
+
+func f(row Int): Result(String, Error) {
+	ensure row is GreaterThan(-1) or bad("too small")
+	return "ok"
+}
+
+func main() {
+	println("hi")
+}
+`
+	out := compileForstPipelineExt(t, src, pipelineOpts{goWorkspaceDir: moduleRootFromWD(t)})
+	if !strings.Contains(out, `bad("too small")`) {
+		t.Fatalf("expected ensure-or fallback emit:\n%s", out)
+	}
+	assertGoParses(t, out)
+}

--- a/forst/internal/transformer/go/transformer_unit_coverage_test.go
+++ b/forst/internal/transformer/go/transformer_unit_coverage_test.go
@@ -91,12 +91,12 @@ func TestPipeline_ensureWithOrFallback(t *testing.T) {
 
 import "errors"
 
-func bad(msg String): Error {
+func Bad(msg String): Error {
 	return errors.New(msg)
 }
 
 func f(row Int): Result(String, Error) {
-	ensure row is GreaterThan(-1) or bad("too small")
+	ensure row is GreaterThan(-1) or Bad("too small")
 	return "ok"
 }
 
@@ -105,7 +105,7 @@ func main() {
 }
 `
 	out := compileForstPipelineExt(t, src, pipelineOpts{goWorkspaceDir: moduleRootFromWD(t)})
-	if !strings.Contains(out, `bad("too small")`) {
+	if !strings.Contains(out, `Bad("too small")`) {
 		t.Fatalf("expected ensure-or fallback emit:\n%s", out)
 	}
 	assertGoParses(t, out)

--- a/forst/internal/transformer/go/typedef_expr_branch_test.go
+++ b/forst/internal/transformer/go/typedef_expr_branch_test.go
@@ -129,3 +129,41 @@ func TestTransformTypeDefExpr_pointerAssertionExpr_deref(t *testing.T) {
 		t.Fatal("expected Go expr")
 	}
 }
+
+func TestTransformTypeDefExpr_shapeBaseEmptyStruct(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tr := setupTransformer(tc, log)
+	base := ast.TypeIdent(ast.TypeShape)
+	expr, err := tr.transformTypeDefExpr(ast.TypeDefAssertionExpr{
+		Assertion: &ast.AssertionNode{BaseType: &base},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, ok := (*expr).(*goast.StructType)
+	if !ok || st.Fields == nil || len(st.Fields.List) != 0 {
+		t.Fatalf("expected empty struct for Shape base, got %#v", *expr)
+	}
+}
+
+func TestTransformTypeDefExpr_plainUserTypeAlias(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := setupTypeChecker(log)
+	tc.Defs["RawId"] = ast.TypeDefNode{
+		Ident: "RawId",
+		Expr:  ast.TypeDefAssertionExpr{Assertion: &ast.AssertionNode{BaseType: ptrTypeIdent(ast.TypeString)}},
+	}
+	tr := setupTransformer(tc, log)
+	expr, err := tr.transformTypeDefExpr(ast.TypeDefAssertionExpr{
+		Assertion: &ast.AssertionNode{BaseType: ptrTypeIdent(ast.TypeIdent("RawId"))},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id, ok := (*expr).(*goast.Ident); !ok || id.Name != "RawId" {
+		t.Fatalf("expected RawId alias, got %#v", *expr)
+	}
+}

--- a/forst/internal/typechecker/alias_return_test.go
+++ b/forst/internal/typechecker/alias_return_test.go
@@ -120,8 +120,3 @@ func TestIsTypeCompatible_simpleTypeAliasToString(t *testing.T) {
 		t.Fatal("expected Greeting alias compatible with String")
 	}
 }
-
-//go:fix inline
-func ptrTypeIdent(id ast.TypeIdent) *ast.TypeIdent {
-	return new(id)
-}

--- a/forst/internal/typechecker/channel_type_test.go
+++ b/forst/internal/typechecker/channel_type_test.go
@@ -1,0 +1,72 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestChannelElementType_chanInt(t *testing.T) {
+	tn := ast.TypeNode{
+		Ident:      ast.TypeChannel,
+		TypeParams: []ast.TypeNode{{Ident: ast.TypeInt}},
+	}
+	elem, ok := ChannelElementType(tn)
+	if !ok || elem.Ident != ast.TypeInt {
+		t.Fatalf("elem = %#v ok=%v", elem, ok)
+	}
+}
+
+func TestChannelElementType_notChannel(t *testing.T) {
+	_, ok := ChannelElementType(ast.TypeNode{Ident: ast.TypeInt})
+	if ok {
+		t.Fatal("Int is not a channel type")
+	}
+}
+
+func TestIsChannelReturn_singleChanReturn(t *testing.T) {
+	fn := &ast.FunctionNode{
+		ReturnTypes: []ast.TypeNode{{
+			Ident:      ast.TypeChannel,
+			TypeParams: []ast.TypeNode{{Ident: ast.TypeString}},
+		}},
+	}
+	if !IsChannelReturn(fn, nil) {
+		t.Fatal("expected channel return")
+	}
+}
+
+func TestIsChannelReturn_multipleReturns(t *testing.T) {
+	fn := &ast.FunctionNode{
+		ReturnTypes: []ast.TypeNode{
+			{Ident: ast.TypeInt},
+			{Ident: ast.TypeChannel, TypeParams: []ast.TypeNode{{Ident: ast.TypeInt}}},
+		},
+	}
+	if IsChannelReturn(fn, nil) {
+		t.Fatal("multiple returns should not be channel return")
+	}
+}
+
+func TestIsChannelReturn_fromTypeCheckerSignature(t *testing.T) {
+	tc := New(setupTestLogger(nil), false)
+	tc.Functions = map[ast.Identifier]FunctionSignature{
+		"ch": {
+			Ident: ast.Ident{ID: "ch"},
+			ReturnTypes: []ast.TypeNode{{
+				Ident:      ast.TypeChannel,
+				TypeParams: []ast.TypeNode{{Ident: ast.TypeInt}},
+			}},
+		},
+	}
+	fn := ast.FunctionNode{Ident: ast.Ident{ID: "ch"}}
+	if !IsChannelReturn(&fn, tc) {
+		t.Fatal("expected chan Int return from typechecker signature")
+	}
+}
+
+func TestIsChannelReturn_nilFunction(t *testing.T) {
+	if IsChannelReturn(nil, nil) {
+		t.Fatal("nil function should not be channel return")
+	}
+}

--- a/forst/internal/typechecker/check_types_snippets_test.go
+++ b/forst/internal/typechecker/check_types_snippets_test.go
@@ -545,6 +545,142 @@ func main() {
 	println(string(n))
 }`,
 		},
+		{
+			"nominal_error_constructor",
+			`package main
+error E { msg: String }
+func main() {
+	e := E({ msg: "x" })
+	println(e.msg)
+}`,
+		},
+		{
+			"pointer_deref",
+			`package main
+func main() {
+	n := 1
+	p := &n
+	println(string(*p))
+}`,
+		},
+		{
+			"star_div_mod_compound",
+			`package main
+func main() {
+	n := 10
+	n *= 2
+	n /= 4
+	n %= 3
+	println(string(n))
+}`,
+		},
+		{
+			"defer_and_go",
+			`package main
+func work() {}
+func main() {
+	defer work()
+	go work()
+}
+`,
+		},
+		{
+			"receiver_method_call",
+			`package main
+type Counter = { n: Int }
+func (Counter) inc(): Counter { return { n: 1 } }
+func main() {
+	c := Counter{ n: 0 }
+	c = c.inc()
+	println(string(c.n))
+}
+`,
+		},
+		{
+			"type_alias_chain",
+			`package main
+type RawId = String
+type UserId = RawId
+func main() {
+	id: UserId = "u1"
+	println(id)
+}
+`,
+		},
+		{
+			"for_range_index_value",
+			`package main
+func main() {
+	xs := [1, 2]
+	for i, v := range xs {
+		println(string(i) + string(v))
+	}
+}
+`,
+		},
+		{
+			"postfix_inc_dec",
+			`package main
+func main() {
+	i := 0
+	i++
+	i--
+	println(string(i))
+}
+`,
+		},
+		{
+			"compound_assign_for_post",
+			`package main
+func main() {
+	for i := 0; i < 3; i += 1 {
+		println(string(i))
+	}
+}
+`,
+		},
+		{
+			"labeled_break",
+			`package main
+func main() {
+outer: for i := 0; i < 3; i = i + 1 {
+		for j := 0; j < 3; j = j + 1 {
+			if j == 1 {
+				break outer
+			}
+		}
+	}
+}
+`,
+		},
+		{
+			"compound_assign_statements",
+			`package main
+func main() {
+	n := 1
+	n += 2
+	n -= 1
+	n *= 2
+	println(string(n))
+}
+`,
+		},
+		{
+			"result_err_narrowing",
+			`package main
+error ParseError { code: Int }
+error IoError { path: String }
+type ErrKind = ParseError | IoError
+func onlyParse(p ParseError) {}
+func mk(): Result(Int, ErrKind) { return 0 }
+func main() {
+	x := mk()
+	if x is Err(ParseError) {
+		onlyParse(x)
+	}
+}
+`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/forst/internal/typechecker/example_ft_bundle_test.go
+++ b/forst/internal/typechecker/example_ft_bundle_test.go
@@ -28,6 +28,9 @@ func TestCheckTypes_examplesBundle(t *testing.T) {
 		"nominal_error.ft",
 		"map_catalog.ft",
 		"tictactoe/engine.ft",
+		"rfc/guard/basic_guard.ft",
+		"rfc/guard/shape_guard.ft",
+		"rfc/providers/providers.ft",
 	}
 	root := filepath.Join("..", "..", "..", "examples", "in")
 	for _, name := range rel {

--- a/forst/internal/typechecker/infer_assertion_test.go
+++ b/forst/internal/typechecker/infer_assertion_test.go
@@ -119,3 +119,43 @@ func TestInferAssertion_unknownBaseTypeErrors(t *testing.T) {
 		t.Fatal("expected unknown base type error")
 	}
 }
+
+func TestInferAssertion_maxConstraintOnInt(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	base := ast.TypeInt
+	assertion := &ast.AssertionNode{
+		BaseType: &base,
+		Constraints: []ast.ConstraintNode{{
+			Name: "Max",
+			Args: []ast.ConstraintArgumentNode{{
+				Value: func() *ast.ValueNode {
+					v := ast.ValueNode(ast.IntLiteralNode{Value: 100})
+					return &v
+				}(),
+			}},
+		}},
+	}
+	types, err := tc.InferAssertionType(assertion, false, "n", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(types) != 1 {
+		t.Fatalf("got %#v", types)
+	}
+	if _, ok := tc.Defs[types[0].Ident]; !ok {
+		t.Fatalf("expected hash type def for Max constraint, got %q", types[0].Ident)
+	}
+}
+
+func TestIsBuiltinAssertionConstraintName(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"Min", "Max", "Nil", "Present", ast.ValueConstraint} {
+		if !isBuiltinAssertionConstraintName(name) {
+			t.Fatalf("%q should be builtin", name)
+		}
+	}
+	if isBuiltinAssertionConstraintName("CustomGuard") {
+		t.Fatal("custom guard should not be builtin")
+	}
+}

--- a/forst/internal/typechecker/infer_assertion_test.go
+++ b/forst/internal/typechecker/infer_assertion_test.go
@@ -113,7 +113,7 @@ func TestInferAssertion_unknownBaseTypeErrors(t *testing.T) {
 	log := setupTestLogger(nil)
 	tc := New(log, false)
 	assertion := &ast.AssertionNode{
-		BaseType: ptrTypeIdent(ast.TypeIdent("NoSuchType")),
+		BaseType: new(ast.TypeIdent("NoSuchType")),
 	}
 	if _, err := tc.InferAssertionType(assertion, false, "x", nil); err == nil {
 		t.Fatal("expected unknown base type error")

--- a/forst/internal/typechecker/infer_assignment_test.go
+++ b/forst/internal/typechecker/infer_assignment_test.go
@@ -1,0 +1,97 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/parser"
+)
+
+func TestInferAssignmentTypes_shortDeclInfersTypes(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+
+func main() {
+	x := 1
+	s := "hello"
+	println(x)
+	println(s)
+}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
+	xTy, ok := tc.VariableTypes[ast.Identifier("x")]
+	if !ok || len(xTy) != 1 || xTy[0].Ident != ast.TypeInt {
+		t.Fatalf("x types = %#v ok=%v", xTy, ok)
+	}
+	sTy, ok := tc.VariableTypes[ast.Identifier("s")]
+	if !ok || len(sTy) != 1 || sTy[0].Ident != ast.TypeString {
+		t.Fatalf("s types = %#v ok=%v", sTy, ok)
+	}
+}
+
+func TestInferAssignmentTypes_rejectsExplicitTypesOnCompound(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	chk := New(log, false)
+	chk.VariableTypes[ast.Identifier("n")] = []ast.TypeNode{{Ident: ast.TypeInt}}
+	assign := ast.AssignmentNode{
+		LValues:       []ast.ExpressionNode{ast.VariableNode{Ident: ast.Ident{ID: "n"}}},
+		RValues:       []ast.ExpressionNode{ast.IntLiteralNode{Value: 1}},
+		ExplicitTypes: []*ast.TypeNode{{Ident: ast.TypeInt}},
+		CompoundOp:    ast.TokenPlusEq,
+	}
+	if err := chk.inferAssignmentTypes(assign); err == nil {
+		t.Fatal("expected error for explicit types on compound assign")
+	}
+}
+
+func TestInferAssignmentTypes_rejectsMultiLValueCompound(t *testing.T) {
+	t.Parallel()
+	chk := New(setupTestLogger(nil), false)
+	assign := ast.AssignmentNode{
+		LValues: []ast.ExpressionNode{
+			ast.VariableNode{Ident: ast.Ident{ID: "a"}},
+			ast.VariableNode{Ident: ast.Ident{ID: "b"}},
+		},
+		RValues:    []ast.ExpressionNode{ast.IntLiteralNode{Value: 1}},
+		CompoundOp: ast.TokenPlusEq,
+	}
+	if err := chk.inferAssignmentTypes(assign); err == nil {
+		t.Fatal("expected error for multi-value compound assign")
+	}
+}
+
+func TestInferAssignmentTypes_regularAssign(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+
+func main() {
+	var x Int
+	x = 42
+	println(x)
+}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
+	ty, ok := tc.VariableTypes[ast.Identifier("x")]
+	if !ok || len(ty) != 1 || ty[0].Ident != ast.TypeInt {
+		t.Fatalf("x types = %#v ok=%v", ty, ok)
+	}
+}

--- a/forst/internal/typechecker/infer_function_test.go
+++ b/forst/internal/typechecker/infer_function_test.go
@@ -1,0 +1,115 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/parser"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestInferFunctionReturnType_emptyBodyNoReturnAnnotation(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	fn := ast.FunctionNode{
+		Ident: ast.Ident{ID: "noop"},
+		Body:  nil,
+	}
+	got, err := tc.inferFunctionReturnType(fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !IsVoidReturnTypes(got) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestInferFunctionReturnType_singleIntReturn(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+func f(): Int {
+	return 42
+}
+func main() {}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
+	sig := tc.Functions["f"]
+	if len(sig.ReturnTypes) != 1 || sig.ReturnTypes[0].Ident != ast.TypeInt {
+		t.Fatalf("return types = %#v", sig.ReturnTypes)
+	}
+}
+
+func TestInferFunctionReturnType_nilReturnWithErrorType(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+func f(): Error {
+	return nil
+}
+func main() {}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInferFunctionReturnType_nilReturnNonNilableErrors(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+func f(): Int {
+	return nil
+}
+func main() {}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	err = tc.CheckTypes(nodes)
+	if err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestInferFunctionReturnType_resultFromExpression(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+func inner(): Result(Int, Error) {
+	return 1
+}
+func outer(): Result(Int, Error) {
+	return inner()
+}
+func main() {}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/forst/internal/typechecker/infer_nominal_error_test.go
+++ b/forst/internal/typechecker/infer_nominal_error_test.go
@@ -1,0 +1,138 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+
+	"github.com/sirupsen/logrus"
+)
+
+func nominalErrorTC(t *testing.T) *TypeChecker {
+	t.Helper()
+	tc := New(logrus.New(), false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "NotFound",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"id": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+				},
+			},
+		},
+	})
+	return tc
+}
+
+func TestInferNominalErrorConstructorCall_validPayload(t *testing.T) {
+	tc := nominalErrorTC(t)
+	call := ast.FunctionCallNode{
+		Function: ast.Ident{ID: "NotFound"},
+		Arguments: []ast.ExpressionNode{
+			ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"id": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+				},
+			},
+		},
+	}
+	types, handled, err := tc.inferNominalErrorConstructorCall(call, nil)
+	if err != nil || !handled {
+		t.Fatalf("handled=%v err=%v", handled, err)
+	}
+	if len(types) != 1 || types[0].Ident != "NotFound" {
+		t.Fatalf("types = %#v", types)
+	}
+}
+
+func TestInferNominalErrorConstructorCall_notErrorTypedef(t *testing.T) {
+	tc := New(logrus.New(), false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "Point",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	})
+	call := ast.FunctionCallNode{
+		Function: ast.Ident{ID: "Point"},
+		Arguments: []ast.ExpressionNode{
+			ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			}},
+		},
+	}
+	_, handled, err := tc.inferNominalErrorConstructorCall(call, nil)
+	if err != nil || handled {
+		t.Fatalf("expected not handled for shape typedef, handled=%v err=%v", handled, err)
+	}
+}
+
+func TestInferNominalErrorConstructorCall_wrongArity(t *testing.T) {
+	tc := nominalErrorTC(t)
+	call := ast.FunctionCallNode{
+		Function:  ast.Ident{ID: "NotFound"},
+		Arguments: []ast.ExpressionNode{},
+	}
+	_, handled, err := tc.inferNominalErrorConstructorCall(call, nil)
+	if err == nil || !handled {
+		t.Fatalf("expected arity diagnostic, handled=%v err=%v", handled, err)
+	}
+	diag, ok := err.(*Diagnostic)
+	if !ok || diag.Code != "call-arity" {
+		t.Fatalf("got %T %v", err, err)
+	}
+}
+
+func TestInferNominalErrorConstructorCall_nonShapeArgument(t *testing.T) {
+	tc := nominalErrorTC(t)
+	call := ast.FunctionCallNode{
+		Function:  ast.Ident{ID: "NotFound"},
+		Arguments: []ast.ExpressionNode{ast.StringLiteralNode{Value: "x"}},
+	}
+	_, handled, err := tc.inferNominalErrorConstructorCall(call, nil)
+	if err == nil || !handled {
+		t.Fatalf("expected call-type diagnostic, handled=%v err=%v", handled, err)
+	}
+	diag, ok := err.(*Diagnostic)
+	if !ok || diag.Code != "call-type" {
+		t.Fatalf("got %T %v", err, err)
+	}
+}
+
+func TestInferNominalErrorConstructorCall_payloadMismatch(t *testing.T) {
+	tc := nominalErrorTC(t)
+	call := ast.FunctionCallNode{
+		Function: ast.Ident{ID: "NotFound"},
+		Arguments: []ast.ExpressionNode{
+			ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"wrong": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	}
+	_, handled, err := tc.inferNominalErrorConstructorCall(call, nil)
+	if err == nil || !handled {
+		t.Fatalf("expected payload mismatch, handled=%v err=%v", handled, err)
+	}
+	if !strings.Contains(err.Error(), "payload does not match") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestInferNominalErrorConstructorCall_unknownFunction(t *testing.T) {
+	tc := New(logrus.New(), false)
+	call := ast.FunctionCallNode{
+		Function:  ast.Ident{ID: "Missing"},
+		Arguments: []ast.ExpressionNode{ast.ShapeNode{}},
+	}
+	_, handled, err := tc.inferNominalErrorConstructorCall(call, nil)
+	if err != nil || handled {
+		t.Fatalf("expected not handled for unknown fn, handled=%v err=%v", handled, err)
+	}
+}

--- a/forst/internal/typechecker/lookup_field_assertion_test.go
+++ b/forst/internal/typechecker/lookup_field_assertion_test.go
@@ -1,6 +1,7 @@
 package typechecker
 
 import (
+	"strings"
 	"testing"
 
 	"forst/internal/ast"
@@ -44,5 +45,36 @@ func TestLookupFieldPathOnMergedFields_emptyPath(t *testing.T) {
 	_, err := tc.lookupFieldPathOnMergedFields(map[string]ast.ShapeFieldNode{}, []string{})
 	if err == nil {
 		t.Fatal("expected empty field path error")
+	}
+}
+
+func TestLookupFieldPathOnMergedFields_nestedPath(t *testing.T) {
+	tc := New(logger.New(), false)
+	fields := map[string]ast.ShapeFieldNode{
+		"user": {
+			Shape: &ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"name": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+				},
+			},
+		},
+	}
+	got, err := tc.lookupFieldPathOnMergedFields(fields, []string{"user", "name"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Ident != ast.TypeString {
+		t.Fatalf("got %q", got.Ident)
+	}
+}
+
+func TestLookupFieldPathOnMergedFields_missingField(t *testing.T) {
+	tc := New(logger.New(), false)
+	_, err := tc.lookupFieldPathOnMergedFields(
+		map[string]ast.ShapeFieldNode{"a": {Type: &ast.TypeNode{Ident: ast.TypeInt}}},
+		[]string{"missing"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got %v", err)
 	}
 }

--- a/forst/internal/typechecker/lookup_field_path_resolve_alias_test.go
+++ b/forst/internal/typechecker/lookup_field_path_resolve_alias_test.go
@@ -7,11 +7,6 @@ import (
 	"forst/internal/logger"
 )
 
-//go:fix inline
-func ptrTypeIdentForAliasTest(id ast.TypeIdent) *ast.TypeIdent {
-	return new(id)
-}
-
 func TestResolveTypeAliasChain_unknown_ident_unchanged(t *testing.T) {
 	tc := &TypeChecker{
 		log:  logger.New(),

--- a/forst/internal/typechecker/lookup_function_test.go
+++ b/forst/internal/typechecker/lookup_function_test.go
@@ -48,3 +48,84 @@ func main() {}
 		t.Fatalf("got %#v", ty)
 	}
 }
+
+func TestLookupFunctionReturnType_endToEndReceiverMethod(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+
+type Counter = { n: Int }
+
+func (Counter) inc(): Int {
+	return 1
+}
+
+func main() {}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
+	var fn *ast.FunctionNode
+	for _, n := range nodes {
+		if f, ok := n.(ast.FunctionNode); ok && f.Receiver != nil {
+			fn = &f
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("no receiver method found")
+	}
+	rts, err := tc.LookupFunctionReturnType(fn)
+	if err != nil || len(rts) != 1 || rts[0].Ident != ast.TypeInt {
+		t.Fatalf("return types = %#v err=%v", rts, err)
+	}
+}
+
+func TestLookupFunctionReturnType_undefinedReceiverMethod(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	counter := ast.TypeIdent("Counter")
+	_ = counter
+	fn := &ast.FunctionNode{
+		Ident: ast.Ident{ID: "missing"},
+		Receiver: &ast.SimpleParamNode{
+			Type: ast.TypeNode{Ident: "Counter"},
+		},
+	}
+	_, err := tc.LookupFunctionReturnType(fn)
+	if err == nil || !strings.Contains(err.Error(), "undefined receiver method") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestLookupAssertionType_constraintAssertion(t *testing.T) {
+	t.Parallel()
+	tc := New(logrus.New(), false)
+	str := ast.TypeString
+	a := &ast.AssertionNode{
+		BaseType: &str,
+		Constraints: []ast.ConstraintNode{{
+			Name: "Min",
+			Args: []ast.ConstraintArgumentNode{{
+				Value: func() *ast.ValueNode {
+					v := ast.IntLiteralNode{Value: 1}
+					var n ast.ValueNode = v
+					return &n
+				}(),
+			}},
+		}},
+	}
+	ty, err := tc.LookupAssertionType(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ty == nil || !ty.IsHashBased() {
+		t.Fatalf("expected hash-based assertion type, got %#v", ty)
+	}
+}

--- a/forst/internal/typechecker/narrowing_display_test.go
+++ b/forst/internal/typechecker/narrowing_display_test.go
@@ -89,8 +89,3 @@ func TestNarrowingPredicateDisplayFromIsRHS_typeDefAssertionExprValue(t *testing
 		t.Fatal("expected display from TypeDefAssertionExpr value")
 	}
 }
-
-//go:fix inline
-func ptrVal(v ast.ValueNode) *ast.ValueNode {
-	return new(v)
-}

--- a/forst/internal/typechecker/param_shape_test.go
+++ b/forst/internal/typechecker/param_shape_test.go
@@ -58,3 +58,38 @@ func TestShapeFieldsFromParamType_inlineShape(t *testing.T) {
 		t.Fatalf("ShapeFieldsFromParamType: ok=%v fields=%d", ok, len(fields))
 	}
 }
+
+func TestShapeFieldsFromParamType_typedefShape(t *testing.T) {
+	t.Parallel()
+	tc := New(nil, false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "Point",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+					"y": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	})
+	fields, ok := tc.ShapeFieldsFromParamType(ast.TypeNode{Ident: "Point"})
+	if !ok || len(fields) != 2 {
+		t.Fatalf("typedef shape fields: ok=%v len=%d", ok, len(fields))
+	}
+}
+
+func TestShapeFieldTypeNode_nestedShape(t *testing.T) {
+	t.Parallel()
+	field := ast.ShapeFieldNode{
+		Shape: &ast.ShapeNode{
+			Fields: map[string]ast.ShapeFieldNode{
+				"z": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+			},
+		},
+	}
+	ty, ok := ShapeFieldTypeNode(field)
+	if !ok || ty.Ident != ast.TypeShape || ty.Assertion == nil {
+		t.Fatalf("nested shape field type: %#v ok=%v", ty, ok)
+	}
+}

--- a/forst/internal/typechecker/providers_engine.go
+++ b/forst/internal/typechecker/providers_engine.go
@@ -32,7 +32,15 @@ func (tc *TypeChecker) providersEngine() *ProvidersEngine {
 }
 
 func (tc *TypeChecker) initProvidersInference() {
+	var deferCheck bool
+	var forstPkg string
+	if tc.providers != nil {
+		deferCheck = tc.providers.DeferWiringRootCheck
+		forstPkg = tc.providers.ForstPackage
+	}
 	tc.providers = newProvidersEngine()
+	tc.providers.DeferWiringRootCheck = deferCheck
+	tc.providers.ForstPackage = forstPkg
 	tc.Warnings = nil
 }
 

--- a/forst/internal/typechecker/providers_engine_test.go
+++ b/forst/internal/typechecker/providers_engine_test.go
@@ -1,0 +1,17 @@
+package typechecker
+
+import "testing"
+
+func TestInitProvidersInference_preservesDeferAndForstPackage(t *testing.T) {
+	t.Parallel()
+	tc := New(nil, false)
+	tc.SetDeferProvidersWiringRootCheck(true)
+	tc.SetForstPackage("demo")
+	tc.initProvidersInference()
+	if !tc.providersEngine().DeferWiringRootCheck {
+		t.Fatal("DeferWiringRootCheck should survive providers re-init")
+	}
+	if tc.providersEngine().ForstPackage != "demo" {
+		t.Fatalf("ForstPackage = %q, want demo", tc.providersEngine().ForstPackage)
+	}
+}

--- a/forst/internal/typechecker/providers_finish_test.go
+++ b/forst/internal/typechecker/providers_finish_test.go
@@ -1,0 +1,126 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/providersgraph"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestValidateSidecarExportable_rejectsProvidersOnExportedFn(t *testing.T) {
+	tc := New(logrus.New(), false)
+	tc.FunctionProviders = map[ast.Identifier][]ProviderSlot{
+		"Handle": {{RootIdent: "Logger", Key: "Logger"}},
+	}
+	nodes := []ast.Node{
+		ast.PackageNode{Ident: ast.Ident{ID: "main"}},
+		ast.FunctionNode{Ident: ast.Ident{ID: "Handle", Span: ast.SourceSpan{StartLine: 1}}},
+	}
+	err := tc.validateSidecarExportable(nodes)
+	if err == nil {
+		t.Fatal("expected sidecar export error")
+	}
+	diag, ok := err.(*Diagnostic)
+	if !ok || diag.Code != "providers-sidecar-export" {
+		t.Fatalf("got %T %v", err, err)
+	}
+	if !strings.Contains(diag.Msg, "Handle") || !strings.Contains(diag.Msg, "Logger") {
+		t.Fatalf("msg = %q", diag.Msg)
+	}
+}
+
+func TestValidateSidecarExportable_nonMainPackageSkipped(t *testing.T) {
+	tc := New(logrus.New(), false)
+	tc.FunctionProviders = map[ast.Identifier][]ProviderSlot{
+		"Handle": {{RootIdent: "Logger", Key: "Logger"}},
+	}
+	nodes := []ast.Node{
+		ast.PackageNode{Ident: ast.Ident{ID: "lib"}},
+		ast.FunctionNode{Ident: ast.Ident{ID: "Handle"}},
+	}
+	if err := tc.validateSidecarExportable(nodes); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateWiringRootFn_unsatisfiedProviders(t *testing.T) {
+	tc := New(logrus.New(), false)
+	tc.Functions = map[ast.Identifier]FunctionSignature{
+		"TestX": {Ident: ast.Ident{ID: "TestX", Span: ast.SourceSpan{StartLine: 2}}},
+	}
+	tc.FunctionProviders = map[ast.Identifier][]ProviderSlot{
+		"TestX": {{RootIdent: "Logger", Key: "Logger"}},
+	}
+	err := tc.validateWiringRootFn("TestX")
+	if err == nil {
+		t.Fatal("expected wiring root error")
+	}
+	diag, ok := err.(*Diagnostic)
+	if !ok || diag.Code != "providers-unsatisfied" {
+		t.Fatalf("got %T %v", err, err)
+	}
+	if !strings.Contains(diag.Msg, "Logger") {
+		t.Fatalf("msg = %q", diag.Msg)
+	}
+}
+
+func TestValidateWiringRootFn_noProvidersOk(t *testing.T) {
+	tc := New(logrus.New(), false)
+	if err := tc.validateWiringRootFn("TestX"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateModuleProviders_crossPackageUnsatisfied(t *testing.T) {
+	tc := New(logrus.New(), false)
+	tc.providers = newProvidersEngine()
+	tc.importPathByLocal = map[string]string{"alpha": "testmod/alpha"}
+	tc.providers.CallEdges = []providersgraph.CallEdge{{
+		CallerFn:    "Handle",
+		CalleeFn:    "ExpireToken",
+		ImportLocal: "alpha",
+		Scope:       providersgraph.ProviderScopeSnapshot{},
+		Span:        ast.SourceSpan{StartLine: 5},
+	}}
+	perPkg := map[string]map[ast.Identifier][]ProviderSlot{
+		"alpha": {"ExpireToken": {{RootIdent: "Logger", Key: "Logger"}}},
+	}
+	importMap := map[string]string{"testmod/alpha": "alpha"}
+	err := ValidateModuleProviders("beta", tc, importMap, perPkg)
+	if err == nil {
+		t.Fatal("expected cross-package unsatisfied error")
+	}
+	diag, ok := err.(*Diagnostic)
+	if !ok || diag.Code != "providers-unsatisfied" {
+		t.Fatalf("got %T %v", err, err)
+	}
+}
+
+func TestScopeSatisfiesAllSlots(t *testing.T) {
+	tc := New(logrus.New(), false)
+	scope := map[string]ast.TypeNode{"Logger": {Ident: "Logger"}}
+	slots := []ProviderSlot{{RootIdent: "Logger", Key: "Logger", ContractType: ast.TypeNode{Ident: "Logger"}}}
+	if !scopeSatisfiesAllSlots(tc, scope, slots) {
+		t.Fatal("expected scope to satisfy slot")
+	}
+	if scopeSatisfiesAllSlots(tc, map[string]ast.TypeNode{}, slots) {
+		t.Fatal("expected empty scope to fail")
+	}
+}
+
+func TestCallerForwardsSlots(t *testing.T) {
+	tc := New(logrus.New(), false)
+	tc.FunctionProviders = map[ast.Identifier][]ProviderSlot{
+		"caller": {{RootIdent: "Logger", Key: "Logger"}, {RootIdent: "Clock", Key: "Clock"}},
+	}
+	callee := []ProviderSlot{{RootIdent: "Logger", Key: "Logger"}}
+	if !callerForwardsSlots(tc, "caller", callee) {
+		t.Fatal("caller should forward Logger")
+	}
+	if callerForwardsSlots(tc, "caller", []ProviderSlot{{RootIdent: "Missing", Key: "Missing"}}) {
+		t.Fatal("caller should not forward missing slot")
+	}
+}

--- a/forst/internal/typechecker/providers_obligation_chain_test.go
+++ b/forst/internal/typechecker/providers_obligation_chain_test.go
@@ -1,0 +1,57 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildProvidersObligationChain_fromParse(t *testing.T) {
+	src := `package main
+import "testing"
+
+type Logger = { info(msg String) }
+
+func needsLogger() {
+	use logger: Logger
+}
+
+func TestX(t *testing.T) {
+	needsLogger()
+}
+`
+	tc, err := parseAndCheck(t, src)
+	if err == nil {
+		t.Fatal("expected unsatisfied providers error")
+	}
+	diag, ok := err.(*Diagnostic)
+	if !ok {
+		t.Fatalf("got %T: %v", err, err)
+	}
+	if !strings.Contains(diag.Msg, "TestX") || !strings.Contains(diag.Msg, "needsLogger") {
+		t.Fatalf("expected obligation chain in message: %q", diag.Msg)
+	}
+	chain := tc.BuildProvidersObligationChain("TestX", "Logger")
+	if !strings.Contains(chain, "TestX") || !strings.Contains(chain, "Logger") {
+		t.Fatalf("BuildProvidersObligationChain = %q", chain)
+	}
+}
+
+func TestBuildCallSiteObligationChain(t *testing.T) {
+	tc := New(nil, false)
+	tc.SetForstPackage("main")
+	chain := tc.buildCallSiteObligationChain("caller", "callee", []string{"Logger"})
+	if !strings.Contains(chain, "caller") || !strings.Contains(chain, "callee") || !strings.Contains(chain, "Logger") {
+		t.Fatalf("chain = %q", chain)
+	}
+}
+
+func TestBuildWiringRootObligationChain(t *testing.T) {
+	tc := New(nil, false)
+	tc.SetForstPackage("main")
+	chain := tc.buildWiringRootObligationChain("TestX", []ProviderSlot{
+		{RootIdent: "Logger", Key: "Logger"},
+	})
+	if !strings.Contains(chain, "TestX") || !strings.Contains(chain, "Logger") {
+		t.Fatalf("chain = %q", chain)
+	}
+}

--- a/forst/internal/typechecker/providers_scope.go
+++ b/forst/internal/typechecker/providers_scope.go
@@ -42,8 +42,8 @@ func (tc *TypeChecker) providerScopeFromShape(shape ast.ShapeNode) (ProviderScop
 		if len(valTypes) != 1 {
 			return ProviderScope{}, fmt.Errorf("wiring field %s must have a single type", fieldName)
 		}
-		contractType, ok := eng.KnownRoots[fieldName]
-		if !ok {
+		contractType, knownContract := eng.KnownRoots[fieldName]
+		if !knownContract {
 			if eng.DeferWiringRootCheck {
 				contractType = ast.TypeNode{Ident: ast.TypeIdent(fieldName)}
 			} else {
@@ -51,9 +51,11 @@ func (tc *TypeChecker) providerScopeFromShape(shape ast.ShapeNode) (ProviderScop
 					"unknown wiring key %q", fieldName)
 			}
 		}
-		if !tc.wiringValueAssignable(valTypes[0], contractType) {
-			return ProviderScope{}, diagnosticf(fieldSpan, "providers-wiring-type",
-				"wiring field %s: expected type %s, got %s", fieldName, contractType.Ident, valTypes[0].Ident)
+		if knownContract || !eng.DeferWiringRootCheck {
+			if !tc.wiringValueAssignable(valTypes[0], contractType) {
+				return ProviderScope{}, diagnosticf(fieldSpan, "providers-wiring-type",
+					"wiring field %s: expected type %s, got %s", fieldName, contractType.Ident, valTypes[0].Ident)
+			}
 		}
 		amb.Keys[fieldName] = contractType
 		amb.Shadowed[fieldName] = true

--- a/forst/internal/typechecker/result_err_branch_return_test.go
+++ b/forst/internal/typechecker/result_err_branch_return_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"forst/internal/ast"
 	"forst/internal/parser"
 )
 
@@ -180,5 +181,19 @@ func main() {
 	}
 	if !strings.Contains(err.Error(), "Err(...)") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIsErrExprAST(t *testing.T) {
+	t.Parallel()
+	if !isErrExprAST(ast.ErrExprNode{Value: ast.StringLiteralNode{Value: "e"}}) {
+		t.Fatal("ErrExprNode should match")
+	}
+	e := ast.ErrExprNode{Value: ast.StringLiteralNode{Value: "e"}}
+	if !isErrExprAST(&e) {
+		t.Fatal("*ErrExprNode should match")
+	}
+	if isErrExprAST(ast.IntLiteralNode{Value: 1}) {
+		t.Fatal("int literal should not match")
 	}
 }

--- a/forst/internal/typechecker/unify_is_test.go
+++ b/forst/internal/typechecker/unify_is_test.go
@@ -1,26 +1,69 @@
 package typechecker
 
 import (
-	"strings"
 	"testing"
 
+	"forst/internal/ast"
 	"forst/internal/parser"
 )
 
-// TestUnifyIs_typeGuardCallInIfCondition exercises unifyIsOperator via real CheckTypes (see unify_is.go).
-func TestUnifyIs_typeGuardCallInIfCondition(t *testing.T) {
+func TestGetLeftmostVariable_nestedBinary(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	left := ast.BinaryExpressionNode{
+		Left:  ast.VariableNode{Ident: ast.Ident{ID: "a"}},
+		Right: ast.IntLiteralNode{Value: 1},
+	}
+	got, err := tc.getLeftmostVariable(left)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := got.(ast.VariableNode); !ok || v.Ident.ID != "a" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestGetLeftmostVariable_nonVariableErrors(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	_, err := tc.getLeftmostVariable(ast.IntLiteralNode{Value: 1})
+	if err == nil {
+		t.Fatal("expected error for literal LHS")
+	}
+}
+
+func TestUnifyIsOperator_shapeLiteral(t *testing.T) {
 	t.Parallel()
 	log := setupTestLogger(nil)
 	src := `package main
-
-type N = Int
-
-is (v N) Ok() {
-	ensure v is GreaterThan(0)
+type Row = { id: Int, name: String }
+func main() {
+	r := Row{ id: 1, name: "a" }
+	if r is { id: 1 } {
+		println("ok")
+	}
+}
+`
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatal(err)
+	}
 }
 
+func TestUnifyIsOperator_resultOkGuard(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	src := `package main
+func f(): Result(Int, Error) {
+	return 1
+}
 func main() {
-	x := 1
+	x := f()
 	if x is Ok() {
 		println("ok")
 	}
@@ -33,69 +76,6 @@ func main() {
 	}
 	tc := New(log, false)
 	if err := tc.CheckTypes(nodes); err != nil {
-		t.Fatalf("CheckTypes: %v", err)
-	}
-}
-
-// TestUnifyIs_typeGuardCallInIfCondition_invalidLeftHandSide exercises unifyIsOperator when getLeftmostVariable fails (non-variable LHS of `is`).
-func TestUnifyIs_typeGuardCallInIfCondition_invalidLeftHandSide(t *testing.T) {
-	t.Parallel()
-	log := setupTestLogger(nil)
-	src := `package main
-
-type N = Int
-
-is (v N) Ok() {
-	ensure v is GreaterThan(0)
-}
-
-func main() {
-	if 1 is Ok() {
-		println("ok")
-	}
-}
-`
-	p := parser.NewTestParser(src, log)
-	nodes, err := p.ParseFile()
-	if err != nil {
 		t.Fatal(err)
-	}
-	tc := New(log, false)
-	err = tc.CheckTypes(nodes)
-	if err == nil {
-		t.Fatal("expected CheckTypes error for non-variable left-hand side of is")
-	}
-	if !strings.Contains(err.Error(), "invalid left-hand side of 'is' operator") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestUnifyIs_nominalErrorBaseType_rejected(t *testing.T) {
-	t.Parallel()
-	log := setupTestLogger(nil)
-	src := `package main
-
-error ParseError { code: Int }
-type ErrKind = ParseError
-
-func main() {
-	var e: ErrKind = { code: 1 }
-	if e is ParseError {
-		println(e)
-	}
-}
-`
-	p := parser.NewTestParser(src, log)
-	nodes, err := p.ParseFile()
-	if err != nil {
-		t.Fatal(err)
-	}
-	tc := New(log, false)
-	err = tc.CheckTypes(nodes)
-	if err == nil {
-		t.Fatal("expected CheckTypes error: nominal error cannot be bare `is` guard")
-	}
-	if !strings.Contains(err.Error(), "cannot be used as an `is` guard") || !strings.Contains(err.Error(), "Err()") {
-		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/forst/internal/typechecker/unify_operators_test.go
+++ b/forst/internal/typechecker/unify_operators_test.go
@@ -138,3 +138,22 @@ func TestUnifyTypes_comparisonErrNeNil(t *testing.T) {
 		t.Fatalf("want Bool, got %s", ty.Ident)
 	}
 }
+
+func TestUnifyTypes_arithmeticAddInt(t *testing.T) {
+	tc := New(logrus.New(), false)
+	ty, err := tc.unifyTypes(ast.IntLiteralNode{Value: 1}, ast.IntLiteralNode{Value: 2}, ast.TokenPlus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ty.Ident != ast.TypeInt {
+		t.Fatalf("got %s", ty.Ident)
+	}
+}
+
+func TestUnifyTypes_arithmeticAddBoolRejected(t *testing.T) {
+	tc := New(logrus.New(), false)
+	_, err := tc.unifyTypes(ast.BoolLiteralNode{Value: true}, ast.IntLiteralNode{Value: 1}, ast.TokenPlus)
+	if err == nil {
+		t.Fatal("expected error adding bool and int")
+	}
+}

--- a/forst/internal/typechecker/unify_shape_test.go
+++ b/forst/internal/typechecker/unify_shape_test.go
@@ -91,3 +91,120 @@ func main() {
 		t.Fatal(err)
 	}
 }
+
+func TestIsShapeAlias_nominalError(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "E",
+		Expr: ast.TypeDefErrorExpr{
+			Payload: ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+				"m": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+			}},
+		},
+	})
+	if !tc.isShapeAlias("E") {
+		t.Fatal("nominal error should count as shape alias")
+	}
+}
+
+func TestIsShapeAlias_unknownType(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	if tc.isShapeAlias("Missing") {
+		t.Fatal("unknown type should not be shape alias")
+	}
+}
+
+func TestGetShapeFields_fromTypeDefShapeAlias(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tc := New(log, false)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "Point",
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+					"y": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	})
+	fields, err := tc.getShapeFields(ast.TypeNode{Ident: "Point"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fields) != 2 {
+		t.Fatalf("got %d fields", len(fields))
+	}
+}
+
+func TestGetShapeFields_fromMatchAssertion(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	shape := ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"name": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+		},
+	}
+	base := ast.TypeShape
+	assertion := &ast.AssertionNode{
+		BaseType: &base,
+		Constraints: []ast.ConstraintNode{{
+			Name: ConstraintMatch,
+			Args: []ast.ConstraintArgumentNode{{Shape: &shape}},
+		}},
+	}
+	fields, err := tc.getShapeFields(
+		ast.TypeNode{Ident: ast.TypeShape, Assertion: assertion},
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := fields["name"]; !ok {
+		t.Fatalf("got %#v", fields)
+	}
+}
+
+func TestGetShapeFields_missingFieldsErrors(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	_, err := tc.getShapeFields(ast.TypeNode{Ident: ast.TypeInt}, nil)
+	if err == nil {
+		t.Fatal("expected error for non-shape type")
+	}
+}
+
+func TestValidateShapeFields_compatibleFields(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	left := map[string]ast.ShapeFieldNode{
+		"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+	}
+	right := ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+		},
+	}
+	if err := tc.ValidateShapeFields(right, left, "Point"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateShapeFields_unknownFieldErrors(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	left := map[string]ast.ShapeFieldNode{
+		"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+	}
+	right := ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"z": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+		},
+	}
+	if err := tc.ValidateShapeFields(right, left, "Point"); err == nil {
+		t.Fatal("expected unknown field error")
+	}
+}

--- a/forst/internal/typechecker/utils_test.go
+++ b/forst/internal/typechecker/utils_test.go
@@ -1,0 +1,79 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestIsPlainFailureCompatibleWithDeclaredResult(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	result := ast.TypeNode{
+		Ident:      ast.TypeResult,
+		TypeParams: []ast.TypeNode{{Ident: ast.TypeInt}, {Ident: ast.TypeString}},
+	}
+	if !tc.isPlainFailureCompatibleWithDeclaredResult(
+		ast.TypeNode{Ident: ast.TypeString},
+		result,
+	) {
+		t.Fatal("plain string failure should match Result(Int, String)")
+	}
+	if tc.isPlainFailureCompatibleWithDeclaredResult(
+		ast.TypeNode{Ident: ast.TypeInt},
+		result,
+	) {
+		t.Fatal("int should not match failure slot String")
+	}
+}
+
+func TestReturnTypeMatchesInferredShape(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	hashName := ast.TypeIdent("T_abc")
+	tc.Defs[hashName] = ast.TypeDefNode{
+		Ident: hashName,
+		Expr: ast.TypeDefShapeExpr{
+			Shape: ast.ShapeNode{
+				Fields: map[string]ast.ShapeFieldNode{
+					"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+				},
+			},
+		},
+	}
+	base := ast.TypeShape
+	expected := ast.TypeNode{
+		Ident: ast.TypeShape,
+		Assertion: &ast.AssertionNode{
+			BaseType: &base,
+			Constraints: []ast.ConstraintNode{{
+				Name: ConstraintMatch,
+				Args: []ast.ConstraintArgumentNode{{
+					Shape: &ast.ShapeNode{
+						Fields: map[string]ast.ShapeFieldNode{
+							"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+						},
+					},
+				}},
+			}},
+		},
+	}
+	if !tc.returnTypeMatchesInferredShape(ast.TypeNode{Ident: hashName}, expected) {
+		t.Fatal("hash shape should match parsed Match return type")
+	}
+}
+
+func TestRegisterHashBasedType_idempotent(t *testing.T) {
+	t.Parallel()
+	tc := New(setupTestLogger(nil), false)
+	fields := map[string]ast.ShapeFieldNode{
+		"a": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+	}
+	RegisterHashBasedType(tc, "H1", fields)
+	RegisterHashBasedType(tc, "H1", map[string]ast.ShapeFieldNode{
+		"b": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+	})
+	if def, ok := tc.Defs["H1"].(ast.TypeDefNode); !ok || len(def.Expr.(ast.TypeDefShapeExpr).Shape.Fields) != 1 {
+		t.Fatal("second register should not overwrite")
+	}
+}


### PR DESCRIPTION
Ensure `or bad(...)` / nominal error payloads are emitted on ensure failure instead of a generic errors.New message. Preserve deferred providers wiring flags across typechecker re-init and skip assignability checks for unknown wiring keys while defer is enabled. Coerce string aliases when Assertion.BaseType is a direct builtin. Add broad unit-test coverage (inline snippets and hooks for goload, safefs, forstpkg, cmd/forst test) so merged Go coverage reaches 79.8%.

fix(transformer): wire ensure-or fallback in Go codegen

transformErrorStatement now lowers custom ensure failure expressions via transformEnsureErrorFallback / ensureFailureErrorExpr. Nominal errors like or NotOk({ msg: "bad" }) emit composite literals, not NotOk(NotOk{...}).

Example:
```forst
func f(row Int): Result(String, Error) {
  ensure row is GreaterThan(-1) or Bad("too small")
  return "ok"
}
```

fix(typechecker): preserve deferred wiring state across providers re-init

initProvidersInference no longer drops DeferWiringRootCheck or ForstPackage when CheckTypes re-initializes the providers engine. Unknown wiring keys during deferred merge skip type assignability until post-merge revalidation.

Example:
```forst
with { BadKey: &NopLogger {} } {
  use logger: Logger
}
```

test: expand unit coverage across cmd and internal packages

Add pipeline and direct unit tests for transformer/go (providers, shapes, ensure builtins, cross-package wiring), typechecker inference/providers, generators, goload, safefs, forstpkg, modulecheck, providersgraph, and cmd/forst CLI paths. Introduce test hooks where OS/filesystem branches are hard to reach from unit tests alone.