### PR TITLE
feat(transformer): add ensure diagnostics in tests

### DIFF
--- a/forst/cmd/forst/main_test.go
+++ b/forst/cmd/forst/main_test.go
@@ -547,7 +547,7 @@ func TestResultExamplesIncludeEnsureLowering(t *testing.T) {
 		filepath.Join(root, "result_ensure.ft"),
 	}
 	const wantBranch = `if n <= 0`
-	const wantMsg = `assertion failed: Int.GreaterThan(0)`
+	const wantMsg = `ensure n is Int.GreaterThan(0): want > 0`
 	for _, path := range examples {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			t.Parallel()

--- a/forst/internal/transformer/go/ensure_failure_message.go
+++ b/forst/internal/transformer/go/ensure_failure_message.go
@@ -1,0 +1,222 @@
+package transformergo
+
+import (
+	"fmt"
+	"strconv"
+
+	"forst/internal/ast"
+	goast "go/ast"
+	"go/token"
+)
+
+func ensureSubjectLabel(v ast.VariableNode) string {
+	return string(v.Ident.ID)
+}
+
+func constraintArgDisplay(arg ast.ConstraintArgumentNode) string {
+	return arg.String()
+}
+
+type ensureGotDiagnostic struct {
+	suffixFormat string
+	gotArgs      []goast.Expr
+}
+
+func defaultGotDiagnostic(subjectExpr goast.Expr) ensureGotDiagnostic {
+	return ensureGotDiagnostic{
+		suffixFormat: "got %v, want %s",
+		gotArgs:      []goast.Expr{subjectExpr},
+	}
+}
+
+func (t *Transformer) ensureSubjectVarType(stmt ast.EnsureNode) (ast.TypeNode, bool) {
+	ty, err := t.TypeChecker.LookupVariableType(&stmt.Variable, t.currentScope())
+	if err != nil {
+		return ast.TypeNode{}, false
+	}
+	return ty, true
+}
+
+func (t *Transformer) isStringLikeType(tn ast.TypeNode) bool {
+	if tn.Ident == ast.TypeString {
+		return true
+	}
+	return t.typeIsStringAlias(tn.Ident)
+}
+
+func (t *Transformer) ensureResultGotDiagnostic(variable ast.VariableNode, c ast.ConstraintNode, subjectExpr goast.Expr) ensureGotDiagnostic {
+	errExpr, err := t.goResultErrIdentForExpr(variable)
+	if err != nil {
+		return defaultGotDiagnostic(subjectExpr)
+	}
+	if c.Name == "Ok" && len(c.Args) == 1 {
+		valExpr, err := t.goResultSuccessValueExprForOkDiscriminator(variable)
+		if err != nil {
+			return ensureGotDiagnostic{
+				suffixFormat: "got err=%v, want %s",
+				gotArgs:      []goast.Expr{errExpr},
+			}
+		}
+		return ensureGotDiagnostic{
+			suffixFormat: "got err=%v, val=%v, want %s",
+			gotArgs:      []goast.Expr{errExpr, valExpr},
+		}
+	}
+	return ensureGotDiagnostic{
+		suffixFormat: "got err=%v, want %s",
+		gotArgs:      []goast.Expr{errExpr},
+	}
+}
+
+// ensureConstraintGotDiagnostic picks Fatalf got-clause format and expressions for the failed ensure.
+func (t *Transformer) ensureConstraintGotDiagnostic(stmt ast.EnsureNode, subjectExpr goast.Expr) ensureGotDiagnostic {
+	assertion := stmt.Assertion
+	if len(assertion.Constraints) != 1 {
+		return defaultGotDiagnostic(subjectExpr)
+	}
+	c := assertion.Constraints[0]
+
+	switch c.Name {
+	case string(TrueConstraint), string(FalseConstraint):
+		return ensureGotDiagnostic{
+			suffixFormat: "got %t, want %s",
+			gotArgs:      []goast.Expr{subjectExpr},
+		}
+	case "Ok", "Err":
+		return t.ensureResultGotDiagnostic(stmt.Variable, c, subjectExpr)
+	}
+
+	varType, hasType := t.ensureSubjectVarType(stmt)
+	stringLike := hasType && t.isStringLikeType(varType)
+	if !stringLike && assertion.BaseType != nil {
+		stringLike = t.typeIsStringAlias(*assertion.BaseType)
+	}
+	if stringLike {
+		stringExpr, err := t.assertionTransformer.transformStringBuiltinVariable(stmt.Variable)
+		if err != nil {
+			return defaultGotDiagnostic(subjectExpr)
+		}
+		switch c.Name {
+		case string(MinConstraint), string(MaxConstraint):
+			return ensureGotDiagnostic{
+				suffixFormat: "got len=%d (%q), want %s",
+				gotArgs: []goast.Expr{
+					&goast.CallExpr{
+						Fun:  goast.NewIdent("len"),
+						Args: []goast.Expr{stringExpr},
+					},
+					stringExpr,
+				},
+			}
+		case string(HasPrefixConstraint), string(ContainsConstraint), string(NotEmptyConstraint):
+			return ensureGotDiagnostic{
+				suffixFormat: "got %q, want %s",
+				gotArgs:      []goast.Expr{stringExpr},
+			}
+		}
+	}
+
+	return defaultGotDiagnostic(subjectExpr)
+}
+
+// ensureConstraintWantHint returns a human-readable expected-value description from ensure constraints.
+func (t *Transformer) ensureConstraintWantHint(assertion *ast.AssertionNode) string {
+	if assertion.BaseType != nil && len(assertion.Constraints) == 0 {
+		return fmt.Sprintf("%s()", assertion.BaseType.String())
+	}
+	if len(assertion.Constraints) == 0 {
+		return t.getAssertionStringForError(assertion)
+	}
+	if len(assertion.Constraints) > 1 {
+		return t.getAssertionStringForError(assertion)
+	}
+	c := assertion.Constraints[0]
+	switch c.Name {
+	case string(TrueConstraint):
+		return "true"
+	case string(FalseConstraint):
+		return "false"
+	case string(NilConstraint):
+		return "nil"
+	case string(PresentConstraint):
+		return "non-nil"
+	case string(NotEmptyConstraint):
+		return "non-empty"
+	case "Ok":
+		return "Ok()"
+	case "Err":
+		return "Err()"
+	case string(GreaterThanConstraint):
+		if len(c.Args) >= 1 {
+			return "> " + constraintArgDisplay(c.Args[0])
+		}
+	case string(LessThanConstraint):
+		if len(c.Args) >= 1 {
+			return "< " + constraintArgDisplay(c.Args[0])
+		}
+	case string(MinConstraint):
+		if len(c.Args) >= 1 {
+			return ">= " + constraintArgDisplay(c.Args[0])
+		}
+	case string(MaxConstraint):
+		if len(c.Args) >= 1 {
+			return "<= " + constraintArgDisplay(c.Args[0])
+		}
+	case string(HasPrefixConstraint):
+		if len(c.Args) >= 1 {
+			return fmt.Sprintf("prefix %s", constraintArgDisplay(c.Args[0]))
+		}
+	case string(ContainsConstraint):
+		if len(c.Args) >= 1 {
+			return fmt.Sprintf("contains %s", constraintArgDisplay(c.Args[0]))
+		}
+	}
+	return t.getAssertionStringForError(assertion)
+}
+
+func (t *Transformer) ensureFailureMessage(stmt ast.EnsureNode) (subjectLabel, assertionLabel, wantHint string) {
+	subjectLabel = ensureSubjectLabel(stmt.Variable)
+	assertionLabel = t.getAssertionStringForError(&stmt.Assertion)
+	wantHint = t.ensureConstraintWantHint(&stmt.Assertion)
+	return subjectLabel, assertionLabel, wantHint
+}
+
+func goQuotedStringLit(s string) *goast.BasicLit {
+	return &goast.BasicLit{Kind: token.STRING, Value: strconv.Quote(s)}
+}
+
+func testFatalfCall(testIdent *goast.Ident, format string, args ...goast.Expr) *goast.ExprStmt {
+	callArgs := make([]goast.Expr, 0, 1+len(args))
+	callArgs = append(callArgs, goQuotedStringLit(format))
+	callArgs = append(callArgs, args...)
+	return &goast.ExprStmt{
+		X: &goast.CallExpr{
+			Fun: &goast.SelectorExpr{
+				X:   testIdent,
+				Sel: goast.NewIdent("Fatalf"),
+			},
+			Args: callArgs,
+		},
+	}
+}
+
+// ensureTestFatalfCall emits t.Fatalf with got/want diagnostics for a failed ensure in a test function.
+func (t *Transformer) ensureTestFatalfCall(testIdent *goast.Ident, stmt ast.EnsureNode) goast.Stmt {
+	subjectLabel, assertionLabel, wantHint := t.ensureFailureMessage(stmt)
+	subjectExpr, err := t.transformExpression(stmt.Variable)
+	if err != nil {
+		return testFatalfCall(testIdent, "ensure %s is %s",
+			goQuotedStringLit(subjectLabel),
+			goQuotedStringLit(assertionLabel),
+		)
+	}
+	got := t.ensureConstraintGotDiagnostic(stmt, subjectExpr)
+	format := "ensure %s is %s: " + got.suffixFormat
+	args := []goast.Expr{
+		goQuotedStringLit(subjectLabel),
+		goQuotedStringLit(assertionLabel),
+	}
+	args = append(args, got.gotArgs...)
+	args = append(args, goQuotedStringLit(wantHint))
+	return testFatalfCall(testIdent, format, args...)
+}

--- a/forst/internal/transformer/go/ensure_failure_message_test.go
+++ b/forst/internal/transformer/go/ensure_failure_message_test.go
@@ -1,0 +1,463 @@
+package transformergo
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	goast "go/ast"
+)
+
+func TestEnsureConstraintWantHint(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tr := setupTransformer(setupTypeChecker(log), log)
+
+	tests := []struct {
+		name string
+		a    ast.AssertionNode
+		want string
+	}{
+		{
+			name: "bool true",
+			a: ast.AssertionNode{
+				BaseType:    typeIdentPtr(string(ast.TypeBool)),
+				Constraints: []ast.ConstraintNode{{Name: string(TrueConstraint)}},
+			},
+			want: "true",
+		},
+		{
+			name: "bool false",
+			a: ast.AssertionNode{
+				BaseType:    typeIdentPtr(string(ast.TypeBool)),
+				Constraints: []ast.ConstraintNode{{Name: string(FalseConstraint)}},
+			},
+			want: "false",
+		},
+		{
+			name: "int greater than",
+			a: ast.AssertionNode{
+				BaseType: typeIdentPtr(string(ast.TypeInt)),
+				Constraints: []ast.ConstraintNode{{
+					Name: string(GreaterThanConstraint),
+					Args: []ast.ConstraintArgumentNode{{Value: intLiteralNodePtr(0)}},
+				}},
+			},
+			want: "> 0",
+		},
+		{
+			name: "type guard only",
+			a: ast.AssertionNode{
+				BaseType: typeIdentPtr("Strong"),
+			},
+			want: "Strong()",
+		},
+		{
+			name: "result ok",
+			a: ast.AssertionNode{
+				Constraints: []ast.ConstraintNode{{Name: "Ok"}},
+			},
+			want: "Ok()",
+		},
+		{
+			name: "string has prefix",
+			a: ast.AssertionNode{
+				BaseType: typeIdentPtr(string(ast.TypeString)),
+				Constraints: []ast.ConstraintNode{{
+					Name: string(HasPrefixConstraint),
+					Args: []ast.ConstraintArgumentNode{{
+						Value: strLiteralNodePtr("https://"),
+					}},
+				}},
+			},
+			want: `prefix "https://"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tr.ensureConstraintWantHint(&tt.a)
+			if got != tt.want {
+				t.Fatalf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureConstraintGotDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setup      func(*Transformer)
+		stmt       ast.EnsureNode
+		wantFormat string
+		wantIn     []string
+		wantNotIn  []string
+	}{
+		{
+			name: "bool false uses %t",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "flag"}},
+				Assertion: ast.AssertionNode{
+					BaseType:    typeIdentPtr(string(ast.TypeBool)),
+					Constraints: []ast.ConstraintNode{{Name: string(FalseConstraint)}},
+				},
+			},
+			wantFormat: "got %t, want %s",
+			wantIn:     []string{"flag"},
+		},
+		{
+			name: "string contains uses %q",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "s"}},
+				Assertion: ast.AssertionNode{
+					BaseType: typeIdentPtr(string(ast.TypeString)),
+					Constraints: []ast.ConstraintNode{{
+						Name: string(ContainsConstraint),
+						Args: []ast.ConstraintArgumentNode{{
+							Value: strLiteralNodePtr("needle"),
+						}},
+					}},
+				},
+			},
+			wantFormat: "got %q, want %s",
+			wantIn:     []string{"s"},
+		},
+		{
+			name: "string not empty uses %q",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "s"}},
+				Assertion: ast.AssertionNode{
+					BaseType:    typeIdentPtr(string(ast.TypeString)),
+					Constraints: []ast.ConstraintNode{{Name: string(NotEmptyConstraint)}},
+				},
+			},
+			wantFormat: "got %q, want %s",
+			wantIn:     []string{"s"},
+		},
+		{
+			name: "string max uses len and %q",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "s"}},
+				Assertion: ast.AssertionNode{
+					BaseType: typeIdentPtr(string(ast.TypeString)),
+					Constraints: []ast.ConstraintNode{{
+						Name: string(MaxConstraint),
+						Args: []ast.ConstraintArgumentNode{{Value: intLiteralNodePtr(10)}},
+					}},
+				},
+			},
+			wantFormat: "got len=%d (%q), want %s",
+			wantIn:     []string{"len(", "s"},
+		},
+		{
+			name: "multi constraint falls back to default %v",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "n"}},
+				Assertion: ast.AssertionNode{
+					BaseType: typeIdentPtr(string(ast.TypeInt)),
+					Constraints: []ast.ConstraintNode{
+						{Name: string(GreaterThanConstraint), Args: []ast.ConstraintArgumentNode{{Value: intLiteralNodePtr(0)}}},
+						{Name: string(LessThanConstraint), Args: []ast.ConstraintArgumentNode{{Value: intLiteralNodePtr(100)}}},
+					},
+				},
+			},
+			wantFormat: "got %v, want %s",
+			wantIn:     []string{"n"},
+		},
+		{
+			name: "type guard only falls back to default %v",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "p"}},
+				Assertion: ast.AssertionNode{
+					BaseType: typeIdentPtr("Strong"),
+				},
+			},
+			wantFormat: "got %v, want %s",
+			wantIn:     []string{"p"},
+		},
+		{
+			name: "pointer nil uses default %v",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "p"}},
+				Assertion: ast.AssertionNode{
+					BaseType:    typeIdentPtr(string(ast.TypeInt)),
+					Constraints: []ast.ConstraintNode{{Name: string(NilConstraint)}},
+				},
+			},
+			wantFormat: "got %v, want %s",
+			wantIn:     []string{"p"},
+		},
+		{
+			name: "result err uses err=%v",
+			setup: func(tr *Transformer) {
+				tr.resultLocalSplit = map[string]resultLocalSplit{
+					"x": {errGoName: "xErr", successGoNames: []string{"x"}},
+				}
+			},
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "x"}},
+				Assertion: ast.AssertionNode{
+					Constraints: []ast.ConstraintNode{{Name: "Err"}},
+				},
+			},
+			wantFormat: "got err=%v, want %s",
+			wantIn:     []string{"xErr"},
+		},
+		{
+			name: "bool true uses %t",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "ok"}},
+				Assertion: ast.AssertionNode{
+					BaseType:    typeIdentPtr(string(ast.TypeBool)),
+					Constraints: []ast.ConstraintNode{{Name: string(TrueConstraint)}},
+				},
+			},
+			wantFormat: "got %t, want %s",
+			wantIn:     []string{"ok"},
+		},
+		{
+			name: "string has prefix uses %q",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "s"}},
+				Assertion: ast.AssertionNode{
+					BaseType: typeIdentPtr(string(ast.TypeString)),
+					Constraints: []ast.ConstraintNode{{
+						Name: string(HasPrefixConstraint),
+						Args: []ast.ConstraintArgumentNode{{
+							Value: strLiteralNodePtr("https://"),
+						}},
+					}},
+				},
+			},
+			wantFormat: "got %q, want %s",
+			wantIn:     []string{"s"},
+		},
+		{
+			name: "string min uses len and %q",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "s"}},
+				Assertion: ast.AssertionNode{
+					BaseType: typeIdentPtr(string(ast.TypeString)),
+					Constraints: []ast.ConstraintNode{{
+						Name: string(MinConstraint),
+						Args: []ast.ConstraintArgumentNode{{Value: intLiteralNodePtr(1)}},
+					}},
+				},
+			},
+			wantFormat: "got len=%d (%q), want %s",
+			wantIn:     []string{"len(", "s"},
+		},
+		{
+			name: "int greater than uses default %v",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "n"}},
+				Assertion: ast.AssertionNode{
+					BaseType: typeIdentPtr(string(ast.TypeInt)),
+					Constraints: []ast.ConstraintNode{{
+						Name: string(GreaterThanConstraint),
+						Args: []ast.ConstraintArgumentNode{{Value: intLiteralNodePtr(0)}},
+					}},
+				},
+			},
+			wantFormat: "got %v, want %s",
+			wantIn:     []string{"n"},
+		},
+		{
+			name: "result ok uses err=%v",
+			setup: func(tr *Transformer) {
+				tr.resultLocalSplit = map[string]resultLocalSplit{
+					"x": {errGoName: "xErr", successGoNames: []string{"x"}},
+				}
+			},
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "x"}},
+				Assertion: ast.AssertionNode{
+					Constraints: []ast.ConstraintNode{{Name: "Ok"}},
+				},
+			},
+			wantFormat: "got err=%v, want %s",
+			wantIn:     []string{"xErr"},
+			wantNotIn:  []string{"x,"},
+		},
+		{
+			name: "result ok with arg uses err and val",
+			setup: func(tr *Transformer) {
+				tr.resultLocalSplit = map[string]resultLocalSplit{
+					"x": {errGoName: "xErr", successGoNames: []string{"x"}},
+				}
+			},
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "x"}},
+				Assertion: ast.AssertionNode{
+					Constraints: []ast.ConstraintNode{{
+						Name: "Ok",
+						Args: []ast.ConstraintArgumentNode{{Value: intLiteralNodePtr(42)}},
+					}},
+				},
+			},
+			wantFormat: "got err=%v, val=%v, want %s",
+			wantIn:     []string{"xErr", "x"},
+		},
+		{
+			name: "result ok without split falls back to subject %v",
+			stmt: ast.EnsureNode{
+				Variable: ast.VariableNode{Ident: ast.Ident{ID: "x"}},
+				Assertion: ast.AssertionNode{
+					Constraints: []ast.ConstraintNode{{Name: "Ok"}},
+				},
+			},
+			wantFormat: "got %v, want %s",
+			wantIn:     []string{"x"},
+			wantNotIn:  []string{"xErr"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := setupTestLogger(nil)
+			tr := setupTransformer(setupTypeChecker(log), log)
+			if tt.setup != nil {
+				tt.setup(tr)
+			}
+			subjectExpr, err := tr.transformExpression(tt.stmt.Variable)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := tr.ensureConstraintGotDiagnostic(tt.stmt, subjectExpr)
+			if got.suffixFormat != tt.wantFormat {
+				t.Fatalf("format got %q want %q", got.suffixFormat, tt.wantFormat)
+			}
+			var argStrs []string
+			for _, arg := range got.gotArgs {
+				argStrs = append(argStrs, goExprString(t, arg))
+			}
+			s := strings.Join(argStrs, ", ")
+			for _, sub := range tt.wantIn {
+				if !strings.Contains(s, sub) {
+					t.Fatalf("missing %q in got args:\n%s", sub, s)
+				}
+			}
+			for _, sub := range tt.wantNotIn {
+				if strings.Contains(s, sub) {
+					t.Fatalf("unexpected %q in got args:\n%s", sub, s)
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureTestFatalfCall_staticFallbackOmitsGot(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tr := setupTransformer(setupTypeChecker(log), log)
+	// Multi-value Result split — transformExpression rejects single binding.
+	tr.resultLocalSplit = map[string]resultLocalSplit{
+		"x": {errGoName: "xErr", successGoNames: []string{"a", "b"}},
+	}
+	stmt := ast.EnsureNode{
+		Variable: ast.VariableNode{Ident: ast.Ident{ID: "x"}},
+		Assertion: ast.AssertionNode{
+			Constraints: []ast.ConstraintNode{{Name: "Ok"}},
+		},
+	}
+	call := tr.ensureTestFatalfCall(goast.NewIdent("t"), stmt)
+	s := goExprString(t, call)
+	for _, sub := range []string{
+		`t.Fatalf(`,
+		`"ensure %s is %s"`,
+		`"x"`,
+	} {
+		if !strings.Contains(s, sub) {
+			t.Fatalf("missing %q in:\n%s", sub, s)
+		}
+	}
+	for _, sub := range []string{"got %", "got err="} {
+		if strings.Contains(s, sub) {
+			t.Fatalf("static fallback should not contain %q in:\n%s", sub, s)
+		}
+	}
+}
+
+func TestEnsureTestFatalfCall_emitsGotWant(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tr := setupTransformer(setupTypeChecker(log), log)
+	stmt := ast.EnsureNode{
+		Variable: ast.VariableNode{Ident: ast.Ident{ID: "ok"}},
+		Assertion: ast.AssertionNode{
+			BaseType:    typeIdentPtr(string(ast.TypeBool)),
+			Constraints: []ast.ConstraintNode{{Name: string(TrueConstraint)}},
+		},
+	}
+	call := tr.ensureTestFatalfCall(goast.NewIdent("t"), stmt)
+	s := goExprString(t, call)
+	for _, sub := range []string{
+		`t.Fatalf(`,
+		`"ensure %s is %s: got %t, want %s"`,
+		`"ok"`,
+		`"Bool.True()"`,
+		`"true"`,
+		`ok`,
+	} {
+		if !strings.Contains(s, sub) {
+			t.Fatalf("missing %q in:\n%s", sub, s)
+		}
+	}
+}
+
+func TestEnsureTestFatalfCall_fieldAccessSubject(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tr := setupTransformer(setupTypeChecker(log), log)
+	stmt := ast.EnsureNode{
+		Variable: ast.VariableNode{Ident: ast.Ident{ID: "s.active"}},
+		Assertion: ast.AssertionNode{
+			BaseType:    typeIdentPtr(string(ast.TypeBool)),
+			Constraints: []ast.ConstraintNode{{Name: string(FalseConstraint)}},
+		},
+	}
+	call := tr.ensureTestFatalfCall(goast.NewIdent("t"), stmt)
+	s := goExprString(t, call)
+	for _, sub := range []string{
+		`"s.active"`,
+		`"false"`,
+		`got %t`,
+		`s.active`,
+	} {
+		if !strings.Contains(s, sub) {
+			t.Fatalf("missing %q in:\n%s", sub, s)
+		}
+	}
+}
+
+func TestDefaultAssertionErrorExpr_includesSubjectAndWant(t *testing.T) {
+	t.Parallel()
+	log := setupTestLogger(nil)
+	tr := setupTransformer(setupTypeChecker(log), log)
+	stmt := ast.EnsureNode{
+		Variable: ast.VariableNode{Ident: ast.Ident{ID: "n"}},
+		Assertion: ast.AssertionNode{
+			BaseType: typeIdentPtr(string(ast.TypeInt)),
+			Constraints: []ast.ConstraintNode{{
+				Name: string(GreaterThanConstraint),
+				Args: []ast.ConstraintArgumentNode{{Value: intLiteralNodePtr(0)}},
+			}},
+		},
+	}
+	s := goExprString(t, tr.defaultAssertionErrorExpr(stmt))
+	for _, sub := range []string{
+		`errors.New`,
+		`ensure n is Int.GreaterThan(0): want > 0`,
+	} {
+		if !strings.Contains(s, sub) {
+			t.Fatalf("missing %q in:\n%s", sub, s)
+		}
+	}
+}
+
+func strLiteralNodePtr(v string) *ast.ValueNode {
+	var n ast.ValueNode = ast.StringLiteralNode{Value: v}
+	return &n
+}

--- a/forst/internal/transformer/go/pipeline_emit_ensure_test.go
+++ b/forst/internal/transformer/go/pipeline_emit_ensure_test.go
@@ -198,6 +198,15 @@ func TestSampleFields(t *testing.T) {
 		`func TestSampleFields(t *testing.T) {`,
 		`t.Helper()`,
 		`t.Fatalf(`,
+		`got %t`,
+		`"s.active"`,
+		`"Bool.False()"`,
+		`"false"`,
+		`"s.enabled"`,
+		`"Bool.True()"`,
+		`"true"`,
+		`s.active`,
+		`s.enabled`,
 	} {
 		if !strings.Contains(out, sub) {
 			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
@@ -228,6 +237,11 @@ func TestEnsureBool(t *testing.T) {
 	for _, sub := range []string{
 		`t.Helper()`,
 		`t.Fatalf(`,
+		`got %t`,
+		`"ok"`,
+		`"Bool.True()"`,
+		`"true"`,
+		`ok`,
 	} {
 		if !strings.Contains(out, sub) {
 			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
@@ -253,7 +267,214 @@ func main() {}
 	if !strings.Contains(out, `func check() error`) {
 		t.Fatalf("expected error return for ensure in non-test function, got:\n%s", out)
 	}
-	if !strings.Contains(out, `return errors.New`) {
-		t.Fatalf("expected errors.New for ensure failure in non-test function, got:\n%s", out)
+	if !strings.Contains(out, `ensure ok is Bool.True(): want true`) {
+		t.Fatalf("expected ensure want hint in non-test function, got:\n%s", out)
+	}
+}
+
+func TestPipeline_ensureStringMinInTest_emitsLenGot(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+import "testing"
+
+func TestEnsureStringMin(t *testing.T) {
+	s := ""
+	ensure s is Min(1)
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{
+		`t.Fatalf(`,
+		`got len=%d (%q)`,
+		`len(`,
+		`s`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
+		}
+	}
+}
+
+func TestPipeline_ensureResultOkInTest_emitsErrGot(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+import "testing"
+
+func f(): Result(Int, Error) {
+	return 1
+}
+
+func TestEnsureResultOk(t *testing.T) {
+	x := f()
+	ensure x is Ok()
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{
+		`t.Fatalf(`,
+		`got err=%v`,
+		`xErr`,
+		`"Ok()"`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
+		}
+	}
+}
+
+func TestPipeline_ensureStringHasPrefixInTest_emitsQuotedGot(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+import "testing"
+
+func TestEnsureStringHasPrefix(t *testing.T) {
+	s := "http://"
+	ensure s is HasPrefix("https://")
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{
+		`t.Fatalf(`,
+		`got %q`,
+		`s`,
+		`"prefix \"https://\""`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
+		}
+	}
+}
+
+func TestPipeline_ensureStringAliasMinInTest_emitsStringCoercionInLenGot(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+import "testing"
+
+type Label = String
+
+func TestEnsureStringAliasMin(t *testing.T) {
+	s: Label = ""
+	ensure s is Min(1)
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{
+		`t.Fatalf(`,
+		`got len=%d (%q)`,
+		`len(string(s))`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
+		}
+	}
+}
+
+func TestPipeline_ensureResultErrInTest_emitsErrGot(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+import "testing"
+
+func f(): Result(Int, Error) {
+	return 1
+}
+
+func TestEnsureResultErr(t *testing.T) {
+	x := f()
+	ensure x is Err()
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{
+		`t.Fatalf(`,
+		`got err=%v`,
+		`xErr`,
+		`"Err()"`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
+		}
+	}
+}
+
+func TestPipeline_ensureResultOkWithPayloadInTest_emitsErrAndValGot(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+import "testing"
+
+func f(): Result(Int, Error) {
+	return 1
+}
+
+func TestEnsureResultOkPayload(t *testing.T) {
+	x := f()
+	ensure x is Ok(42)
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{
+		`t.Fatalf(`,
+		`got err=%v, val=%v`,
+		`xErr`,
+		`x`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
+		}
+	}
+}
+
+func TestPipeline_ensurePointerNilInTest_emitsDefaultGot(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+import "testing"
+
+func TestEnsurePointerNil(t *testing.T) {
+	var p: *Int = nil
+	ensure p is Nil()
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{
+		`t.Fatalf(`,
+		`got %v, want %s`,
+		`p`,
+		`"nil"`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
+		}
+	}
+}
+
+func TestPipeline_ensureInTest_usesCustomTestingTParamName(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+import "testing"
+
+func TestEnsureCustomHarness(tt *testing.T) {
+	ok := true
+	ensure ok is True()
+}
+`
+	out := compileForstPipeline(t, src)
+	for _, sub := range []string{
+		`tt.Helper()`,
+		`tt.Fatalf(`,
+		`got %t`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Fatalf("generated Go missing %q\n----\n%s\n----", sub, out)
+		}
+	}
+	if strings.Contains(out, `func TestEnsureCustomHarness(t *testing.T)`) {
+		t.Fatalf("expected custom harness param tt, not t:\n%s", out)
 	}
 }

--- a/forst/internal/transformer/go/statement_ensure.go
+++ b/forst/internal/transformer/go/statement_ensure.go
@@ -195,35 +195,13 @@ func (t *Transformer) transformErrorStatement(fn ast.FunctionNode, stmt ast.Ensu
 					},
 				},
 			}
-			fatalMsg := "assertion failed"
 			if stmt.Error != nil {
 				if errExpr, err := t.transformEnsureErrorFallback(*stmt.Error); err == nil {
-					fatalCall := &goast.ExprStmt{
-						X: &goast.CallExpr{
-							Fun: &goast.SelectorExpr{
-								X:   testIdent,
-								Sel: goast.NewIdent("Fatalf"),
-							},
-							Args: []goast.Expr{
-								&goast.BasicLit{Kind: token.STRING, Value: "\"%v\""},
-								errExpr,
-							},
-						},
-					}
+					fatalCall := testFatalfCall(testIdent, "%v", errExpr)
 					return &goast.BlockStmt{List: []goast.Stmt{helperCall, fatalCall}}
 				}
 			}
-			fatalCall := &goast.ExprStmt{
-				X: &goast.CallExpr{
-					Fun: &goast.SelectorExpr{
-						X:   testIdent,
-						Sel: goast.NewIdent("Fatalf"),
-					},
-					Args: []goast.Expr{
-						&goast.BasicLit{Kind: token.STRING, Value: "\"" + fatalMsg + "\""},
-					},
-				},
-			}
+			fatalCall := t.ensureTestFatalfCall(testIdent, stmt)
 			return &goast.BlockStmt{List: []goast.Stmt{helperCall, fatalCall}}
 		}
 	}
@@ -271,7 +249,7 @@ func (t *Transformer) transformErrorStatement(fn ast.FunctionNode, stmt ast.Ensu
 		}
 		errExpr, err := t.ensureFailureErrorExpr(stmt)
 		if err != nil {
-			errExpr = t.defaultAssertionErrorExpr(&stmt.Assertion)
+			errExpr = t.defaultAssertionErrorExpr(stmt)
 		}
 		return &goast.ReturnStmt{
 			Results: []goast.Expr{zeroSucc, errExpr},
@@ -295,7 +273,7 @@ func (t *Transformer) transformErrorStatement(fn ast.FunctionNode, stmt ast.Ensu
 		if returnType.IsError() {
 			errExpr, err := t.ensureFailureErrorExpr(stmt)
 			if err != nil {
-				errExpr = t.defaultAssertionErrorExpr(&stmt.Assertion)
+				errExpr = t.defaultAssertionErrorExpr(stmt)
 			}
 			result = errExpr
 		} else {

--- a/forst/internal/transformer/go/statement_ensure_fallback_test.go
+++ b/forst/internal/transformer/go/statement_ensure_fallback_test.go
@@ -56,6 +56,7 @@ func TestEnsureFailureErrorExpr_customOrGeneric(t *testing.T) {
 	}
 
 	generic, err := tr.ensureFailureErrorExpr(ast.EnsureNode{
+		Variable: ast.VariableNode{Ident: ast.Ident{ID: "n"}},
 		Assertion: ast.AssertionNode{
 			BaseType: typeIdentPtr(string(ast.TypeInt)),
 			Constraints: []ast.ConstraintNode{{
@@ -67,7 +68,7 @@ func TestEnsureFailureErrorExpr_customOrGeneric(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s := goExprString(t, generic); !strings.Contains(s, `errors.New`) || !strings.Contains(s, `assertion failed`) {
+	if s := goExprString(t, generic); !strings.Contains(s, `errors.New`) || !strings.Contains(s, `ensure n is Int.GreaterThan(1): want > 1`) {
 		t.Fatalf("generic: %s", s)
 	}
 }

--- a/forst/internal/transformer/go/statement_helpers.go
+++ b/forst/internal/transformer/go/statement_helpers.go
@@ -5,7 +5,6 @@ import (
 
 	"forst/internal/ast"
 	goast "go/ast"
-	"go/token"
 )
 
 // transformEnsureErrorFallback lowers `ensure … or Bad("msg")` / `or errVar` to a Go expression.
@@ -41,19 +40,17 @@ func (t *Transformer) transformEnsureErrorFallback(errorNode ast.EnsureErrorNode
 	}
 }
 
-func (t *Transformer) defaultAssertionErrorExpr(assertion *ast.AssertionNode) goast.Expr {
+func (t *Transformer) defaultAssertionErrorExpr(stmt ast.EnsureNode) goast.Expr {
 	t.Output.EnsureImport("errors")
-	assertionMsg := t.getAssertionStringForError(assertion)
+	subjectLabel, assertionLabel, wantHint := t.ensureFailureMessage(stmt)
+	msg := fmt.Sprintf("ensure %s is %s: want %s", subjectLabel, assertionLabel, wantHint)
 	return &goast.CallExpr{
 		Fun: &goast.SelectorExpr{
 			X:   goast.NewIdent("errors"),
 			Sel: goast.NewIdent("New"),
 		},
 		Args: []goast.Expr{
-			&goast.BasicLit{
-				Kind:  token.STRING,
-				Value: fmt.Sprintf("\"assertion failed: %s\"", assertionMsg),
-			},
+			goQuotedStringLit(msg),
 		},
 	}
 }
@@ -63,7 +60,7 @@ func (t *Transformer) ensureFailureErrorExpr(stmt ast.EnsureNode) (goast.Expr, e
 	if stmt.Error != nil {
 		return t.transformEnsureErrorFallback(*stmt.Error)
 	}
-	return t.defaultAssertionErrorExpr(&stmt.Assertion), nil
+	return t.defaultAssertionErrorExpr(stmt), nil
 }
 
 // getAssertionStringForError returns a properly qualified assertion string for error messages


### PR DESCRIPTION
Replace generic "assertion failed" messages with structured ensure failure diagnostics. Test functions now emit t.Fatalf with subject label, qualified assertion label, and constraint-specific got expressions (%t for bool, %q or len for strings, err/val for Result), plus readable want hints derived from constraints. Non-test paths emit errors.New with subject and want only.

Introduce ensure_failure_message helpers, wire them through statement_ensure and defaultAssertionErrorExpr, and expand unit and pipeline coverage for got format selection, string aliases, Result Ok/Err, custom testing.T param names, and static fallback when subject codegen fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `ensure` failures now produce clearer, more specific error messages with the checked value and the expected condition.
  * Messages better reflect common cases like comparisons, booleans, strings, nil checks, and result-style values.

* **Bug Fixes**
  * Improved generated failure output for `ensure` inside test code.
  * Updated expectation handling so assertion messages are more precise and consistent across different forms of `ensure`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->