### PR TITLE
perf(typechecker): add scope-key hashing, compat memo

### DIFF
--- a/forst/cmd/forst/lsp/analyze.go
+++ b/forst/cmd/forst/lsp/analyze.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"forst/internal/ast"
-	"forst/internal/forstpkg"
 	"forst/internal/goload"
 	"forst/internal/lexer"
 	"forst/internal/modulecheck"
@@ -90,21 +89,16 @@ func (s *LSPServer) analyzeForstDocument(uri string) (ctx *forstDocumentContext,
 	}
 
 	moduleRoot := goload.FindModuleRoot(filepath.Dir(filePath))
-	forstPkg := forstpkg.PackageNameOrDefault(forstpkg.PackageNameFromNodes(nodes))
 
 	var tc *typechecker.TypeChecker
 	var checkErr error
 	modResult, modErr := modulecheck.CheckModuleProviders(s.log, modulecheck.Options{ModuleRoot: moduleRoot})
-	if modResult != nil && modResult.PerPackage[forstPkg] != nil {
-		tc = modResult.PerPackage[forstPkg]
+	_ = modResult
+	tc = typechecker.New(s.log, false)
+	tc.GoWorkspaceDir = moduleRoot
+	checkErr = tc.CheckTypes(nodes)
+	if modErr != nil && checkErr == nil {
 		checkErr = modErr
-	} else {
-		tc = typechecker.New(s.log, false)
-		tc.GoWorkspaceDir = moduleRoot
-		checkErr = tc.CheckTypes(nodes)
-		if modErr != nil && checkErr == nil {
-			checkErr = modErr
-		}
 	}
 	ctx.Nodes = nodes
 	ctx.TC = tc

--- a/forst/cmd/forst/lsp/completion.go
+++ b/forst/cmd/forst/lsp/completion.go
@@ -486,7 +486,7 @@ func deepestScopeInBlock(body []ast.Node, tokens []ast.Token, tokIdx, bodyL, bod
 			if idx < 0 {
 				continue
 			}
-			if n := matchIfChainFrom(st, tokens, tokIdx, idx, bodyR, tc); n != nil {
+			if n := matchIfChainFrom(&st, tokens, tokIdx, idx, bodyR, tc); n != nil {
 				return n
 			}
 		case *ast.IfNode:
@@ -495,7 +495,7 @@ func deepestScopeInBlock(body []ast.Node, tokens []ast.Token, tokIdx, bodyL, bod
 			if idx < 0 {
 				continue
 			}
-			if n := matchIfChainFrom(*st, tokens, tokIdx, idx, bodyR, tc); n != nil {
+			if n := matchIfChainFrom(st, tokens, tokIdx, idx, bodyR, tc); n != nil {
 				return n
 			}
 		case ast.EnsureNode:
@@ -515,7 +515,10 @@ func deepestScopeInBlock(body []ast.Node, tokens []ast.Token, tokIdx, bodyL, bod
 	return nil
 }
 
-func matchIfChainFrom(ifn ast.IfNode, tokens []ast.Token, tokIdx, ifIdx, limit int, tc *typechecker.TypeChecker) ast.Node {
+func matchIfChainFrom(ifn *ast.IfNode, tokens []ast.Token, tokIdx, ifIdx, limit int, tc *typechecker.TypeChecker) ast.Node {
+	if ifn == nil {
+		return nil
+	}
 	l, r := ifThenBraces(tokens, ifIdx)
 	if l < 0 {
 		return nil
@@ -531,7 +534,8 @@ func matchIfChainFrom(ifn ast.IfNode, tokens []ast.Token, tokIdx, ifIdx, limit i
 		return nil
 	}
 	next := r + 1
-	for _, ei := range ifn.ElseIfs {
+	for i := range ifn.ElseIfs {
+		ei := &ifn.ElseIfs[i]
 		eiIdx := findFirstElseIfKeywords(tokens, next, limit)
 		if eiIdx < 0 {
 			break
@@ -570,8 +574,8 @@ func matchIfChainFrom(ifn ast.IfNode, tokens []ast.Token, tokIdx, ifIdx, limit i
 	return nil
 }
 
-func deepestScopeInFunction(fn ast.FunctionNode, tokens []ast.Token, tokIdx int, bodyL, bodyR int, tc *typechecker.TypeChecker) ast.Node {
-	_ = tc.RestoreScope(fn)
+func deepestScopeInFunction(scopeNode ast.Node, fn ast.FunctionNode, tokens []ast.Token, tokIdx int, bodyL, bodyR int, tc *typechecker.TypeChecker) ast.Node {
+	_ = tc.RestoreScope(scopeNode)
 	ifIdx := 0
 	ensureIdx := 0
 	for _, stmt := range fn.Body {
@@ -582,7 +586,7 @@ func deepestScopeInFunction(fn ast.FunctionNode, tokens []ast.Token, tokIdx int,
 			if idx < 0 {
 				continue
 			}
-			if n := matchIfChainFrom(st, tokens, tokIdx, idx, bodyR, tc); n != nil {
+			if n := matchIfChainFrom(&st, tokens, tokIdx, idx, bodyR, tc); n != nil {
 				return n
 			}
 		case *ast.IfNode:
@@ -591,7 +595,7 @@ func deepestScopeInFunction(fn ast.FunctionNode, tokens []ast.Token, tokIdx int,
 			if idx < 0 {
 				continue
 			}
-			if n := matchIfChainFrom(*st, tokens, tokIdx, idx, bodyR, tc); n != nil {
+			if n := matchIfChainFrom(st, tokens, tokIdx, idx, bodyR, tc); n != nil {
 				return n
 			}
 		case ast.EnsureNode:
@@ -608,8 +612,8 @@ func deepestScopeInFunction(fn ast.FunctionNode, tokens []ast.Token, tokIdx int,
 			}
 		}
 	}
-	_ = tc.RestoreScope(fn)
-	return fn
+	_ = tc.RestoreScope(scopeNode)
+	return scopeNode
 }
 
 func findInnermostScopeNode(nodes []ast.Node, tokens []ast.Token, tokIdx int, tc *typechecker.TypeChecker) ast.Node {
@@ -621,30 +625,30 @@ func findInnermostScopeNode(nodes []ast.Node, tokens []ast.Token, tokIdx int, tc
 				continue
 			}
 			if pOpen, pClose, ok := paramListParenRange(tokens, v); ok && tokIdx > pOpen && tokIdx < pClose {
-				return v
+				return n
 			}
 			if tokIdx <= lb || tokIdx >= rb {
 				continue
 			}
-			return deepestScopeInFunction(v, tokens, tokIdx, lb, rb, tc)
+			return deepestScopeInFunction(n, v, tokens, tokIdx, lb, rb, tc)
 		case *ast.FunctionNode:
 			lb, rb := functionBodyBraces(tokens, *v)
 			if lb < 0 {
 				continue
 			}
 			if pOpen, pClose, ok := paramListParenRange(tokens, *v); ok && tokIdx > pOpen && tokIdx < pClose {
-				return v
+				return n
 			}
 			if tokIdx <= lb || tokIdx >= rb {
 				continue
 			}
-			return deepestScopeInFunction(*v, tokens, tokIdx, lb, rb, tc)
+			return deepestScopeInFunction(n, *v, tokens, tokIdx, lb, rb, tc)
 		case ast.TypeGuardNode:
-			if n := typeGuardScopeForPosition(v, tokens, tokIdx, tc); n != nil {
+			if n := typeGuardScopeForPosition(n, v, tokens, tokIdx, tc); n != nil {
 				return n
 			}
 		case *ast.TypeGuardNode:
-			if n := typeGuardScopeForPosition(*v, tokens, tokIdx, tc); n != nil {
+			if n := typeGuardScopeForPosition(n, *v, tokens, tokIdx, tc); n != nil {
 				return n
 			}
 		}
@@ -695,16 +699,16 @@ func typeGuardBodyBraces(tokens []ast.Token, guardName string) (l, r int) {
 	return -1, -1
 }
 
-func typeGuardScopeForPosition(g ast.TypeGuardNode, tokens []ast.Token, tokIdx int, tc *typechecker.TypeChecker) ast.Node {
+func typeGuardScopeForPosition(scopeNode ast.Node, g ast.TypeGuardNode, tokens []ast.Token, tokIdx int, tc *typechecker.TypeChecker) ast.Node {
 	name := string(g.Ident)
 	lb, rb := typeGuardBodyBraces(tokens, name)
 	if lb < 0 || tokIdx <= lb || tokIdx >= rb {
 		return nil
 	}
-	if err := tc.RestoreScope(g); err != nil {
+	if err := tc.RestoreScope(scopeNode); err != nil {
 		return nil
 	}
-	return g
+	return scopeNode
 }
 
 func lhsExpressionBeforeDot(lineToCursor string) string {

--- a/forst/cmd/forst/lsp/completion_match_if_chain_test.go
+++ b/forst/cmd/forst/lsp/completion_match_if_chain_test.go
@@ -47,7 +47,7 @@ func TestMatchIfChainFrom_returnsEnsureBlockFromIfBody(t *testing.T) {
 		{Type: ast.TokenRBrace},
 		{Type: ast.TokenRBrace},
 	}
-	scopeNode := matchIfChainFrom(ifNode, tokens, 5, 0, len(tokens), tc)
+	scopeNode := matchIfChainFrom(&ifNode, tokens, 5, 0, len(tokens), tc)
 	if scopeNode == nil {
 		t.Fatal("expected ensure block scope node from if body")
 	}
@@ -94,7 +94,7 @@ func TestMatchIfChainFrom_returnsEnsureBlockFromElseIfBody(t *testing.T) {
 		{Type: ast.TokenRBrace},
 		{Type: ast.TokenRBrace},
 	}
-	scopeNode := matchIfChainFrom(ifNode, tokens, 8, 0, len(tokens), tc)
+	scopeNode := matchIfChainFrom(&ifNode, tokens, 8, 0, len(tokens), tc)
 	if scopeNode == nil {
 		t.Fatal("expected ensure block scope node from else-if body")
 	}
@@ -139,7 +139,7 @@ func TestMatchIfChainFrom_returnsEnsureBlockFromElseBody(t *testing.T) {
 		{Type: ast.TokenRBrace},
 		{Type: ast.TokenRBrace},
 	}
-	scopeNode := matchIfChainFrom(ifNode, tokens, 8, 0, len(tokens), tc)
+	scopeNode := matchIfChainFrom(&ifNode, tokens, 8, 0, len(tokens), tc)
 	if scopeNode == nil {
 		t.Fatal("expected ensure block scope node from else body")
 	}
@@ -195,17 +195,20 @@ is (p P) Strong {
 	}
 
 	var guardNode ast.TypeGuardNode
+	var guardScope ast.Node
 	guardFound := false
 	for _, node := range context.Nodes {
 		switch typedNode := node.(type) {
 		case ast.TypeGuardNode:
 			if string(typedNode.Ident) == "Strong" {
 				guardNode = typedNode
+				guardScope = node
 				guardFound = true
 			}
 		case *ast.TypeGuardNode:
 			if typedNode != nil && string(typedNode.Ident) == "Strong" {
 				guardNode = *typedNode
+				guardScope = node
 				guardFound = true
 			}
 		}
@@ -214,11 +217,15 @@ is (p P) Strong {
 		t.Fatal("expected to find Strong type guard node")
 	}
 
-	scopeNodeInside := typeGuardScopeForPosition(guardNode, context.Tokens, leftBrace+1, context.TC)
+	bodyL, _ := typeGuardBodyBraces(context.Tokens, "Strong")
+	if bodyL < 0 {
+		t.Fatal("expected type guard body braces in analyzed file")
+	}
+	scopeNodeInside := typeGuardScopeForPosition(guardScope, guardNode, context.Tokens, bodyL+1, context.TC)
 	if scopeNodeInside == nil {
 		t.Fatal("expected type guard scope node for position inside body")
 	}
-	outsideScope := typeGuardScopeForPosition(guardNode, context.Tokens, 0, context.TC)
+	outsideScope := typeGuardScopeForPosition(guardScope, guardNode, context.Tokens, 0, context.TC)
 	if outsideScope != nil {
 		t.Fatalf("expected nil scope outside type guard body, got %T", outsideScope)
 	}

--- a/forst/cmd/forst/lsp/navigation_locals.go
+++ b/forst/cmd/forst/lsp/navigation_locals.go
@@ -79,9 +79,9 @@ func visitNodeForScope(tc *typechecker.TypeChecker, n ast.Node, want *typechecke
 func visitStmtForScope(tc *typechecker.TypeChecker, st ast.Node, want *typechecker.Scope) ast.Node {
 	switch v := st.(type) {
 	case ast.IfNode:
-		return visitIfChainForScope(tc, v, want)
+		return visitIfChainForScope(tc, &v, want)
 	case *ast.IfNode:
-		return visitIfChainForScope(tc, *v, want)
+		return visitIfChainForScope(tc, v, want)
 	case ast.ForNode:
 		if err := tc.RestoreScope(v); err == nil && tc.CurrentScope() == want {
 			return v
@@ -113,9 +113,12 @@ func visitStmtForScope(tc *typechecker.TypeChecker, st ast.Node, want *typecheck
 	return nil
 }
 
-func visitIfChainForScope(tc *typechecker.TypeChecker, ifn ast.IfNode, want *typechecker.Scope) ast.Node {
-	if err := tc.RestoreScope(&ifn); err == nil && tc.CurrentScope() == want {
-		return &ifn
+func visitIfChainForScope(tc *typechecker.TypeChecker, ifn *ast.IfNode, want *typechecker.Scope) ast.Node {
+	if ifn == nil {
+		return nil
+	}
+	if err := tc.RestoreScope(ifn); err == nil && tc.CurrentScope() == want {
+		return ifn
 	}
 	for _, inner := range ifn.Body {
 		if r := visitStmtForScope(tc, inner, want); r != nil {
@@ -123,9 +126,9 @@ func visitIfChainForScope(tc *typechecker.TypeChecker, ifn ast.IfNode, want *typ
 		}
 	}
 	for i := range ifn.ElseIfs {
-		ei := ifn.ElseIfs[i]
-		if err := tc.RestoreScope(&ei); err == nil && tc.CurrentScope() == want {
-			return &ei
+		ei := &ifn.ElseIfs[i]
+		if err := tc.RestoreScope(ei); err == nil && tc.CurrentScope() == want {
+			return ei
 		}
 		for _, inner := range ei.Body {
 			if r := visitStmtForScope(tc, inner, want); r != nil {

--- a/forst/cmd/forst/lsp/navigation_locals_scope_test.go
+++ b/forst/cmd/forst/lsp/navigation_locals_scope_test.go
@@ -6,6 +6,115 @@ import (
 	"forst/internal/ast"
 )
 
+func TestNavigationLocals_lookupSymbolAtToken_afterCheckTypes(t *testing.T) {
+	t.Parallel()
+	const src = `package main
+
+func outer(x Int): Int {
+	y := x
+	return y
+}
+`
+	nodes, tokens, tc := parseNodesAndTokensForNavigationTest(t, src)
+	usePos, ok := lspPosForNthIdentToken(tokens, "x", 1)
+	if !ok {
+		t.Fatal("use of x")
+	}
+	idx := tokenIndexAtLSPPosition(tokens, usePos)
+	if err := tc.RestoreScope(nil); err != nil {
+		t.Fatalf("RestoreScope(nil): %v", err)
+	}
+	sym, ok := lookupSymbolAtToken(tc, nodes, tokens, idx, ast.Identifier("x"))
+	if !ok {
+		t.Fatal("lookupSymbolAtToken failed")
+	}
+	if sym.Identifier != "x" {
+		t.Fatalf("sym=%#v", sym)
+	}
+}
+
+func TestNavigationLocals_findInnermostScopeRestores_twoFunctions(t *testing.T) {
+	t.Parallel()
+	const src = `package main
+
+func outer(x Int): Int {
+	y := x
+	return y
+}
+
+func main() {
+	println(outer(1))
+}
+`
+	nodes, tokens, tc := parseNodesAndTokensForNavigationTest(t, src)
+	usePos, ok := lspPosForNthIdentToken(tokens, "x", 1)
+	if !ok {
+		t.Fatal("use of x")
+	}
+	idx := tokenIndexAtLSPPosition(tokens, usePos)
+	scopeNode := findInnermostScopeNode(nodes, tokens, idx, tc)
+	if scopeNode == nil {
+		t.Fatal("expected scope node")
+	}
+	if err := tc.RestoreScope(scopeNode); err != nil {
+		t.Fatalf("RestoreScope(%T): %v", scopeNode, err)
+	}
+	if _, ok := tc.CurrentScope().LookupVariable(ast.Identifier("x")); !ok {
+		t.Fatal("expected param x after restore")
+	}
+}
+
+func TestNavigationLocals_findInnermostScopeRestores(t *testing.T) {
+	t.Parallel()
+	const src = `package main
+
+func f(x Int): Int {
+	return x
+}
+`
+	nodes, tokens, tc := parseNodesAndTokensForNavigationTest(t, src)
+	usePos, ok := lspPosForNthIdentToken(tokens, "x", 1)
+	if !ok {
+		t.Fatal("use of x")
+	}
+	idx := tokenIndexAtLSPPosition(tokens, usePos)
+	scopeNode := findInnermostScopeNode(nodes, tokens, idx, tc)
+	if scopeNode == nil {
+		t.Fatal("expected scope node")
+	}
+	if err := tc.RestoreScope(scopeNode); err != nil {
+		t.Fatalf("RestoreScope(%T): %v", scopeNode, err)
+	}
+	if _, ok := tc.CurrentScope().LookupVariable(ast.Identifier("x")); !ok {
+		t.Fatal("expected param x after restore")
+	}
+}
+
+func TestNavigationLocals_restoreScopeOnParsedFunctionNode(t *testing.T) {
+	t.Parallel()
+	const src = `package main
+
+func f(x Int): Int {
+	return x
+}
+`
+	nodes, _, tc := parseNodesAndTokensForNavigationTest(t, src)
+	for _, n := range nodes {
+		fn, ok := n.(ast.FunctionNode)
+		if !ok || fn.Ident.ID != "f" {
+			continue
+		}
+		if err := tc.RestoreScope(n); err != nil {
+			t.Fatalf("RestoreScope: %v", err)
+		}
+		if _, ok := tc.CurrentScope().LookupVariable(ast.Identifier("x")); !ok {
+			t.Fatal("expected param x in function scope")
+		}
+		return
+	}
+	t.Fatal("function f not found")
+}
+
 func TestNavigationLocals_lookupSymbolAndSameBinding(t *testing.T) {
 	t.Parallel()
 	const src = `package main

--- a/forst/cmd/forst/lsp/package_analysis.go
+++ b/forst/cmd/forst/lsp/package_analysis.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"forst/internal/ast"
-	"forst/internal/forstpkg"
 	"forst/internal/goload"
 	"forst/internal/lexer"
 	"forst/internal/modulecheck"
@@ -308,20 +307,16 @@ func (s *LSPServer) buildPackageSnapshot(uris []string, results []fileParseResul
 		return &packageSnapshot{uris: uris, results: results}
 	}
 	moduleRoot := goload.FindModuleRoot(workDir)
-	forstPkg := forstpkg.PackageNameOrDefault(forstpkg.PackageNameFromNodes(merged))
 
 	var tc *typechecker.TypeChecker
 	var checkErr error
 	modResult, modErr := modulecheck.CheckModuleProviders(s.log, modulecheck.Options{ModuleRoot: moduleRoot})
-	if modErr == nil && modResult != nil && modResult.PerPackage[forstPkg] != nil {
-		tc = modResult.PerPackage[forstPkg]
-	} else {
-		tc = typechecker.New(s.log, false)
-		tc.GoWorkspaceDir = workDir
-		checkErr = tc.CheckTypes(merged)
-		if modErr != nil && checkErr == nil {
-			checkErr = modErr
-		}
+	_ = modResult
+	tc = typechecker.New(s.log, false)
+	tc.GoWorkspaceDir = workDir
+	checkErr = tc.CheckTypes(merged)
+	if modErr != nil && checkErr == nil {
+		checkErr = modErr
 	}
 	return &packageSnapshot{
 		uris:        uris,

--- a/forst/cmd/forst/lsp/package_analysis.go
+++ b/forst/cmd/forst/lsp/package_analysis.go
@@ -313,7 +313,7 @@ func (s *LSPServer) buildPackageSnapshot(uris []string, results []fileParseResul
 	modResult, modErr := modulecheck.CheckModuleProviders(s.log, modulecheck.Options{ModuleRoot: moduleRoot})
 	_ = modResult
 	tc = typechecker.New(s.log, false)
-	tc.GoWorkspaceDir = workDir
+	tc.GoWorkspaceDir = moduleRoot
 	checkErr = tc.CheckTypes(merged)
 	if modErr != nil && checkErr == nil {
 		checkErr = modErr

--- a/forst/cmd/forst/lsp/package_analysis_test.go
+++ b/forst/cmd/forst/lsp/package_analysis_test.go
@@ -236,3 +236,62 @@ func Disk(): Int {
 		t.Fatalf("got %q want %q", contents[uri], want)
 	}
 }
+
+func TestBuildPackageSnapshot_GoWorkspaceDirUsesModuleRoot(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	s := NewLSPServer("8080", log)
+
+	moduleRoot := t.TempDir()
+	pkgDir := filepath.Join(moduleRoot, "sub")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(moduleRoot, "go.mod"), []byte("module nestedlsp\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	aPath := filepath.Join(pkgDir, "a.ft")
+	bPath := filepath.Join(pkgDir, "b.ft")
+	const srcA = `package main
+
+func A(): Int {
+	return 1
+}
+`
+	const srcB = `package main
+
+func B(): Int {
+	return 2
+}
+`
+	if err := os.WriteFile(aPath, []byte(srcA), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bPath, []byte(srcB), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	uriA := mustFileURI(t, aPath)
+	uriB := mustFileURI(t, bPath)
+	uris := []string{uriA, uriB}
+	contents := map[string]string{uriA: srcA, uriB: srcB}
+
+	results, err := s.parsePackageGroupMembersParallel(uris, contents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range results {
+		if results[i].ParseErr != nil {
+			t.Fatalf("parse err file %d: %v", i, results[i].ParseErr)
+		}
+	}
+
+	snap := s.buildPackageSnapshot(uris, results, pkgDir)
+	if snap == nil || snap.tc == nil {
+		t.Fatal("expected non-nil snapshot with typechecker")
+	}
+	if snap.tc.GoWorkspaceDir != moduleRoot {
+		t.Fatalf("GoWorkspaceDir = %q, want module root %q", snap.tc.GoWorkspaceDir, moduleRoot)
+	}
+}

--- a/forst/internal/compiler/bench_test.go
+++ b/forst/internal/compiler/bench_test.go
@@ -32,6 +32,31 @@ func benchmarkCompileFile(b *testing.B, exampleRel string) {
 	}
 }
 
+func benchmarkCompileMerged(b *testing.B, rootRel, entryRel string) {
+	b.Helper()
+	root := filepath.Join("..", "..", "..", "examples", "in", rootRel)
+	entry := filepath.Join(root, entryRel)
+	if _, err := os.Stat(entry); err != nil {
+		b.Fatalf("example entry %s: %v", entry, err)
+	}
+	c := New(Args{
+		Command:     "run",
+		FilePath:    entry,
+		PackageRoot: root,
+		LogLevel:    "error",
+	}, silentCompilerTestLogger())
+	if _, err := c.CompileFile(); err != nil {
+		b.Fatalf("warm CompileFile: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.CompileFile(); err != nil {
+			b.Fatalf("CompileFile: %v", err)
+		}
+	}
+}
+
 func BenchmarkCompile_basic(b *testing.B) {
 	benchmarkCompileFile(b, "basic.ft")
 }
@@ -42,4 +67,12 @@ func BenchmarkCompile_shapeGuard(b *testing.B) {
 
 func BenchmarkCompile_generics(b *testing.B) {
 	benchmarkCompileFile(b, "generics.ft")
+}
+
+func BenchmarkCompile_tictactoe(b *testing.B) {
+	benchmarkCompileMerged(b, "tictactoe", "server.ft")
+}
+
+func BenchmarkCompile_providers(b *testing.B) {
+	benchmarkCompileMerged(b, filepath.Join("rfc", "providers"), "main_wiring.ft")
 }

--- a/forst/internal/compiler/bench_test.go
+++ b/forst/internal/compiler/bench_test.go
@@ -76,3 +76,15 @@ func BenchmarkCompile_tictactoe(b *testing.B) {
 func BenchmarkCompile_providers(b *testing.B) {
 	benchmarkCompileMerged(b, filepath.Join("rfc", "providers"), "main_wiring.ft")
 }
+
+func TestBenchmarkCompile_shapeGuard_warmup(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "examples", "in", "rfc", "guard", "shape_guard.ft")
+	c := New(Args{
+		Command:  "run",
+		FilePath: path,
+		LogLevel: "error",
+	}, silentCompilerTestLogger())
+	if _, err := c.CompileFile(); err != nil {
+		t.Fatalf("CompileFile(shape_guard.ft): %v", err)
+	}
+}

--- a/forst/internal/compiler/compiler_hooks_test.go
+++ b/forst/internal/compiler/compiler_hooks_test.go
@@ -124,7 +124,14 @@ func TestTypecheckForCompile_usesPerPackageWhenPresent(t *testing.T) {
 		t.Fatalf("typecheck: err=%v tc=%v modResult=%v", err, tc, modResult)
 	}
 	pkg := forstpkg.PackageNameOrDefault(forstpkg.PackageNameFromNodes(nodes))
-	if modResult.PerPackage[pkg] != tc {
+	if modResult.PerPackage[pkg] == nil {
+		t.Fatal("expected module PerPackage entry")
+	}
+	if c.typecheckUsesFreshEntryChecker(filepath.Dir(basic)) {
+		if tc == modResult.PerPackage[pkg] {
+			t.Fatal("examples/in entry compile must re-typecheck the entry file AST")
+		}
+	} else if modResult.PerPackage[pkg] != tc {
 		t.Fatal("expected typechecker from module PerPackage map")
 	}
 }

--- a/forst/internal/compiler/compiler_hooks_test.go
+++ b/forst/internal/compiler/compiler_hooks_test.go
@@ -127,11 +127,8 @@ func TestTypecheckForCompile_usesPerPackageWhenPresent(t *testing.T) {
 	if modResult.PerPackage[pkg] == nil {
 		t.Fatal("expected module PerPackage entry")
 	}
-	if c.typecheckUsesFreshEntryChecker(filepath.Dir(basic)) {
-		if tc == modResult.PerPackage[pkg] {
-			t.Fatal("examples/in entry compile must re-typecheck the entry file AST")
-		}
-	} else if modResult.PerPackage[pkg] != tc {
+	// Rebind path reuses the module PerPackage checker after CheckTypes on entry nodes.
+	if tc != modResult.PerPackage[pkg] {
 		t.Fatal("expected typechecker from module PerPackage map")
 	}
 }

--- a/forst/internal/compiler/module_providers.go
+++ b/forst/internal/compiler/module_providers.go
@@ -21,7 +21,7 @@ func (c *Compiler) typecheckForCompile(nodes []ast.Node) (*typechecker.TypeCheck
 	}
 	forstPkg := forstpkg.PackageNameOrDefault(forstpkg.PackageNameFromNodes(nodes))
 	if modResult != nil {
-		if tc := modResult.PerPackage[forstPkg]; tc != nil {
+		if tc := modResult.PerPackage[forstPkg]; tc != nil && !c.typecheckUsesFreshEntryChecker(entryDirFromArgs(c.Args)) {
 			return tc, modResult, nil
 		}
 	}
@@ -70,4 +70,32 @@ func isCompilerWorkspaceModule(modRoot string) bool {
 	}
 	_, err := os.Stat(filepath.Join(modRoot, "cmd", "forst"))
 	return err == nil
+}
+
+func entryDirFromArgs(args Args) string {
+	if args.FilePath == "" {
+		return ""
+	}
+	return filepath.Dir(args.FilePath)
+}
+
+// typecheckUsesFreshEntryChecker is true when modulecheck merges every same-package file
+// in examples/in during the providers pass, which would desync scopes from a single-file compile.
+func (c *Compiler) typecheckUsesFreshEntryChecker(entryDir string) bool {
+	if c.Args.PackageRoot != "" || entryDir == "" {
+		return false
+	}
+	modRoot := goload.FindModuleRoot(entryDir)
+	if !isCompilerWorkspaceModule(modRoot) {
+		return false
+	}
+	examplesIn, err := filepath.Abs(filepath.Join(modRoot, "..", "examples", "in"))
+	if err != nil {
+		return false
+	}
+	absEntry, err := filepath.Abs(entryDir)
+	if err != nil {
+		return false
+	}
+	return absEntry == examplesIn
 }

--- a/forst/internal/compiler/module_providers.go
+++ b/forst/internal/compiler/module_providers.go
@@ -22,13 +22,10 @@ func (c *Compiler) typecheckForCompile(nodes []ast.Node) (*typechecker.TypeCheck
 	forstPkg := forstpkg.PackageNameOrDefault(forstpkg.PackageNameFromNodes(nodes))
 	if modResult != nil {
 		if tc := modResult.PerPackage[forstPkg]; tc != nil {
-			savedProviders := cloneFunctionProviders(tc.FunctionProviders)
 			// Module check used merged-package AST nodes; re-bind scopes to this compile's nodes.
-			if err := tc.CheckTypes(nodes); err != nil {
+			if err := RebindTypecheckerScopes(tc, nodes); err != nil {
 				return tc, modResult, err
 			}
-			tc.SetFunctionProviders(savedProviders)
-			tc.FunctionProviders = savedProviders
 			return tc, modResult, nil
 		}
 	}
@@ -105,6 +102,17 @@ func (c *Compiler) typecheckUsesFreshEntryChecker(entryDir string) bool {
 		return false
 	}
 	return absEntry == examplesIn
+}
+
+// RebindTypecheckerScopes re-runs CheckTypes on nodes so scope stacks match the compile AST.
+func RebindTypecheckerScopes(tc *typechecker.TypeChecker, nodes []ast.Node) error {
+	savedProviders := cloneFunctionProviders(tc.FunctionProviders)
+	if err := tc.CheckTypes(nodes); err != nil {
+		return err
+	}
+	tc.SetFunctionProviders(savedProviders)
+	tc.FunctionProviders = savedProviders
+	return nil
 }
 
 func cloneFunctionProviders(src map[ast.Identifier][]typechecker.ProviderSlot) map[ast.Identifier][]typechecker.ProviderSlot {

--- a/forst/internal/compiler/module_providers.go
+++ b/forst/internal/compiler/module_providers.go
@@ -21,7 +21,14 @@ func (c *Compiler) typecheckForCompile(nodes []ast.Node) (*typechecker.TypeCheck
 	}
 	forstPkg := forstpkg.PackageNameOrDefault(forstpkg.PackageNameFromNodes(nodes))
 	if modResult != nil {
-		if tc := modResult.PerPackage[forstPkg]; tc != nil && !c.typecheckUsesFreshEntryChecker(entryDirFromArgs(c.Args)) {
+		if tc := modResult.PerPackage[forstPkg]; tc != nil {
+			savedProviders := cloneFunctionProviders(tc.FunctionProviders)
+			// Module check used merged-package AST nodes; re-bind scopes to this compile's nodes.
+			if err := tc.CheckTypes(nodes); err != nil {
+				return tc, modResult, err
+			}
+			tc.SetFunctionProviders(savedProviders)
+			tc.FunctionProviders = savedProviders
 			return tc, modResult, nil
 		}
 	}
@@ -98,4 +105,17 @@ func (c *Compiler) typecheckUsesFreshEntryChecker(entryDir string) bool {
 		return false
 	}
 	return absEntry == examplesIn
+}
+
+func cloneFunctionProviders(src map[ast.Identifier][]typechecker.ProviderSlot) map[ast.Identifier][]typechecker.ProviderSlot {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[ast.Identifier][]typechecker.ProviderSlot, len(src))
+	for k, v := range src {
+		slots := make([]typechecker.ProviderSlot, len(v))
+		copy(slots, v)
+		out[k] = slots
+	}
+	return out
 }

--- a/forst/internal/compiler/module_providers_scope_test.go
+++ b/forst/internal/compiler/module_providers_scope_test.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"forst/internal/ast"
 )
 
 func TestModuleRootForProvidersPass_singleExampleFile(t *testing.T) {
@@ -41,5 +43,78 @@ func TestCompileFile_basicExampleNoModuleWalkPanic(t *testing.T) {
 	}
 	if code == nil || !strings.Contains(*code, "func greet()") {
 		t.Fatalf("expected greet in output")
+	}
+}
+
+func TestCompileFile_shapeGuardExample(t *testing.T) {
+	_, currentFile, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", "..", ".."))
+	shapeGuardPath := filepath.Join(projectRoot, "examples", "in", "rfc", "guard", "shape_guard.ft")
+
+	c := New(Args{
+		Command:  "build",
+		FilePath: shapeGuardPath,
+		LogLevel: "error",
+	}, nil)
+	code, err := c.CompileFile()
+	if err != nil {
+		t.Fatalf("CompileFile(shape_guard.ft): %v", err)
+	}
+	if code == nil {
+		t.Fatal("expected non-nil code")
+	}
+	out := *code
+	if !strings.Contains(out, "func createTask(") {
+		t.Fatal("expected createTask in shape_guard output")
+	}
+	if !strings.Contains(out, "func G_") {
+		t.Fatal("expected G_ type guard function in shape_guard output")
+	}
+}
+
+func TestTypecheckForCompileEntry_shapeGuardRebindsEntryScopes(t *testing.T) {
+	_, currentFile, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", "..", ".."))
+	shapeGuardPath := filepath.Join(projectRoot, "examples", "in", "rfc", "guard", "shape_guard.ft")
+
+	c := New(Args{
+		Command:  "run",
+		FilePath: shapeGuardPath,
+		LogLevel: "error",
+	}, nil)
+
+	entryNodes, err := c.loadInputNodesForCompile()
+	if err != nil {
+		t.Fatalf("loadInputNodesForCompile: %v", err)
+	}
+	tc, modResult, err := c.typecheckForCompile(entryNodes)
+	if err != nil {
+		t.Fatalf("typecheckForCompile: %v", err)
+	}
+	if modResult == nil {
+		t.Fatal("expected module result")
+	}
+
+	var loggedInNode ast.Node
+	for _, n := range entryNodes {
+		switch g := n.(type) {
+		case ast.TypeGuardNode:
+			if g.Ident == "LoggedIn" {
+				loggedInNode = n
+			}
+		case *ast.TypeGuardNode:
+			if g != nil && g.Ident == "LoggedIn" {
+				loggedInNode = n
+			}
+		}
+	}
+	if loggedInNode == nil {
+		t.Fatal("LoggedIn not found in entry nodes")
+	}
+	if !tc.HasScopeForNode(loggedInNode) {
+		t.Fatal("expected scope on entry LoggedIn node after rebind")
+	}
+	if err := tc.RestoreScope(loggedInNode); err != nil {
+		t.Fatalf("RestoreScope entry LoggedIn: %v", err)
 	}
 }

--- a/forst/internal/executor/executor.go
+++ b/forst/internal/executor/executor.go
@@ -223,6 +223,12 @@ func (e *FunctionExecutor) compileFunction(packageName, functionName string) (*C
 	var checker *typechecker.TypeChecker
 	if modErr == nil && modResult != nil && modResult.PerPackage[packageName] != nil {
 		checker = modResult.PerPackage[packageName]
+		// Module check used merged-package AST nodes; re-bind scopes to this compile's nodes.
+		if err := compiler.RebindTypecheckerScopes(checker, forstNodes); err != nil {
+			e.log.Error("Encountered error re-binding scopes: ", err)
+			checker.DebugPrintCurrentScope()
+			return nil, err
+		}
 	} else {
 		checker = typechecker.New(e.log, false)
 		checker.GoWorkspaceDir = moduleRoot

--- a/forst/internal/executor/executor_compile_scope_test.go
+++ b/forst/internal/executor/executor_compile_scope_test.go
@@ -1,0 +1,38 @@
+package executor
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const ifAfterAssignExecutorSrc = `package demo
+
+func F(cells []String, a Int): String {
+	x0 := cells[a]
+	if x0 == "" {
+		return ""
+	}
+	return x0
+}
+`
+
+func TestCompileFunction_rebindsScopesAfterModuleCheck(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "demo.ft"), ifAfterAssignExecutorSrc)
+
+	ex := testExecutor(t, root)
+	compiled, err := ex.compileFunction("demo", "F")
+	if err != nil {
+		t.Fatalf("compileFunction(demo, F): %v", err)
+	}
+	if compiled == nil {
+		t.Fatal("expected compiled function")
+	}
+	if compiled.FunctionName != "F" || compiled.PackageName != "demo" {
+		t.Fatalf("unexpected metadata: %+v", compiled)
+	}
+	if !strings.Contains(compiled.GoCode, "func F(") {
+		t.Fatalf("expected F in Go output, got:\n%s", compiled.GoCode)
+	}
+}

--- a/forst/internal/forstpkg/forstpkg.go
+++ b/forst/internal/forstpkg/forstpkg.go
@@ -103,3 +103,20 @@ func ParseAndMergePackage(log *logrus.Logger, paths []string) (merged []ast.Node
 	}
 	return MergePackageASTs(lists), byPath, nil
 }
+
+// MergePackageASTsFromPaths merges already-parsed per-file ASTs in path order.
+// Use this instead of re-parsing when transform must share node pointers with typecheck.
+func MergePackageASTsFromPaths(byPath map[string][]ast.Node, paths []string) ([]ast.Node, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no paths")
+	}
+	lists := make([][]ast.Node, 0, len(paths))
+	for _, p := range paths {
+		nodes, ok := byPath[p]
+		if !ok {
+			return nil, fmt.Errorf("path %s not in parse map", p)
+		}
+		lists = append(lists, nodes)
+	}
+	return MergePackageASTs(lists), nil
+}

--- a/forst/internal/forstpkg/forstpkg_test.go
+++ b/forst/internal/forstpkg/forstpkg_test.go
@@ -164,6 +164,78 @@ func b(): Int { return 2 }
 	}
 }
 
+func TestMergePackageASTsFromPaths_returnsSamePointersAsMerged(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	lib := filepath.Join(dir, "lib.ft")
+	testFt := filepath.Join(dir, "lib_test.ft")
+	if err := os.WriteFile(lib, []byte(`package demo
+
+func buildBody(label String): String { return label }
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(testFt, []byte(`package demo
+
+import "testing"
+
+func TestBody(t *testing.T) {
+	body := buildBody("x")
+	if body == "" {
+		t.Fatal("empty")
+	}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	log := logrus.New()
+	log.SetOutput(nil)
+	merged, byPath, err := ParseAndMergePackage(log, []string{lib, testFt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subset, err := MergePackageASTsFromPaths(byPath, []string{testFt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	testNodes := byPath[testFt]
+	if len(subset) != len(testNodes) {
+		t.Fatalf("subset len=%d testNodes len=%d", len(subset), len(testNodes))
+	}
+	var ifInMerged *ast.IfNode
+	for _, n := range merged {
+		fn, ok := n.(ast.FunctionNode)
+		if !ok || fn.Ident.ID != "TestBody" {
+			continue
+		}
+		for _, stmt := range fn.Body {
+			if ifn, ok := stmt.(*ast.IfNode); ok {
+				ifInMerged = ifn
+				break
+			}
+		}
+	}
+	var ifInSubset *ast.IfNode
+	for _, n := range subset {
+		fn, ok := n.(ast.FunctionNode)
+		if !ok || fn.Ident.ID != "TestBody" {
+			continue
+		}
+		for _, stmt := range fn.Body {
+			if ifn, ok := stmt.(*ast.IfNode); ok {
+				ifInSubset = ifn
+				break
+			}
+		}
+	}
+	if ifInMerged == nil || ifInSubset == nil {
+		t.Fatal("expected if node in merged and subset")
+	}
+	if ifInMerged != ifInSubset {
+		t.Fatal("if node pointer in subset must match merged parse")
+	}
+}
+
 func TestParseAndMergePackage_emptyPaths(t *testing.T) {
 	log := logrus.New()
 	log.SetOutput(nil)

--- a/forst/internal/hasher/scope_key.go
+++ b/forst/internal/hasher/scope_key.go
@@ -1,0 +1,189 @@
+package hasher
+
+import (
+	"forst/internal/ast"
+	"hash/fnv"
+	"sort"
+)
+
+// HashScopeKey returns a scope-map key for node. It is cheaper than HashNode for
+// scope-owning nodes whose bodies are not part of scope identity (functions,
+// type guards, ensure blocks). Full HashNode semantics are unchanged for type identity.
+func (h *StructuralHasher) HashScopeKey(node ast.Node) (NodeHash, error) {
+	if node == nil || isNilPointer(node) {
+		return NodeHash(NilHash), nil
+	}
+	w := newHashWalk(h)
+	switch n := node.(type) {
+	case ast.FunctionNode:
+		return w.hashScopeFunction(n)
+	case *ast.FunctionNode:
+		if n == nil {
+			return NodeHash(NilHash), nil
+		}
+		return w.hashScopeFunction(*n)
+	case ast.EnsureNode:
+		return w.hashScopeEnsure(n)
+	case *ast.EnsureNode:
+		if n == nil {
+			return NodeHash(NilHash), nil
+		}
+		return w.hashScopeEnsure(*n)
+	case ast.EnsureBlockNode:
+		return w.hashScopeEnsureBlock(node)
+	case *ast.EnsureBlockNode:
+		if n == nil {
+			return NodeHash(NilHash), nil
+		}
+		return w.hashScopeEnsureBlock(node)
+	case ast.TypeGuardNode:
+		return w.hashScopeTypeGuard(n)
+	case *ast.TypeGuardNode:
+		if n == nil {
+			return NodeHash(NilHash), nil
+		}
+		return w.hashScopeTypeGuard(*n)
+	default:
+		return h.HashNode(node)
+	}
+}
+
+// HashScopeKeyDisambiguated mixes a base scope key with node identity when structural
+// scope keys collide for distinct AST nodes.
+func (h *StructuralHasher) HashScopeKeyDisambiguated(node ast.Node, base NodeHash) (NodeHash, error) {
+	hasher := fnv.New64a()
+	if err := h.writeHashes(hasher, uint64(base)); err != nil {
+		return 0, err
+	}
+	if key, ok := NodeIdentityKey(node); ok {
+		if err := h.writeHashes(hasher, uint64(key.Typ), uint64(key.Data)); err != nil {
+			return 0, err
+		}
+	}
+	return NodeHash(hasher.Sum64()), nil
+}
+
+func (w *hashWalk) hashScopeFunction(n ast.FunctionNode) (NodeHash, error) {
+	hasher := fnv.New64a()
+	if err := w.h.writeHashes(hasher, NodeKind["Function"], []byte(n.Ident.ID)); err != nil {
+		return 0, err
+	}
+	if n.Receiver != nil {
+		hash, err := w.hash(*n.Receiver)
+		if err != nil {
+			return 0, err
+		}
+		if err := w.h.writeHashes(hasher, hash); err != nil {
+			return 0, err
+		}
+	}
+	params := make([]ast.Node, len(n.Params))
+	for i, p := range n.Params {
+		params[i] = p
+	}
+	paramHash, err := w.hashNodes(params)
+	if err != nil {
+		return 0, err
+	}
+	if err := w.h.writeHashes(hasher, paramHash); err != nil {
+		return 0, err
+	}
+	for _, rt := range n.ReturnTypes {
+		hash, err := w.hash(rt)
+		if err != nil {
+			return 0, err
+		}
+		if err := w.h.writeHashes(hasher, hash); err != nil {
+			return 0, err
+		}
+	}
+	return NodeHash(hasher.Sum64()), nil
+}
+
+func (w *hashWalk) hashScopeEnsure(n ast.EnsureNode) (NodeHash, error) {
+	hasher := fnv.New64a()
+	if err := w.h.writeHashes(hasher, NodeKind["Ensure"]); err != nil {
+		return 0, err
+	}
+	vh, err := w.hash(n.Variable)
+	if err != nil {
+		return 0, err
+	}
+	if err := w.h.writeHashes(hasher, vh); err != nil {
+		return 0, err
+	}
+	ah, err := w.hash(n.Assertion)
+	if err != nil {
+		return 0, err
+	}
+	if err := w.h.writeHashes(hasher, ah); err != nil {
+		return 0, err
+	}
+	if n.Error != nil {
+		if err := w.h.writeHashes(hasher, []byte((*n.Error).String())); err != nil {
+			return 0, err
+		}
+	}
+	return NodeHash(hasher.Sum64()), nil
+}
+
+func (w *hashWalk) hashScopeEnsureBlock(node ast.Node) (NodeHash, error) {
+	hasher := fnv.New64a()
+	if err := w.h.writeHashes(hasher, NodeKind["EnsureBlock"]); err != nil {
+		return 0, err
+	}
+	if key, ok := NodeIdentityKey(node); ok {
+		if err := w.h.writeHashes(hasher, uint64(key.Typ), uint64(key.Data)); err != nil {
+			return 0, err
+		}
+	}
+	return NodeHash(hasher.Sum64()), nil
+}
+
+func (w *hashWalk) hashScopeTypeGuard(n ast.TypeGuardNode) (NodeHash, error) {
+	hasher := fnv.New64a()
+	if err := w.h.writeHashes(hasher, NodeKind["TypeGuard"], []byte(n.Ident)); err != nil {
+		return 0, err
+	}
+	subjHash, err := w.hash(n.Subject)
+	if err != nil {
+		return 0, err
+	}
+	if err := w.h.writeHashes(hasher, subjHash); err != nil {
+		return 0, err
+	}
+	params := make([]ast.ParamNode, len(n.Parameters()))
+	copy(params, n.Parameters())
+	sort.Slice(params, func(i, j int) bool {
+		var iName, jName string
+		switch p := params[i].(type) {
+		case ast.SimpleParamNode:
+			iName = string(p.Ident.ID)
+		case ast.DestructuredParamNode:
+			if len(p.Fields) > 0 {
+				iName = p.Fields[0]
+			}
+		}
+		switch p := params[j].(type) {
+		case ast.SimpleParamNode:
+			jName = string(p.Ident.ID)
+		case ast.DestructuredParamNode:
+			if len(p.Fields) > 0 {
+				jName = p.Fields[0]
+			}
+		}
+		return iName < jName
+	})
+	nodes := make([]ast.Node, len(params))
+	for i, p := range params {
+		nodes[i] = p
+	}
+	paramHash, err := w.hashNodes(nodes)
+	if err != nil {
+		return 0, err
+	}
+	if err := w.h.writeHashes(hasher, paramHash); err != nil {
+		return 0, err
+	}
+	return NodeHash(hasher.Sum64()), nil
+}

--- a/forst/internal/hasher/scope_key_test.go
+++ b/forst/internal/hasher/scope_key_test.go
@@ -1,0 +1,103 @@
+package hasher
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestHashScopeKey_functionExcludesBody(t *testing.T) {
+	t.Parallel()
+	body200 := make([]ast.Node, 200)
+	for i := range body200 {
+		body200[i] = ast.IntLiteralNode{Value: int64(i)}
+	}
+	fn := ast.FunctionNode{
+		Ident: ast.Ident{ID: "f"},
+		Body:  body200,
+	}
+	fnEmpty := fn
+	fnEmpty.Body = nil
+
+	h := New()
+	scopeHash, err := h.HashScopeKey(fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scopeEmpty, err := h.HashScopeKey(fnEmpty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scopeHash != scopeEmpty {
+		t.Fatalf("scope key should ignore body: %x vs %x", scopeHash, scopeEmpty)
+	}
+
+	full, err := h.HashNode(fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fullEmpty, err := h.HashNode(fnEmpty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if full == fullEmpty {
+		t.Fatal("full HashNode must include body")
+	}
+}
+
+func TestHashScopeKey_distinctEnsureSubjects(t *testing.T) {
+	t.Parallel()
+	assertion := ast.AssertionNode{Constraints: []ast.ConstraintNode{{Name: "Min"}}}
+	e1 := ast.EnsureNode{
+		Variable:  ast.VariableNode{Ident: ast.Ident{ID: "a"}},
+		Assertion: assertion,
+	}
+	e2 := ast.EnsureNode{
+		Variable:  ast.VariableNode{Ident: ast.Ident{ID: "b"}},
+		Assertion: assertion,
+	}
+	h := New()
+	h1, err := h.HashScopeKey(e1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := h.HashScopeKey(e2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 == h2 {
+		t.Fatalf("distinct ensure subjects must not share scope key: %x", h1)
+	}
+}
+
+func TestHashScopeKey_typeGuardExcludesBody(t *testing.T) {
+	t.Parallel()
+	subject := ast.SimpleParamNode{
+		Ident: ast.Ident{ID: "x"},
+		Type:  ast.TypeNode{Ident: ast.TypeString},
+	}
+	body := make([]ast.Node, 100)
+	for i := range body {
+		body[i] = ast.ReturnNode{Values: []ast.ExpressionNode{ast.BoolLiteralNode{Value: true}}}
+	}
+	tg := ast.TypeGuardNode{
+		Ident:   "G",
+		Subject: subject,
+		Body:    body,
+	}
+	tgEmpty := tg
+	tgEmpty.Body = nil
+
+	h := New()
+	sk, err := h.HashScopeKey(tg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skEmpty, err := h.HashScopeKey(tgEmpty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sk != skEmpty {
+		t.Fatalf("scope key should ignore type guard body")
+	}
+}

--- a/forst/internal/testrunner/runner.go
+++ b/forst/internal/testrunner/runner.go
@@ -162,14 +162,23 @@ func emitPackageGo(moduleRoot string, pkg PackageUnderTest, modResult *moduleche
 	forstPkg := forstpkg.PackageNameOrDefault(forstpkg.PackageNameFromNodes(merged))
 
 	var tc *typechecker.TypeChecker
-	if modResult != nil && modResult.PerPackage[forstPkg] != nil {
+	fromModule := modResult != nil && modResult.PerPackage[forstPkg] != nil
+	if fromModule {
 		tc = modResult.PerPackage[forstPkg]
 	} else {
 		tc = typechecker.New(log, false)
 		tc.GoWorkspaceDir = moduleRoot
-		if err := tc.CheckTypes(merged); err != nil {
-			return "", fmt.Errorf("typecheck: %w", err)
-		}
+	}
+	var savedProviders map[ast.Identifier][]typechecker.ProviderSlot
+	if fromModule {
+		savedProviders = cloneFunctionProviders(tc.FunctionProviders)
+	}
+	if err := tc.CheckTypes(merged); err != nil {
+		return "", fmt.Errorf("typecheck: %w", err)
+	}
+	if fromModule && savedProviders != nil {
+		tc.SetFunctionProviders(savedProviders)
+		tc.FunctionProviders = savedProviders
 	}
 
 	transformPaths := pkg.FtPaths
@@ -179,9 +188,12 @@ func emitPackageGo(moduleRoot string, pkg PackageUnderTest, modResult *moduleche
 		}
 		transformPaths = pkg.TestPaths
 	}
-	transformNodes, _, err := forstpkg.ParseAndMergePackage(log, transformPaths)
-	if err != nil {
-		return "", fmt.Errorf("parse transform: %w", err)
+	transformNodes := merged
+	if opts.TestOnly {
+		transformNodes, _, err = forstpkg.ParseAndMergePackage(log, transformPaths)
+		if err != nil {
+			return "", fmt.Errorf("parse transform: %w", err)
+		}
 	}
 
 	tr := transformer_go.New(tc, log, opts.ExportStructFields)
@@ -261,6 +273,19 @@ func ParseCLIArgs(args []string) (paths []string, goTestArgs []string) {
 		}
 	}
 	return paths, goTestArgs
+}
+
+func cloneFunctionProviders(src map[ast.Identifier][]typechecker.ProviderSlot) map[ast.Identifier][]typechecker.ProviderSlot {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[ast.Identifier][]typechecker.ProviderSlot, len(src))
+	for k, v := range src {
+		slots := make([]typechecker.ProviderSlot, len(v))
+		copy(slots, v)
+		out[k] = slots
+	}
+	return out
 }
 
 func indexOf(ss []string, s string) int {

--- a/forst/internal/testrunner/runner.go
+++ b/forst/internal/testrunner/runner.go
@@ -154,7 +154,7 @@ func hasGeneratedLibrary(dir string) bool {
 }
 
 func emitPackageGo(moduleRoot string, pkg PackageUnderTest, modResult *modulecheck.ModuleResult, opts EmitOptions, log *logrus.Logger) (string, error) {
-	merged, _, err := forstpkg.ParseAndMergePackage(log, pkg.FtPaths)
+	merged, byPath, err := forstpkg.ParseAndMergePackage(log, pkg.FtPaths)
 	if err != nil {
 		return "", fmt.Errorf("parse: %w", err)
 	}
@@ -190,9 +190,9 @@ func emitPackageGo(moduleRoot string, pkg PackageUnderTest, modResult *moduleche
 	}
 	transformNodes := merged
 	if opts.TestOnly {
-		transformNodes, _, err = forstpkg.ParseAndMergePackage(log, transformPaths)
+		transformNodes, err = forstpkg.MergePackageASTsFromPaths(byPath, transformPaths)
 		if err != nil {
-			return "", fmt.Errorf("parse transform: %w", err)
+			return "", fmt.Errorf("merge transform nodes: %w", err)
 		}
 	}
 

--- a/forst/internal/testrunner/runner_test.go
+++ b/forst/internal/testrunner/runner_test.go
@@ -291,6 +291,73 @@ func TestEmitPackageGo_testOnlyOmitsPackageTypeDefs(t *testing.T) {
 	}
 }
 
+func writeIfScopeTestFixture(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(testmod.GoModContent("ifscope_test")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pkgDir := filepath.Join(dir, "demo")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "lib.ft"), []byte(`package demo
+
+func buildBody(label String): String {
+	return label
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "lib_test.ft"), []byte(`package demo
+
+import "testing"
+
+func TestBodyNonEmpty(t *testing.T) {
+	body := buildBody("x")
+	if body == "" {
+		t.Fatal("empty body")
+	}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return pkgDir
+}
+
+func TestEmitPackageGo_testOnlyIfScopeUsesMergedParseNodes(t *testing.T) {
+	dir := t.TempDir()
+	pkgDir := writeIfScopeTestFixture(t, dir)
+	log := logrus.New()
+	log.SetOutput(os.Stderr)
+	log.SetLevel(logrus.PanicLevel)
+
+	modResult, err := modulecheck.CheckModuleProviders(log, modulecheck.Options{ModuleRoot: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkgs, err := DiscoverPackages(dir, []string{"demo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg := pkgs[0]
+
+	libCode, err := emitPackageGo(dir, pkg, modResult, EmitOptions{}, log)
+	if err != nil {
+		t.Fatalf("emit lib: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "z_forst_gen.go"), []byte(libCode), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	testCode, err := emitPackageGo(dir, pkg, modResult, EmitOptions{TestOnly: true}, log)
+	if err != nil {
+		t.Fatalf("emit test-only: %v", err)
+	}
+	if !strings.Contains(testCode, "func TestBodyNonEmpty(t *testing.T)") {
+		t.Fatalf("test-only emit missing test function:\n%s", testCode)
+	}
+}
+
 func TestRun_dependencyEmitThenSelfTest_succeeds(t *testing.T) {
 	dir := t.TempDir()
 	libpkgDir, _ := writeLibClientTestFixture(t, dir)

--- a/forst/internal/transformer/go/ensure_base_type_integration_test.go
+++ b/forst/internal/transformer/go/ensure_base_type_integration_test.go
@@ -35,7 +35,7 @@ func main() {
 	}
 	tr := New(tc, log)
 
-	var ensureStmt ast.EnsureNode
+	var ensureNode ast.Node
 	var foundEnsure bool
 	for _, n := range nodes {
 		fn, ok := n.(ast.FunctionNode)
@@ -43,8 +43,8 @@ func main() {
 			continue
 		}
 		for _, st := range fn.Body {
-			if en, ok := st.(ast.EnsureNode); ok {
-				ensureStmt = en
+			if _, ok := st.(ast.EnsureNode); ok {
+				ensureNode = st
 				foundEnsure = true
 				break
 			}
@@ -55,10 +55,10 @@ func main() {
 		t.Fatal("ensure statement not found")
 	}
 
-	if err := tr.restoreScope(ensureStmt); err != nil {
+	if err := tr.restoreScope(ensureNode); err != nil {
 		t.Fatal(err)
 	}
-	got, err := tr.getEnsureBaseType(ensureStmt)
+	got, err := tr.getEnsureBaseType(ensureNode.(ast.EnsureNode))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/forst/internal/transformer/go/expression_if_is_test.go
+++ b/forst/internal/transformer/go/expression_if_is_test.go
@@ -68,7 +68,7 @@ is (password Password) Strong(min Int) {
 		t.Fatalf("expected AssertionNode, got %T", bin.Right)
 	}
 
-	if err := tr.restoreScope(guard); err != nil {
+	if err := tr.restoreScope(typeGuardScopeNode(nodes, guard)); err != nil {
 		t.Fatalf("restoreScope: %v", err)
 	}
 	expr, err := tr.transformIfIsCondition(bin.Left, &asn)

--- a/forst/internal/transformer/go/expression_test.go
+++ b/forst/internal/transformer/go/expression_test.go
@@ -257,13 +257,14 @@ func TestTransformExpression_StructLiteralWithNamedType_NoExpectedType(t *testin
 	transformer := setupTransformer(tc, log)
 
 	// Register types and function
-	err := tc.CheckTypes([]ast.Node{echoRequestType, mainFn})
+	nodes := []ast.Node{echoRequestType, mainFn}
+	err := tc.CheckTypes(nodes)
 	if err != nil {
 		t.Fatalf("Type checking failed: %v", err)
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{echoRequestType, mainFn}, mainFn), mainFn)
+	result, err := transformer.transformFunction(functionScopeNode(nodes, mainFn), mainFn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -330,13 +331,14 @@ func TestTransformExpression_StructLiteralTypeEmissionBug(t *testing.T) {
 	transformer := setupTransformer(tc, log)
 
 	// Register types
-	err := tc.CheckTypes([]ast.Node{userType, createUserResponseType, fn})
+	nodes := []ast.Node{userType, createUserResponseType, fn}
+	err := tc.CheckTypes(nodes)
 	if err != nil {
 		t.Fatalf("Type checking failed: %v", err)
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserResponseType, fn}, fn), fn)
+	result, err := transformer.transformFunction(functionScopeNode(nodes, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -436,13 +438,14 @@ func TestTransformExpression_StructLiteralWithFieldAssignments(t *testing.T) {
 	transformer := setupTransformer(tc, log)
 
 	// Register types
-	err := tc.CheckTypes([]ast.Node{userType, createUserRequestType, createUserResponseType, fn})
+	nodes := []ast.Node{userType, createUserRequestType, createUserResponseType, fn}
+	err := tc.CheckTypes(nodes)
 	if err != nil {
 		t.Fatalf("Type checking failed: %v", err)
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserRequestType, createUserResponseType, fn}, fn), fn)
+	result, err := transformer.transformFunction(functionScopeNode(nodes, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -621,13 +624,14 @@ func TestTransformExpression_ClientExampleBug(t *testing.T) {
 	transformer := setupTransformer(tc, log)
 
 	// Register types
-	err := tc.CheckTypes([]ast.Node{userType, createUserRequestType, createUserResponseType, fn})
+	nodes := []ast.Node{userType, createUserRequestType, createUserResponseType, fn}
+	err := tc.CheckTypes(nodes)
 	if err != nil {
 		t.Fatalf("Type checking failed: %v", err)
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserRequestType, createUserResponseType, fn}, fn), fn)
+	result, err := transformer.transformFunction(functionScopeNode(nodes, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -734,13 +738,14 @@ func TestTransformExpression_ClientExampleWithFieldAccess(t *testing.T) {
 	transformer := setupTransformer(tc, log)
 
 	// Register types
-	err := tc.CheckTypes([]ast.Node{userType, createUserRequestType, createUserResponseType, fn})
+	nodes := []ast.Node{userType, createUserRequestType, createUserResponseType, fn}
+	err := tc.CheckTypes(nodes)
 	if err != nil {
 		t.Fatalf("Type checking failed: %v", err)
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserRequestType, createUserResponseType, fn}, fn), fn)
+	result, err := transformer.transformFunction(functionScopeNode(nodes, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -825,13 +830,14 @@ func TestTransformExpression_UnifiedHelperWorking(t *testing.T) {
 	transformer := setupTransformer(tc, log)
 
 	// Register types
-	err := tc.CheckTypes([]ast.Node{userType, createUserResponseType, fn})
+	nodes := []ast.Node{userType, createUserResponseType, fn}
+	err := tc.CheckTypes(nodes)
 	if err != nil {
 		t.Fatalf("Type checking failed: %v", err)
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserResponseType, fn}, fn), fn)
+	result, err := transformer.transformFunction(functionScopeNode(nodes, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}

--- a/forst/internal/transformer/go/expression_test.go
+++ b/forst/internal/transformer/go/expression_test.go
@@ -263,7 +263,7 @@ func TestTransformExpression_StructLiteralWithNamedType_NoExpectedType(t *testin
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(mainFn)
+	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{echoRequestType, mainFn}, mainFn), mainFn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestTransformExpression_StructLiteralTypeEmissionBug(t *testing.T) {
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(fn)
+	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserResponseType, fn}, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestTransformExpression_StructLiteralWithFieldAssignments(t *testing.T) {
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(fn)
+	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserRequestType, createUserResponseType, fn}, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -627,7 +627,7 @@ func TestTransformExpression_ClientExampleBug(t *testing.T) {
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(fn)
+	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserRequestType, createUserResponseType, fn}, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -740,7 +740,7 @@ func TestTransformExpression_ClientExampleWithFieldAccess(t *testing.T) {
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(fn)
+	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserRequestType, createUserResponseType, fn}, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}
@@ -831,7 +831,7 @@ func TestTransformExpression_UnifiedHelperWorking(t *testing.T) {
 	}
 
 	// Transform the function
-	result, err := transformer.transformFunction(fn)
+	result, err := transformer.transformFunction(functionScopeNode([]ast.Node{userType, createUserResponseType, fn}, fn), fn)
 	if err != nil {
 		t.Fatalf("Transform failed: %v", err)
 	}

--- a/forst/internal/transformer/go/for_loop.go
+++ b/forst/internal/transformer/go/for_loop.go
@@ -54,7 +54,7 @@ func (t *Transformer) transformIfNode(n *ast.IfNode) (goast.Stmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := t.restoreScope(n); err != nil {
+	if err := t.restoreScope(t.resolveIfScopeNode(n)); err != nil {
 		return nil, fmt.Errorf("if scope restore: %w", err)
 	}
 	body := &goast.BlockStmt{}
@@ -71,7 +71,10 @@ func (t *Transformer) transformIfNode(n *ast.IfNode) (goast.Stmt, error) {
 	main := &goast.IfStmt{Init: init, Cond: condExpr, Body: body}
 	cur := main
 	for i := range n.ElseIfs {
-		ei := n.ElseIfs[i]
+		ei := &n.ElseIfs[i]
+		if err := t.restoreScope(t.resolveElseIfScopeNode(ei)); err != nil {
+			return nil, fmt.Errorf("else-if scope restore: %w", err)
+		}
 		econd, ok := ei.Condition.(ast.ExpressionNode)
 		if !ok {
 			return nil, fmt.Errorf("else-if condition is not an expression")
@@ -93,6 +96,9 @@ func (t *Transformer) transformIfNode(n *ast.IfNode) (goast.Stmt, error) {
 		cur = next
 	}
 	if n.Else != nil {
+		if err := t.restoreScope(t.resolveElseBlockScopeNode(n.Else)); err != nil {
+			return nil, fmt.Errorf("else scope restore: %w", err)
+		}
 		eb := &goast.BlockStmt{}
 		for _, st := range n.Else.Body {
 			gst, err := t.transformStatement(st)

--- a/forst/internal/transformer/go/function.go
+++ b/forst/internal/transformer/go/function.go
@@ -95,8 +95,8 @@ func (t *Transformer) transformFunctionParams(params []ast.ParamNode) (*goast.Fi
 }
 
 // transformFunction converts a Forst function node to a Go function declaration
-func (t *Transformer) transformFunction(n ast.FunctionNode) (*goast.FuncDecl, error) {
-	if err := t.restoreScope(n); err != nil {
+func (t *Transformer) transformFunction(scopeNode ast.Node, n ast.FunctionNode) (*goast.FuncDecl, error) {
+	if err := t.restoreScope(scopeNode); err != nil {
 		return nil, fmt.Errorf("failed to restore function scope: %s", err)
 	}
 
@@ -157,7 +157,7 @@ func (t *Transformer) transformFunction(n ast.FunctionNode) (*goast.FuncDecl, er
 		if emitImplicitReturn && i == implicitIdx {
 			continue
 		}
-		if err := t.restoreScope(n); err != nil {
+		if err := t.restoreScope(scopeNode); err != nil {
 			return nil, fmt.Errorf("failed to restore function scope in body: %s", err)
 		}
 

--- a/forst/internal/transformer/go/function.go
+++ b/forst/internal/transformer/go/function.go
@@ -172,7 +172,7 @@ func (t *Transformer) transformFunction(scopeNode ast.Node, n ast.FunctionNode) 
 			}
 			stmts = append(stmts, goStmt)
 		case ast.WithNode:
-			withStmts, err := t.transformWithStatements(s)
+			withStmts, err := t.transformWithStatements(stmt, s)
 			if err != nil {
 				return nil, fmt.Errorf("failed to transform with block: %w", err)
 			}

--- a/forst/internal/transformer/go/function_destructured_test.go
+++ b/forst/internal/transformer/go/function_destructured_test.go
@@ -101,7 +101,7 @@ is (m MutationArg) Input(input Shape) {
 		t.Fatal("expected Input type guard")
 	}
 
-	decl, err := tr.transformTypeGuard(guard)
+	decl, err := tr.transformTypeGuard(typeGuardScopeNode(nodes, guard), guard)
 	if err != nil {
 		t.Fatalf("transformTypeGuard: %v", err)
 	}

--- a/forst/internal/transformer/go/function_destructured_test.go
+++ b/forst/internal/transformer/go/function_destructured_test.go
@@ -31,15 +31,20 @@ func sum(a Int, {x, y}: { x: Int, y: Int }): Int {
 	}
 
 	tr := New(tc, log)
+	var scopeNode ast.Node
 	var fn ast.FunctionNode
 	for _, n := range nodes {
 		if f, ok := n.(ast.FunctionNode); ok && f.Ident.ID == "sum" {
+			scopeNode = n
 			fn = f
 			break
 		}
 	}
+	if scopeNode == nil {
+		t.Fatal("sum not found")
+	}
 
-	decl, err := tr.transformFunction(fn)
+	decl, err := tr.transformFunction(scopeNode, fn)
 	if err != nil {
 		t.Fatalf("transform: %v", err)
 	}

--- a/forst/internal/transformer/go/providers.go
+++ b/forst/internal/transformer/go/providers.go
@@ -468,7 +468,16 @@ func splitQualifiedIdent(s string) []string {
 	return nil
 }
 
-func (t *Transformer) transformWithStatements(with ast.WithNode) ([]goast.Stmt, error) {
+func (t *Transformer) transformWithStatements(scopeNode typechecker.ScopeNode, with ast.WithNode) ([]goast.Stmt, error) {
+	if !t.TypeChecker.HasScopeForNode(scopeNode) {
+		scopeNode = t.resolveWithScopeNode(t.entryNodes, with)
+	}
+	if !t.TypeChecker.HasScopeForNode(scopeNode) {
+		return nil, fmt.Errorf("with block: no registered scope for %s", scopeNode)
+	}
+	if err := t.restoreScope(scopeNode); err != nil {
+		return nil, fmt.Errorf("with block: %w", err)
+	}
 	if err := t.pushWiringFrame(with); err != nil {
 		return nil, err
 	}
@@ -476,11 +485,8 @@ func (t *Transformer) transformWithStatements(with ast.WithNode) ([]goast.Stmt, 
 
 	stmts := make([]goast.Stmt, 0, len(with.Body))
 	for _, stmt := range with.Body {
-		if err := t.restoreScopeForWith(with); err != nil {
-			return nil, err
-		}
 		if withStmt, ok := stmt.(ast.WithNode); ok {
-			nested, err := t.transformWithStatements(withStmt)
+			nested, err := t.transformWithStatements(stmt, withStmt)
 			if err != nil {
 				return nil, err
 			}
@@ -499,8 +505,4 @@ func (t *Transformer) transformWithStatements(with ast.WithNode) ([]goast.Stmt, 
 		stmts = append(stmts, goStmt)
 	}
 	return stmts, nil
-}
-
-func (t *Transformer) restoreScopeForWith(with ast.WithNode) error {
-	return t.TypeChecker.RestoreScope(with)
 }

--- a/forst/internal/transformer/go/scope.go
+++ b/forst/internal/transformer/go/scope.go
@@ -14,3 +14,66 @@ func (t *Transformer) restoreScope(node ast.Node) error {
 func (t *Transformer) currentScope() *typechecker.Scope {
 	return t.TypeChecker.CurrentScope()
 }
+
+// typeGuardScopeNode returns the ast.Node from nodes that owns guard's scope (same interface as typecheck).
+func typeGuardScopeNode(nodes []ast.Node, guard ast.TypeGuardNode) ast.Node {
+	for _, n := range nodes {
+		if matchTypeGuardNode(n, guard) {
+			return n
+		}
+	}
+	return ast.Node(guard)
+}
+
+func matchTypeGuardNode(n ast.Node, guard ast.TypeGuardNode) bool {
+	switch g := n.(type) {
+	case ast.TypeGuardNode:
+		return g.Ident == guard.Ident
+	case *ast.TypeGuardNode:
+		return g != nil && g.Ident == guard.Ident
+	default:
+		return false
+	}
+}
+
+// resolveTypeGuardScopeNode finds the ast.Node whose scope was registered during typecheck.
+// Module-level checking may register scopes on merged-package nodes while compile emits a single file.
+func (t *Transformer) resolveTypeGuardScopeNode(entryNodes []ast.Node, guard ast.TypeGuardNode) ast.Node {
+	return t.resolveScopeNode(entryNodes, func(n ast.Node) bool {
+		return matchTypeGuardNode(n, guard)
+	}, ast.Node(guard))
+}
+
+// resolveFunctionScopeNode finds the ast.Node whose scope was registered during typecheck.
+func (t *Transformer) resolveFunctionScopeNode(entryNodes []ast.Node, fn ast.FunctionNode) ast.Node {
+	return t.resolveScopeNode(entryNodes, func(n ast.Node) bool {
+		if f, ok := n.(ast.FunctionNode); ok {
+			return f.Ident.ID == fn.Ident.ID
+		}
+		return false
+	}, ast.Node(fn))
+}
+
+func (t *Transformer) resolveScopeNode(entryNodes []ast.Node, match func(ast.Node) bool, fallback ast.Node) ast.Node {
+	searchLists := [][]ast.Node{entryNodes}
+	if t.moduleResult != nil {
+		for _, merged := range t.moduleResult.PerPackageNodes {
+			searchLists = append(searchLists, merged)
+		}
+	}
+	for _, list := range searchLists {
+		for _, n := range list {
+			if match(n) && t.TypeChecker.HasScopeForNode(n) {
+				return n
+			}
+		}
+	}
+	for _, list := range searchLists {
+		for _, n := range list {
+			if match(n) {
+				return n
+			}
+		}
+	}
+	return fallback
+}

--- a/forst/internal/transformer/go/scope.go
+++ b/forst/internal/transformer/go/scope.go
@@ -47,6 +47,301 @@ func (t *Transformer) resolveTypeGuardScopeNode(entryNodes []ast.Node, guard ast
 	}, ast.Node(guard))
 }
 
+// resolveIfScopeNode finds the ast.Node whose scope was registered during typecheck.
+func (t *Transformer) resolveIfScopeNode(ifn *ast.IfNode) ast.Node {
+	target := ifn.String()
+	for _, list := range t.scopeSearchLists(t.entryNodes) {
+		if n := findRegisteredIfScopeNode(list, target, t.TypeChecker); n != nil {
+			return n
+		}
+	}
+	return ast.Node(ifn)
+}
+
+// resolveElseIfScopeNode finds the registered scope node for an else-if branch.
+func (t *Transformer) resolveElseIfScopeNode(ei *ast.ElseIfNode) ast.Node {
+	target := ei.String()
+	for _, list := range t.scopeSearchLists(t.entryNodes) {
+		if n := findRegisteredElseIfScopeNode(list, target, t.TypeChecker); n != nil {
+			return n
+		}
+	}
+	return ast.Node(ei)
+}
+
+// resolveElseBlockScopeNode finds the registered scope node for an else branch.
+func (t *Transformer) resolveElseBlockScopeNode(eb *ast.ElseBlockNode) ast.Node {
+	target := eb.String()
+	for _, list := range t.scopeSearchLists(t.entryNodes) {
+		if n := findRegisteredElseBlockScopeNode(list, target, t.TypeChecker); n != nil {
+			return n
+		}
+	}
+	return ast.Node(eb)
+}
+
+func findRegisteredIfScopeNode(nodes []ast.Node, ifStr string, tc *typechecker.TypeChecker) ast.Node {
+	for _, n := range nodes {
+		switch x := n.(type) {
+		case ast.FunctionNode:
+			if found := findRegisteredIfInStmts(x.Body, ifStr, tc); found != nil {
+				return found
+			}
+		case *ast.FunctionNode:
+			if x != nil {
+				if found := findRegisteredIfInStmts(x.Body, ifStr, tc); found != nil {
+					return found
+				}
+			}
+		case ast.TypeGuardNode:
+			if found := findRegisteredIfInStmts(x.Body, ifStr, tc); found != nil {
+				return found
+			}
+		case *ast.TypeGuardNode:
+			if x != nil {
+				if found := findRegisteredIfInStmts(x.Body, ifStr, tc); found != nil {
+					return found
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func findRegisteredIfInStmts(stmts []ast.Node, ifStr string, tc *typechecker.TypeChecker) ast.Node {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.IfNode:
+			if s.String() == ifStr && tc.HasScopeForNode(s) {
+				return s
+			}
+			if found := findRegisteredIfInIfNode(s, ifStr, tc); found != nil {
+				return found
+			}
+		case ast.IfNode:
+			if s.String() == ifStr && tc.HasScopeForNode(stmt) {
+				return stmt
+			}
+			if found := findRegisteredIfInIfNode(&s, ifStr, tc); found != nil {
+				return found
+			}
+		case ast.ForNode:
+			if found := findRegisteredIfInStmts(s.Body, ifStr, tc); found != nil {
+				return found
+			}
+		case *ast.ForNode:
+			if s != nil {
+				if found := findRegisteredIfInStmts(s.Body, ifStr, tc); found != nil {
+					return found
+				}
+			}
+		case ast.WithNode:
+			if found := findRegisteredIfInStmts(s.Body, ifStr, tc); found != nil {
+				return found
+			}
+		case ast.EnsureNode:
+			if s.Block != nil {
+				if found := findRegisteredIfInStmts(s.Block.Body, ifStr, tc); found != nil {
+					return found
+				}
+			}
+		case *ast.EnsureNode:
+			if s != nil && s.Block != nil {
+				if found := findRegisteredIfInStmts(s.Block.Body, ifStr, tc); found != nil {
+					return found
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func findRegisteredIfInIfNode(ifn *ast.IfNode, ifStr string, tc *typechecker.TypeChecker) ast.Node {
+	for i := range ifn.ElseIfs {
+		ei := &ifn.ElseIfs[i]
+		if ei.String() == ifStr && tc.HasScopeForNode(ei) {
+			return ei
+		}
+		if found := findRegisteredIfInStmts(ei.Body, ifStr, tc); found != nil {
+			return found
+		}
+	}
+	if ifn.Else != nil {
+		if ifn.Else.String() == ifStr && tc.HasScopeForNode(ifn.Else) {
+			return ifn.Else
+		}
+		if found := findRegisteredIfInStmts(ifn.Else.Body, ifStr, tc); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func findRegisteredElseIfScopeNode(nodes []ast.Node, elseIfStr string, tc *typechecker.TypeChecker) ast.Node {
+	for _, n := range nodes {
+		switch x := n.(type) {
+		case ast.FunctionNode:
+			if found := findRegisteredElseIfInStmts(x.Body, elseIfStr, tc); found != nil {
+				return found
+			}
+		case *ast.FunctionNode:
+			if x != nil {
+				if found := findRegisteredElseIfInStmts(x.Body, elseIfStr, tc); found != nil {
+					return found
+				}
+			}
+		case ast.TypeGuardNode:
+			if found := findRegisteredElseIfInStmts(x.Body, elseIfStr, tc); found != nil {
+				return found
+			}
+		case *ast.TypeGuardNode:
+			if x != nil {
+				if found := findRegisteredElseIfInStmts(x.Body, elseIfStr, tc); found != nil {
+					return found
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func findRegisteredElseIfInStmts(stmts []ast.Node, elseIfStr string, tc *typechecker.TypeChecker) ast.Node {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.IfNode:
+			for i := range s.ElseIfs {
+				ei := &s.ElseIfs[i]
+				if ei.String() == elseIfStr && tc.HasScopeForNode(ei) {
+					return ei
+				}
+			}
+			if found := findRegisteredElseIfInIfNode(s, elseIfStr, tc); found != nil {
+				return found
+			}
+		case ast.IfNode:
+			for i := range s.ElseIfs {
+				ei := &s.ElseIfs[i]
+				if ei.String() == elseIfStr && tc.HasScopeForNode(ei) {
+					return ei
+				}
+			}
+			if found := findRegisteredElseIfInIfNode(&s, elseIfStr, tc); found != nil {
+				return found
+			}
+		case ast.ForNode:
+			if found := findRegisteredElseIfInStmts(s.Body, elseIfStr, tc); found != nil {
+				return found
+			}
+		case *ast.ForNode:
+			if s != nil {
+				if found := findRegisteredElseIfInStmts(s.Body, elseIfStr, tc); found != nil {
+					return found
+				}
+			}
+		case ast.WithNode:
+			if found := findRegisteredElseIfInStmts(s.Body, elseIfStr, tc); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+func findRegisteredElseIfInIfNode(ifn *ast.IfNode, elseIfStr string, tc *typechecker.TypeChecker) ast.Node {
+	if found := findRegisteredElseIfInStmts(ifn.Body, elseIfStr, tc); found != nil {
+		return found
+	}
+	for i := range ifn.ElseIfs {
+		ei := &ifn.ElseIfs[i]
+		if found := findRegisteredElseIfInStmts(ei.Body, elseIfStr, tc); found != nil {
+			return found
+		}
+	}
+	if ifn.Else != nil {
+		if found := findRegisteredElseIfInStmts(ifn.Else.Body, elseIfStr, tc); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func findRegisteredElseBlockScopeNode(nodes []ast.Node, elseStr string, tc *typechecker.TypeChecker) ast.Node {
+	for _, n := range nodes {
+		switch x := n.(type) {
+		case ast.FunctionNode:
+			if found := findRegisteredElseBlockInStmts(x.Body, elseStr, tc); found != nil {
+				return found
+			}
+		case *ast.FunctionNode:
+			if x != nil {
+				if found := findRegisteredElseBlockInStmts(x.Body, elseStr, tc); found != nil {
+					return found
+				}
+			}
+		case ast.TypeGuardNode:
+			if found := findRegisteredElseBlockInStmts(x.Body, elseStr, tc); found != nil {
+				return found
+			}
+		case *ast.TypeGuardNode:
+			if x != nil {
+				if found := findRegisteredElseBlockInStmts(x.Body, elseStr, tc); found != nil {
+					return found
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func findRegisteredElseBlockInStmts(stmts []ast.Node, elseStr string, tc *typechecker.TypeChecker) ast.Node {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.IfNode:
+			if s.Else != nil && s.Else.String() == elseStr && tc.HasScopeForNode(s.Else) {
+				return s.Else
+			}
+			if found := findRegisteredElseBlockInIfNode(s, elseStr, tc); found != nil {
+				return found
+			}
+		case ast.IfNode:
+			if s.Else != nil && s.Else.String() == elseStr && tc.HasScopeForNode(s.Else) {
+				return s.Else
+			}
+			if found := findRegisteredElseBlockInIfNode(&s, elseStr, tc); found != nil {
+				return found
+			}
+		case ast.ForNode:
+			if found := findRegisteredElseBlockInStmts(s.Body, elseStr, tc); found != nil {
+				return found
+			}
+		case *ast.ForNode:
+			if s != nil {
+				if found := findRegisteredElseBlockInStmts(s.Body, elseStr, tc); found != nil {
+					return found
+				}
+			}
+		case ast.WithNode:
+			if found := findRegisteredElseBlockInStmts(s.Body, elseStr, tc); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+func findRegisteredElseBlockInIfNode(ifn *ast.IfNode, elseStr string, tc *typechecker.TypeChecker) ast.Node {
+	if found := findRegisteredElseBlockInStmts(ifn.Body, elseStr, tc); found != nil {
+		return found
+	}
+	for i := range ifn.ElseIfs {
+		ei := &ifn.ElseIfs[i]
+		if found := findRegisteredElseBlockInStmts(ei.Body, elseStr, tc); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
 // resolveFunctionScopeNode finds the ast.Node whose scope was registered during typecheck.
 func (t *Transformer) resolveFunctionScopeNode(entryNodes []ast.Node, fn ast.FunctionNode) ast.Node {
 	if n, ok := t.TypeChecker.ScopeNodeForFunction(fn.Ident.ID); ok {

--- a/forst/internal/transformer/go/scope.go
+++ b/forst/internal/transformer/go/scope.go
@@ -39,6 +39,9 @@ func matchTypeGuardNode(n ast.Node, guard ast.TypeGuardNode) bool {
 // resolveTypeGuardScopeNode finds the ast.Node whose scope was registered during typecheck.
 // Module-level checking may register scopes on merged-package nodes while compile emits a single file.
 func (t *Transformer) resolveTypeGuardScopeNode(entryNodes []ast.Node, guard ast.TypeGuardNode) ast.Node {
+	if n, ok := t.TypeChecker.ScopeNodeForTypeGuard(guard.Ident); ok {
+		return n
+	}
 	return t.resolveScopeNode(entryNodes, func(n ast.Node) bool {
 		return matchTypeGuardNode(n, guard)
 	}, ast.Node(guard))
@@ -46,6 +49,9 @@ func (t *Transformer) resolveTypeGuardScopeNode(entryNodes []ast.Node, guard ast
 
 // resolveFunctionScopeNode finds the ast.Node whose scope was registered during typecheck.
 func (t *Transformer) resolveFunctionScopeNode(entryNodes []ast.Node, fn ast.FunctionNode) ast.Node {
+	if n, ok := t.TypeChecker.ScopeNodeForFunction(fn.Ident.ID); ok {
+		return n
+	}
 	return t.resolveScopeNode(entryNodes, func(n ast.Node) bool {
 		if f, ok := n.(ast.FunctionNode); ok {
 			return f.Ident.ID == fn.Ident.ID
@@ -54,13 +60,126 @@ func (t *Transformer) resolveFunctionScopeNode(entryNodes []ast.Node, fn ast.Fun
 	}, ast.Node(fn))
 }
 
-func (t *Transformer) resolveScopeNode(entryNodes []ast.Node, match func(ast.Node) bool, fallback ast.Node) ast.Node {
-	searchLists := [][]ast.Node{entryNodes}
-	if t.moduleResult != nil {
-		for _, merged := range t.moduleResult.PerPackageNodes {
-			searchLists = append(searchLists, merged)
+func (t *Transformer) resolveWithScopeNode(entryNodes []ast.Node, with ast.WithNode) ast.Node {
+	withStr := with.String()
+	for _, list := range t.scopeSearchLists(entryNodes) {
+		if n := findRegisteredWithScopeNode(list, withStr, t.TypeChecker); n != nil {
+			return n
 		}
 	}
+	return ast.Node(with)
+}
+
+func (t *Transformer) scopeSearchLists(entryNodes []ast.Node) [][]ast.Node {
+	lists := [][]ast.Node{}
+	if tcNodes := t.TypeChecker.TypecheckNodes(); len(tcNodes) > 0 {
+		lists = append(lists, tcNodes)
+	}
+	lists = append(lists, entryNodes)
+	if t.moduleResult != nil {
+		for _, merged := range t.moduleResult.PerPackageNodes {
+			lists = append(lists, merged)
+		}
+	}
+	return lists
+}
+
+func findRegisteredWithScopeNode(nodes []ast.Node, withStr string, tc *typechecker.TypeChecker) ast.Node {
+	for _, n := range nodes {
+		switch x := n.(type) {
+		case ast.FunctionNode:
+			if found := findRegisteredWithInStmts(x.Body, withStr, tc); found != nil {
+				return found
+			}
+		case *ast.FunctionNode:
+			if x != nil {
+				if found := findRegisteredWithInStmts(x.Body, withStr, tc); found != nil {
+					return found
+				}
+			}
+		case ast.TypeGuardNode:
+			if found := findRegisteredWithInStmts(x.Body, withStr, tc); found != nil {
+				return found
+			}
+		case *ast.TypeGuardNode:
+			if x != nil {
+				if found := findRegisteredWithInStmts(x.Body, withStr, tc); found != nil {
+					return found
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func findRegisteredWithInStmts(stmts []ast.Node, withStr string, tc *typechecker.TypeChecker) ast.Node {
+	for _, stmt := range stmts {
+		if w, ok := stmt.(ast.WithNode); ok {
+			if w.String() == withStr && tc.HasScopeForNode(stmt) {
+				return stmt
+			}
+			if found := findRegisteredWithInStmts(w.Body, withStr, tc); found != nil {
+				return found
+			}
+			continue
+		}
+		switch s := stmt.(type) {
+		case ast.IfNode:
+			if found := findRegisteredWithInIf(&s, withStr, tc); found != nil {
+				return found
+			}
+		case *ast.IfNode:
+			if s != nil {
+				if found := findRegisteredWithInIf(s, withStr, tc); found != nil {
+					return found
+				}
+			}
+		case ast.ForNode:
+			if found := findRegisteredWithInStmts(s.Body, withStr, tc); found != nil {
+				return found
+			}
+		case *ast.ForNode:
+			if s != nil {
+				if found := findRegisteredWithInStmts(s.Body, withStr, tc); found != nil {
+					return found
+				}
+			}
+		case ast.EnsureNode:
+			if s.Block != nil {
+				if found := findRegisteredWithInStmts(s.Block.Body, withStr, tc); found != nil {
+					return found
+				}
+			}
+		case *ast.EnsureNode:
+			if s != nil && s.Block != nil {
+				if found := findRegisteredWithInStmts(s.Block.Body, withStr, tc); found != nil {
+					return found
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func findRegisteredWithInIf(ifn *ast.IfNode, withStr string, tc *typechecker.TypeChecker) ast.Node {
+	if found := findRegisteredWithInStmts(ifn.Body, withStr, tc); found != nil {
+		return found
+	}
+	for i := range ifn.ElseIfs {
+		if found := findRegisteredWithInStmts(ifn.ElseIfs[i].Body, withStr, tc); found != nil {
+			return found
+		}
+	}
+	if ifn.Else != nil {
+		if found := findRegisteredWithInStmts(ifn.Else.Body, withStr, tc); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func (t *Transformer) resolveScopeNode(entryNodes []ast.Node, match func(ast.Node) bool, fallback ast.Node) ast.Node {
+	searchLists := t.scopeSearchLists(entryNodes)
 	for _, list := range searchLists {
 		for _, n := range list {
 			if match(n) && t.TypeChecker.HasScopeForNode(n) {

--- a/forst/internal/transformer/go/scope_if_reparse_test.go
+++ b/forst/internal/transformer/go/scope_if_reparse_test.go
@@ -1,7 +1,6 @@
 package transformergo
 
 import (
-	"strings"
 	"testing"
 
 	"forst/internal/ast"
@@ -54,7 +53,7 @@ func findFunctionNodeForTransform(t *testing.T, nodes []ast.Node, name string) a
 
 func TestTransformIfNode_checkerBoundToDifferentAST(t *testing.T) {
 	t.Parallel()
-	_, tc, _ := parseIfAfterAssign(t)
+	nodesA, tc, _ := parseIfAfterAssign(t)
 
 	log := ast.SetupTestLogger(nil)
 	p := parser.NewTestParser(ifAfterAssignSrc, log)
@@ -69,11 +68,28 @@ func TestTransformIfNode_checkerBoundToDifferentAST(t *testing.T) {
 	}
 
 	tr := New(tc, log)
-	_, err = tr.transformIfNode(ifNodeB)
-	if err == nil {
-		t.Fatal("expected transformIfNode to fail when checker bound to different AST")
+	tr.entryNodes = nodesB
+	if _, err = tr.transformIfNode(ifNodeB); err != nil {
+		t.Fatalf("transformIfNode with resolve: %v", err)
 	}
-	if !strings.Contains(err.Error(), "if scope restore") {
-		t.Fatalf("transformIfNode error = %q, want if scope restore", err)
+	_ = nodesA
+}
+
+func TestTransformForstFileToGo_reparsedTestIfSucceeds(t *testing.T) {
+	t.Parallel()
+	nodesA, tc, _ := parseIfAfterAssign(t)
+
+	log := ast.SetupTestLogger(nil)
+	p := parser.NewTestParser(ifAfterAssignSrc, log)
+	nodesB, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("re-parse B: %v", err)
 	}
+
+	tr := New(tc, log)
+	tr.entryNodes = nodesB
+	if _, err := tr.TransformForstFileToGo(nodesB); err != nil {
+		t.Fatalf("TransformForstFileToGo reparsed: %v", err)
+	}
+	_ = nodesA
 }

--- a/forst/internal/transformer/go/scope_if_reparse_test.go
+++ b/forst/internal/transformer/go/scope_if_reparse_test.go
@@ -1,0 +1,79 @@
+package transformergo
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/parser"
+	"forst/internal/typechecker"
+)
+
+const ifAfterAssignSrc = `package demo
+
+func f(cells []String, a Int): String {
+	x0 := cells[a]
+	if x0 == "" {
+		return ""
+	}
+	return x0
+}
+`
+
+func parseIfAfterAssign(t *testing.T) ([]ast.Node, *typechecker.TypeChecker, *ast.IfNode) {
+	t.Helper()
+	log := ast.SetupTestLogger(nil)
+	p := parser.NewTestParser(ifAfterAssignSrc, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := typechecker.New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	fn := findFunctionNodeForTransform(t, nodes, "f")
+	ifn, ok := fn.Body[1].(*ast.IfNode)
+	if !ok {
+		t.Fatalf("body[1] want *IfNode, got %T", fn.Body[1])
+	}
+	return nodes, tc, ifn
+}
+
+func findFunctionNodeForTransform(t *testing.T, nodes []ast.Node, name string) ast.FunctionNode {
+	t.Helper()
+	for _, n := range nodes {
+		fn, ok := n.(ast.FunctionNode)
+		if ok && fn.Ident.ID == ast.Identifier(name) {
+			return fn
+		}
+	}
+	t.Fatalf("function %q not found", name)
+	return ast.FunctionNode{}
+}
+
+func TestTransformIfNode_checkerBoundToDifferentAST(t *testing.T) {
+	t.Parallel()
+	_, tc, _ := parseIfAfterAssign(t)
+
+	log := ast.SetupTestLogger(nil)
+	p := parser.NewTestParser(ifAfterAssignSrc, log)
+	nodesB, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	fnB := findFunctionNodeForTransform(t, nodesB, "f")
+	ifNodeB, ok := fnB.Body[1].(*ast.IfNode)
+	if !ok {
+		t.Fatalf("body[1] want *IfNode, got %T", fnB.Body[1])
+	}
+
+	tr := New(tc, log)
+	_, err = tr.transformIfNode(ifNodeB)
+	if err == nil {
+		t.Fatal("expected transformIfNode to fail when checker bound to different AST")
+	}
+	if !strings.Contains(err.Error(), "if scope restore") {
+		t.Fatalf("transformIfNode error = %q, want if scope restore", err)
+	}
+}

--- a/forst/internal/transformer/go/scope_typeguard_test.go
+++ b/forst/internal/transformer/go/scope_typeguard_test.go
@@ -1,0 +1,117 @@
+package transformergo
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/parser"
+	"forst/internal/typechecker"
+	goast "go/ast"
+)
+
+const loggedInGuardSrc = `package main
+
+type AppContext = {
+  sessionId: *String,
+  user: *String,
+}
+
+is (ctx AppContext) LoggedIn() {
+  ensure ctx.sessionId is Present()
+  ensure ctx.user is Present()
+}
+`
+
+func parseLoggedInGuard(t *testing.T) ([]ast.Node, *typechecker.TypeChecker, ast.Node, ast.TypeGuardNode) {
+	t.Helper()
+	log := ast.SetupTestLogger(nil)
+	p := parser.NewTestParser(loggedInGuardSrc, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := typechecker.New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	var parseNode ast.Node
+	var guard ast.TypeGuardNode
+	for _, n := range nodes {
+		switch g := n.(type) {
+		case ast.TypeGuardNode:
+			parseNode = n
+			guard = g
+		case *ast.TypeGuardNode:
+			if g != nil {
+				parseNode = n
+				guard = *g
+			}
+		}
+		if parseNode != nil {
+			break
+		}
+	}
+	if parseNode == nil {
+		t.Fatal("LoggedIn guard not found in parse nodes")
+	}
+	return nodes, tc, parseNode, guard
+}
+
+func TestResolveTypeGuardScopeNode_defsHeapCopy(t *testing.T) {
+	t.Parallel()
+	nodes, tc, parseNode, guard := parseLoggedInGuard(t)
+
+	if !tc.HasScopeForNode(parseNode) {
+		t.Fatal("expected scope registered on parse node")
+	}
+
+	guardCopy := new(ast.TypeGuardNode)
+	*guardCopy = guard
+	tc.Defs[ast.TypeIdent("LoggedIn")] = guardCopy
+
+	if tc.HasScopeForNode(ast.Node(*guardCopy)) {
+		t.Fatal("Defs heap copy must not have registered scope")
+	}
+	if err := tc.RestoreScope(ast.Node(*guardCopy)); err == nil {
+		t.Fatal("RestoreScope on Defs copy should fail")
+	}
+
+	tr := New(tc, nil)
+	resolved := tr.resolveTypeGuardScopeNode(nodes, *guardCopy)
+	if !tc.HasScopeForNode(resolved) {
+		t.Fatalf("resolved node %T has no scope", resolved)
+	}
+	if err := tc.RestoreScope(resolved); err != nil {
+		t.Fatalf("RestoreScope resolved: %v", err)
+	}
+}
+
+func TestTransformForstFileToGo_loggedInFromDefsCopy(t *testing.T) {
+	t.Parallel()
+	nodes, tc, _, guard := parseLoggedInGuard(t)
+
+	guardCopy := new(ast.TypeGuardNode)
+	*guardCopy = guard
+	tc.Defs[ast.TypeIdent("LoggedIn")] = guardCopy
+
+	tr := New(tc, nil)
+	goFile, err := tr.TransformForstFileToGo(nodes)
+	if err != nil {
+		t.Fatalf("TransformForstFileToGo: %v", err)
+	}
+
+	foundGuard := false
+	for _, d := range goFile.Decls {
+		fn, ok := d.(*goast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if len(fn.Name.Name) >= 2 && fn.Name.Name[0] == 'G' && fn.Name.Name[1] == '_' {
+			foundGuard = true
+			break
+		}
+	}
+	if !foundGuard {
+		t.Fatal("expected emitted G_ type guard function for LoggedIn")
+	}
+}

--- a/forst/internal/transformer/go/scope_with_test.go
+++ b/forst/internal/transformer/go/scope_with_test.go
@@ -1,0 +1,162 @@
+package transformergo
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/parser"
+	"forst/internal/typechecker"
+)
+
+const withHostSrc = `package demo
+
+type Logger = {info(msg String)}
+
+type NopLogger = {}
+
+func (NopLogger) info(msg String) {}
+
+func host() {
+	with { Logger: &NopLogger{} } {
+		use logger: Logger
+		logger.info("hi")
+	}
+}
+`
+
+func parseWithHost(t *testing.T) ([]ast.Node, *typechecker.TypeChecker, ast.Node, ast.WithNode) {
+	t.Helper()
+	log := ast.SetupTestLogger(nil)
+	p := parser.NewTestParser(withHostSrc, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tc := typechecker.New(log, false)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	var withNode ast.Node
+	var with ast.WithNode
+	for _, n := range nodes {
+		fn, ok := n.(ast.FunctionNode)
+		if !ok || fn.Ident.ID != "host" {
+			continue
+		}
+		for _, stmt := range fn.Body {
+			if w, ok := stmt.(ast.WithNode); ok {
+				withNode = stmt
+				with = w
+				break
+			}
+		}
+	}
+	if withNode == nil {
+		t.Fatal("with node not found")
+	}
+	return nodes, tc, withNode, with
+}
+
+func TestTransformWithStatements_parseNodeScope(t *testing.T) {
+	t.Parallel()
+	_, tc, withNode, with := parseWithHost(t)
+	tr := New(tc, nil)
+
+	stmts, err := tr.transformWithStatements(withNode, with)
+	if err != nil {
+		t.Fatalf("transformWithStatements: %v", err)
+	}
+	if len(stmts) == 0 {
+		t.Fatal("expected non-empty with body stmts")
+	}
+}
+
+func TestResolveWithScopeNode_reparseFindsTypecheckScope(t *testing.T) {
+	t.Parallel()
+	parseOnce := func() []ast.Node {
+		log := ast.SetupTestLogger(nil)
+		p := parser.NewTestParser(withHostSrc, log)
+		nodes, err := p.ParseFile()
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		return nodes
+	}
+	findWith := func(nodes []ast.Node) (ast.Node, ast.WithNode) {
+		for _, n := range nodes {
+			fn, ok := n.(ast.FunctionNode)
+			if !ok || fn.Ident.ID != "host" {
+				continue
+			}
+			for _, stmt := range fn.Body {
+				if w, ok := stmt.(ast.WithNode); ok {
+					return stmt, w
+				}
+			}
+		}
+		t.Fatal("with not found")
+		return nil, ast.WithNode{}
+	}
+
+	typecheckNodes := parseOnce()
+	tc := typechecker.New(nil, false)
+	if err := tc.CheckTypes(typecheckNodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	transformNodes := parseOnce()
+	withStmt, with := findWith(transformNodes)
+	tr := New(tc, nil)
+	tr.entryNodes = transformNodes
+
+	resolved := tr.resolveWithScopeNode(transformNodes, with)
+	if !tc.HasScopeForNode(resolved) {
+		tcWith, _ := findWith(typecheckNodes)
+		t.Fatalf("resolved=%s hasScope=%v typecheckWith=%s hasTcScope=%v", resolved, tc.HasScopeForNode(resolved), tcWith, tc.HasScopeForNode(tcWith))
+	}
+	if !tc.HasScopeForNode(withStmt) {
+		_, err := tr.transformWithStatements(withStmt, with)
+		if err != nil {
+			t.Fatalf("transformWithStatements after resolve: %v", err)
+		}
+	}
+}
+
+func TestTransformWithStatements_reparseResolvesTypecheckScope(t *testing.T) {
+	t.Parallel()
+	log := ast.SetupTestLogger(nil)
+	parseOnce := func() []ast.Node {
+		p := parser.NewTestParser(withHostSrc, log)
+		nodes, err := p.ParseFile()
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		return nodes
+	}
+	typecheckNodes := parseOnce()
+	tc := typechecker.New(log, false)
+	if err := tc.CheckTypes(typecheckNodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	transformNodes := parseOnce()
+	var withStmt ast.Node
+	var with ast.WithNode
+	for _, n := range transformNodes {
+		fn, ok := n.(ast.FunctionNode)
+		if !ok || fn.Ident.ID != "host" {
+			continue
+		}
+		for _, stmt := range fn.Body {
+			if w, ok := stmt.(ast.WithNode); ok {
+				withStmt = stmt
+				with = w
+				break
+			}
+		}
+	}
+	tr := New(tc, nil)
+	tr.entryNodes = transformNodes
+	_, err := tr.transformWithStatements(withStmt, with)
+	if err != nil {
+		t.Fatalf("transformWithStatements after re-parse: %v", err)
+	}
+}

--- a/forst/internal/transformer/go/shape_context_typeguard_test.go
+++ b/forst/internal/transformer/go/shape_context_typeguard_test.go
@@ -438,7 +438,7 @@ is (password Password) Strong(min Int) {
 		t.Fatal("expected parsed type guard")
 	}
 
-	decl, err := tr.transformTypeGuard(guard)
+	decl, err := tr.transformTypeGuard(typeGuardScopeNode(nodes, guard), guard)
 	if err != nil {
 		t.Fatalf("transformTypeGuard: %v", err)
 	}

--- a/forst/internal/transformer/go/statement.go
+++ b/forst/internal/transformer/go/statement.go
@@ -628,7 +628,7 @@ func (t *Transformer) transformStatement(stmt ast.Node) (goast.Stmt, error) {
 	case ast.UseNode:
 		return t.transformUseStatement(s)
 	case ast.WithNode:
-		withStmts, err := t.transformWithStatements(s)
+		withStmts, err := t.transformWithStatements(stmt, s)
 		if err != nil {
 			return nil, err
 		}

--- a/forst/internal/transformer/go/test_utils.go
+++ b/forst/internal/transformer/go/test_utils.go
@@ -21,6 +21,16 @@ func setupTransformer(tc *typechecker.TypeChecker, log *logrus.Logger) *Transfor
 	return New(tc, log)
 }
 
+// functionScopeNode returns the ast.Node from nodes that owns fn's scope (same interface as typecheck).
+func functionScopeNode(nodes []ast.Node, fn ast.FunctionNode) ast.Node {
+	for _, n := range nodes {
+		if f, ok := n.(ast.FunctionNode); ok && f.Ident.ID == fn.Ident.ID {
+			return n
+		}
+	}
+	return ast.Node(fn)
+}
+
 // Helper function to check if a string contains a substring
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)

--- a/forst/internal/transformer/go/transformer.go
+++ b/forst/internal/transformer/go/transformer.go
@@ -173,7 +173,7 @@ func (t *Transformer) TransformForstFileToGo(nodes []ast.Node) (*goast.File, err
 			decl := t.transformImportGroup(n)
 			t.Output.AddImportGroup(decl)
 		case ast.FunctionNode:
-			decl, err := t.transformFunction(n)
+			decl, err := t.transformFunction(node, n)
 			if err != nil {
 				return nil, fmt.Errorf("failed to transform function %s: %w", n.GetIdent(), err)
 			}

--- a/forst/internal/transformer/go/transformer.go
+++ b/forst/internal/transformer/go/transformer.go
@@ -117,7 +117,8 @@ func (t *Transformer) TransformForstFileToGo(nodes []ast.Node) (*goast.File, err
 					"guard":    def.GetIdent(),
 					"function": "TransformForstFileToGo",
 				}).Debug("Processing type guard definition (value)")
-				decl, err := t.transformTypeGuard(def)
+				scopeNode := t.resolveTypeGuardScopeNode(nodes, def)
+				decl, err := t.transformTypeGuard(scopeNode, def)
 				if err != nil {
 					return nil, fmt.Errorf("failed to transform type guard %s: %w", def.GetIdent(), err)
 				}
@@ -129,7 +130,8 @@ func (t *Transformer) TransformForstFileToGo(nodes []ast.Node) (*goast.File, err
 					"guard":    def.GetIdent(),
 					"function": "TransformForstFileToGo",
 				}).Debug("Processing type guard definition (pointer)")
-				decl, err := t.transformTypeGuard(*def)
+				scopeNode := t.resolveTypeGuardScopeNode(nodes, *def)
+				decl, err := t.transformTypeGuard(scopeNode, *def)
 				if err != nil {
 					return nil, fmt.Errorf("failed to transform type guard %s: %w", def.GetIdent(), err)
 				}
@@ -173,7 +175,8 @@ func (t *Transformer) TransformForstFileToGo(nodes []ast.Node) (*goast.File, err
 			decl := t.transformImportGroup(n)
 			t.Output.AddImportGroup(decl)
 		case ast.FunctionNode:
-			decl, err := t.transformFunction(node, n)
+			scopeNode := t.resolveFunctionScopeNode(nodes, n)
+			decl, err := t.transformFunction(scopeNode, n)
 			if err != nil {
 				return nil, fmt.Errorf("failed to transform function %s: %w", n.GetIdent(), err)
 			}

--- a/forst/internal/transformer/go/transformer.go
+++ b/forst/internal/transformer/go/transformer.go
@@ -53,6 +53,8 @@ type Transformer struct {
 
 	// OmitPackageTypeDefs skips emitting package types (when z_forst_gen.go already defines them).
 	OmitPackageTypeDefs bool
+	// entryNodes is the slice passed to TransformForstFileToGo (for scope-node fallback lookups).
+	entryNodes []ast.Node
 }
 
 // New creates a new Transformer
@@ -83,6 +85,7 @@ func (t *Transformer) SetModuleResult(m *modulecheck.ModuleResult) {
 // TransformForstFileToGo converts a Forst AST to a Go AST
 // The nodes should already have their types inferred/checked
 func (t *Transformer) TransformForstFileToGo(nodes []ast.Node) (*goast.File, error) {
+	t.entryNodes = nodes
 	// First, collect and register shape types from type definitions
 	if err := t.defineShapeTypes(); err != nil {
 		return nil, err

--- a/forst/internal/transformer/go/typeguard.go
+++ b/forst/internal/transformer/go/typeguard.go
@@ -201,7 +201,7 @@ func (t *Transformer) transformTypeGuard(scopeNode ast.Node, guard ast.TypeGuard
 		case ast.CommentNode:
 			bodyStmts = append(bodyStmts, &goast.EmptyStmt{})
 		case *ast.IfNode:
-			if err := t.restoreScope(n); err != nil {
+			if err := t.restoreScope(t.resolveIfScopeNode(n)); err != nil {
 				return nil, fmt.Errorf("failed to restore if scope in type guard: %s", err)
 			}
 
@@ -218,7 +218,7 @@ func (t *Transformer) transformTypeGuard(scopeNode ast.Node, guard ast.TypeGuard
 			var elseIfs []goast.Stmt
 			for i := range n.ElseIfs {
 				elseIf := &n.ElseIfs[i]
-				if err := t.restoreScope(elseIf); err != nil {
+				if err := t.restoreScope(t.resolveElseIfScopeNode(elseIf)); err != nil {
 					return nil, fmt.Errorf("failed to restore else-if scope in type guard: %s", err)
 				}
 
@@ -239,7 +239,7 @@ func (t *Transformer) transformTypeGuard(scopeNode ast.Node, guard ast.TypeGuard
 			// Transform else block
 			var elseBody *goast.BlockStmt
 			if n.Else != nil {
-				if err := t.restoreScope(n.Else); err != nil {
+				if err := t.restoreScope(t.resolveElseBlockScopeNode(n.Else)); err != nil {
 					return nil, fmt.Errorf("failed to restore else scope in type guard: %s", err)
 				}
 

--- a/forst/internal/transformer/go/typeguard.go
+++ b/forst/internal/transformer/go/typeguard.go
@@ -120,7 +120,7 @@ func (t *Transformer) transformTypeGuardParams(params []ast.ParamNode) (*goast.F
 }
 
 // transformTypeGuard transforms a type guard into a Go function
-func (t *Transformer) transformTypeGuard(guard ast.TypeGuardNode) (*goast.FuncDecl, error) {
+func (t *Transformer) transformTypeGuard(scopeNode ast.Node, guard ast.TypeGuardNode) (*goast.FuncDecl, error) {
 	// Create function name with G_ prefix
 	guardHash, err := t.TypeChecker.Hasher.HashNode(guard)
 	if err != nil {
@@ -172,6 +172,10 @@ func (t *Transformer) transformTypeGuard(guard ast.TypeGuardNode) (*goast.FuncDe
 		}, nil
 	}
 
+	if !t.TypeChecker.HasScopeForNode(scopeNode) {
+		return nil, fmt.Errorf("type guard %s: no registered scope for transform node %s", guard.Ident, scopeNode)
+	}
+
 	// Transform subject parameter
 	subjectParam, err := t.transformTypeGuardParams([]ast.ParamNode{guard.Subject})
 	if err != nil {
@@ -190,14 +194,14 @@ func (t *Transformer) transformTypeGuard(guard ast.TypeGuardNode) (*goast.FuncDe
 	var bodyStmts []goast.Stmt
 	for _, node := range guard.Body {
 		// Ensure the type guard parameter scope is active
-		if err := t.restoreScope(guard); err != nil {
+		if err := t.restoreScope(scopeNode); err != nil {
 			return nil, fmt.Errorf("failed to restore type guard parameter scope: %s", err)
 		}
 		switch n := node.(type) {
 		case ast.CommentNode:
 			bodyStmts = append(bodyStmts, &goast.EmptyStmt{})
 		case *ast.IfNode:
-			if err := t.restoreScope(*n); err != nil {
+			if err := t.restoreScope(n); err != nil {
 				return nil, fmt.Errorf("failed to restore if scope in type guard: %s", err)
 			}
 
@@ -212,7 +216,8 @@ func (t *Transformer) transformTypeGuard(guard ast.TypeGuardNode) (*goast.FuncDe
 
 			// Transform else-if blocks
 			var elseIfs []goast.Stmt
-			for _, elseIf := range n.ElseIfs {
+			for i := range n.ElseIfs {
+				elseIf := &n.ElseIfs[i]
 				if err := t.restoreScope(elseIf); err != nil {
 					return nil, fmt.Errorf("failed to restore else-if scope in type guard: %s", err)
 				}
@@ -234,7 +239,7 @@ func (t *Transformer) transformTypeGuard(guard ast.TypeGuardNode) (*goast.FuncDe
 			// Transform else block
 			var elseBody *goast.BlockStmt
 			if n.Else != nil {
-				if err := t.restoreScope(*n.Else); err != nil {
+				if err := t.restoreScope(n.Else); err != nil {
 					return nil, fmt.Errorf("failed to restore else scope in type guard: %s", err)
 				}
 
@@ -255,7 +260,7 @@ func (t *Transformer) transformTypeGuard(guard ast.TypeGuardNode) (*goast.FuncDe
 			})
 
 		case ast.EnsureNode:
-			if err := t.restoreScope(n); err != nil {
+			if err := t.restoreScope(node); err != nil {
 				return nil, fmt.Errorf("failed to restore ensure statement scope in type guard: %s", err)
 			}
 

--- a/forst/internal/transformer/go/typeguard_test.go
+++ b/forst/internal/transformer/go/typeguard_test.go
@@ -163,11 +163,12 @@ func TestTransformFunctionCallWithShapeLiteralArgument_UsesExpectedType(t *testi
 	delete(tc.Defs, ast.TypeIdent(typeName))
 
 	// Check types for the functions only (top-level *ast.ShapeNode is not a valid infer node).
-	if err := tr.TypeChecker.CheckTypes([]ast.Node{fFunc, mainFunc}); err != nil {
+	nodes := []ast.Node{fFunc, mainFunc}
+	if err := tr.TypeChecker.CheckTypes(nodes); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := tr.TypeChecker.RestoreScope(mainFunc); err != nil {
+	if err := tr.TypeChecker.RestoreScope(functionScopeNode(nodes, mainFunc)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -251,11 +252,12 @@ func TestTransformFunctionCallWithShapeLiteralArgument_UndefinedTypeError(t *tes
 	// Do NOT register the type T_ShapeArg in tc.Defs (simulate missing type)
 
 	// Check types for all nodes
-	if err := tr.TypeChecker.CheckTypes([]ast.Node{fFunc, mainFunc}); err != nil {
+	nodes := []ast.Node{fFunc, mainFunc}
+	if err := tr.TypeChecker.CheckTypes(nodes); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := tr.TypeChecker.RestoreScope(mainFunc); err != nil {
+	if err := tr.TypeChecker.RestoreScope(functionScopeNode(nodes, mainFunc)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -399,11 +401,12 @@ func TestTransformFunctionCallWithShapeLiteralArgument_UsesParameterTypeDef(t *t
 	}
 
 	// Check types for all nodes
-	if err := tr.TypeChecker.CheckTypes([]ast.Node{fFunc, mainFunc}); err != nil {
+	nodes := []ast.Node{fFunc, mainFunc}
+	if err := tr.TypeChecker.CheckTypes(nodes); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := tr.TypeChecker.RestoreScope(mainFunc); err != nil {
+	if err := tr.TypeChecker.RestoreScope(functionScopeNode(nodes, mainFunc)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -602,11 +605,12 @@ func TestTransformFunctionCallWithShapeLiteralArgument_UsesInferredParameterType
 	}
 
 	// Check types for all nodes
-	if err := tr.TypeChecker.CheckTypes([]ast.Node{fFunc, mainFunc}); err != nil {
+	nodes := []ast.Node{fFunc, mainFunc}
+	if err := tr.TypeChecker.CheckTypes(nodes); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := tr.TypeChecker.RestoreScope(mainFunc); err != nil {
+	if err := tr.TypeChecker.RestoreScope(functionScopeNode(nodes, mainFunc)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/forst/internal/typechecker/bench_test.go
+++ b/forst/internal/typechecker/bench_test.go
@@ -70,14 +70,16 @@ func BenchmarkRestoreScope_functionBody(b *testing.B) {
 		Ident: ast.Ident{ID: "benchFn"},
 		Body:  body,
 	}
+	nodes := []ast.Node{fn}
 	tc := benchTypeChecker(b)
-	if err := tc.CollectTypes([]ast.Node{fn}); err != nil {
+	if err := tc.CollectTypes(nodes); err != nil {
 		b.Fatalf("CollectTypes: %v", err)
 	}
+	scopeNode := nodes[0]
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := tc.RestoreScope(fn); err != nil {
+		if err := tc.RestoreScope(scopeNode); err != nil {
 			b.Fatalf("RestoreScope: %v", err)
 		}
 	}

--- a/forst/internal/typechecker/collect.go
+++ b/forst/internal/typechecker/collect.go
@@ -40,80 +40,19 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 		}).Debug("Collecting type definition")
 		tc.registerType(n)
 	case ast.FunctionNode:
-		tc.pushScope(node)
-
-		if n.Receiver != nil {
-			if n.Receiver.Ident.ID != "" {
-				tc.storeSymbol(n.Receiver.Ident.ID, []ast.TypeNode{n.Receiver.Type}, SymbolVariable)
-			}
-		}
-
-		for _, param := range n.Params {
-			switch p := param.(type) {
-			case ast.SimpleParamNode:
-				tc.storeSymbol(p.Ident.ID, []ast.TypeNode{p.Type}, SymbolVariable)
-		case ast.DestructuredParamNode:
-			tc.registerDestructuredParamSymbols(p.Fields, p.Type, SymbolVariable)
-			}
-		}
-
-		for _, node := range n.Body {
-			if err := tc.collectExplicitTypes(node); err != nil {
-				return err
-			}
-		}
-
-		tc.registerFunction(n)
-		tc.popScope()
-
-		if n.Receiver == nil {
-			// Store package-level function symbol
-			tc.storeSymbol(n.Ident.ID, n.ReturnTypes, SymbolFunction)
-		}
+		return tc.collectFunctionNode(node, n)
 	case *ast.FunctionNode:
-		return tc.collectExplicitTypes(*n)
+		if n == nil {
+			return nil
+		}
+		return tc.collectFunctionNode(node, *n)
 	case ast.TypeGuardNode:
-		tc.pushScope(node)
-
-		// Register type guard symbol in global scope
-		tc.globalScope().RegisterSymbol(n.Ident, []ast.TypeNode{{Ident: ast.TypeVoid}}, SymbolTypeGuard)
-
-		// Register parameters in the current scope
-		for _, param := range n.Parameters() {
-			switch p := param.(type) {
-			case ast.SimpleParamNode:
-				tc.log.WithFields(logrus.Fields{
-					"node":     p.String(),
-					"function": "collectExplicitTypes",
-				}).Debug("Storing symbol for simple param of type guard")
-				tc.storeSymbol(p.Ident.ID, []ast.TypeNode{p.Type}, SymbolParameter)
-		case ast.DestructuredParamNode:
-			tc.registerDestructuredParamSymbols(p.Fields, p.Type, SymbolParameter)
-			tc.log.WithFields(logrus.Fields{
-				"node":     p.String(),
-				"function": "collectExplicitTypes",
-			}).Debug("Registered destructured type guard param fields")
-			}
-		}
-
-		// Recursively collect explicit types for each node in the body
-		for _, bodyNode := range n.Body {
-			if err := tc.collectExplicitTypes(bodyNode); err != nil {
-				return err
-			}
-		}
-
-		// Register the type guard in the type checker (heap-stable pointer in Defs)
-		guard := new(ast.TypeGuardNode)
-		*guard = n
-		tc.registerTypeGuard(guard)
-
-		tc.popScope()
+		return tc.collectTypeGuardNode(node, n)
 	case *ast.TypeGuardNode:
 		if n == nil {
 			return nil
 		}
-		return tc.collectExplicitTypes(*n)
+		return tc.collectTypeGuardNode(node, *n)
 	case ast.EnsureNode:
 		tc.log.WithFields(logrus.Fields{
 			"node":     n.String(),
@@ -257,6 +196,77 @@ func (tc *TypeChecker) collectForNode(n *ast.ForNode) error {
 			return err
 		}
 	}
+
+	tc.popScope()
+	return nil
+}
+
+func (tc *TypeChecker) collectFunctionNode(scopeNode ast.Node, n ast.FunctionNode) error {
+	tc.pushScope(scopeNode)
+	tc.registerFunctionScope(n.Ident.ID, scopeNode)
+
+	if n.Receiver != nil {
+		if n.Receiver.Ident.ID != "" {
+			tc.storeSymbol(n.Receiver.Ident.ID, []ast.TypeNode{n.Receiver.Type}, SymbolVariable)
+		}
+	}
+
+	for _, param := range n.Params {
+		switch p := param.(type) {
+		case ast.SimpleParamNode:
+			tc.storeSymbol(p.Ident.ID, []ast.TypeNode{p.Type}, SymbolVariable)
+		case ast.DestructuredParamNode:
+			tc.registerDestructuredParamSymbols(p.Fields, p.Type, SymbolVariable)
+		}
+	}
+
+	for _, bodyNode := range n.Body {
+		if err := tc.collectExplicitTypes(bodyNode); err != nil {
+			return err
+		}
+	}
+
+	tc.registerFunction(n)
+	tc.popScope()
+
+	if n.Receiver == nil {
+		tc.storeSymbol(n.Ident.ID, n.ReturnTypes, SymbolFunction)
+	}
+	return nil
+}
+
+func (tc *TypeChecker) collectTypeGuardNode(scopeNode ast.Node, n ast.TypeGuardNode) error {
+	tc.pushScope(scopeNode)
+	tc.registerTypeGuardScope(n.Ident, scopeNode)
+
+	tc.globalScope().RegisterSymbol(n.Ident, []ast.TypeNode{{Ident: ast.TypeVoid}}, SymbolTypeGuard)
+
+	for _, param := range n.Parameters() {
+		switch p := param.(type) {
+		case ast.SimpleParamNode:
+			tc.log.WithFields(logrus.Fields{
+				"node":     p.String(),
+				"function": "collectTypeGuardNode",
+			}).Debug("Storing symbol for simple param of type guard")
+			tc.storeSymbol(p.Ident.ID, []ast.TypeNode{p.Type}, SymbolParameter)
+		case ast.DestructuredParamNode:
+			tc.registerDestructuredParamSymbols(p.Fields, p.Type, SymbolParameter)
+			tc.log.WithFields(logrus.Fields{
+				"node":     p.String(),
+				"function": "collectTypeGuardNode",
+			}).Debug("Registered destructured type guard param fields")
+		}
+	}
+
+	for _, bodyNode := range n.Body {
+		if err := tc.collectExplicitTypes(bodyNode); err != nil {
+			return err
+		}
+	}
+
+	guard := new(ast.TypeGuardNode)
+	*guard = n
+	tc.registerTypeGuard(guard)
 
 	tc.popScope()
 	return nil

--- a/forst/internal/typechecker/collect.go
+++ b/forst/internal/typechecker/collect.go
@@ -40,7 +40,7 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 		}).Debug("Collecting type definition")
 		tc.registerType(n)
 	case ast.FunctionNode:
-		tc.pushScope(n)
+		tc.pushScope(node)
 
 		if n.Receiver != nil {
 			if n.Receiver.Ident.ID != "" {
@@ -73,15 +73,13 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 	case *ast.FunctionNode:
 		return tc.collectExplicitTypes(*n)
 	case ast.TypeGuardNode:
-		guard := new(ast.TypeGuardNode)
-		*guard = n
-		tc.pushScope(guard)
+		tc.pushScope(node)
 
 		// Register type guard symbol in global scope
-		tc.globalScope().RegisterSymbol(guard.Ident, []ast.TypeNode{{Ident: ast.TypeVoid}}, SymbolTypeGuard)
+		tc.globalScope().RegisterSymbol(n.Ident, []ast.TypeNode{{Ident: ast.TypeVoid}}, SymbolTypeGuard)
 
 		// Register parameters in the current scope
-		for _, param := range guard.Parameters() {
+		for _, param := range n.Parameters() {
 			switch p := param.(type) {
 			case ast.SimpleParamNode:
 				tc.log.WithFields(logrus.Fields{
@@ -99,13 +97,15 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 		}
 
 		// Recursively collect explicit types for each node in the body
-		for _, node := range guard.Body {
-			if err := tc.collectExplicitTypes(node); err != nil {
+		for _, bodyNode := range n.Body {
+			if err := tc.collectExplicitTypes(bodyNode); err != nil {
 				return err
 			}
 		}
 
 		// Register the type guard in the type checker (heap-stable pointer in Defs)
+		guard := new(ast.TypeGuardNode)
+		*guard = n
 		tc.registerTypeGuard(guard)
 
 		tc.popScope()
@@ -119,7 +119,7 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 			"node":     n.String(),
 			"function": "collectExplicitTypes",
 		}).Debug("Storing scope for ensure")
-		tc.pushScope(n)
+		tc.pushScope(node)
 
 		if n.Block != nil {
 			tc.pushScope(n.Block)
@@ -135,7 +135,7 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 	case ast.UseNode:
 		return nil
 	case ast.WithNode:
-		tc.pushScope(n)
+		tc.pushScope(node)
 		for _, node := range n.Body {
 			if err := tc.collectExplicitTypes(node); err != nil {
 				return err
@@ -161,6 +161,13 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 			return err
 		}
 	case ast.ElseIfNode:
+		if err := tc.collectExplicitTypes(&n); err != nil {
+			return err
+		}
+	case *ast.ElseIfNode:
+		if n == nil {
+			return nil
+		}
 		tc.log.WithFields(logrus.Fields{
 			"node":     n.String(),
 			"function": "collectExplicitTypes",
@@ -178,8 +185,6 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 		if n == nil {
 			return nil
 		}
-		return tc.collectExplicitTypes(*n)
-	case ast.ElseBlockNode:
 		tc.log.WithFields(logrus.Fields{
 			"node":     n.String(),
 			"function": "collectExplicitTypes",
@@ -193,6 +198,9 @@ func (tc *TypeChecker) collectExplicitTypes(node ast.Node) error {
 		}
 
 		tc.popScope()
+	case ast.ElseBlockNode:
+		eb := n
+		return tc.collectExplicitTypes(&eb)
 	}
 
 	return nil
@@ -211,8 +219,8 @@ func (tc *TypeChecker) collectIfNode(n *ast.IfNode) error {
 		}
 	}
 
-	for _, node := range n.ElseIfs {
-		if err := tc.collectExplicitTypes(node); err != nil {
+	for i := range n.ElseIfs {
+		if err := tc.collectExplicitTypes(&n.ElseIfs[i]); err != nil {
 			return err
 		}
 	}

--- a/forst/internal/typechecker/collect_order.go
+++ b/forst/internal/typechecker/collect_order.go
@@ -10,30 +10,28 @@ import "forst/internal/ast"
 // The inference pass still uses the original slice order (see CheckTypes).
 func partitionTopLevelForCollect(nodes []ast.Node) []ast.Node {
 	var pkg, imports, typeDefs, packageVars, typeGuards, funcs, rest []ast.Node
-	for _, n := range nodes {
-		switch n := n.(type) {
+	for _, node := range nodes {
+		switch n := node.(type) {
 		case ast.PackageNode:
-			pkg = append(pkg, n)
+			pkg = append(pkg, node)
 		case ast.ImportNode:
-			imports = append(imports, n)
+			imports = append(imports, node)
 		case ast.ImportGroupNode:
-			imports = append(imports, n)
+			imports = append(imports, node)
 		case ast.TypeDefNode:
-			typeDefs = append(typeDefs, n)
+			typeDefs = append(typeDefs, node)
 		case ast.AssignmentNode:
 			if n.IsPackageLevel {
-				packageVars = append(packageVars, n)
+				packageVars = append(packageVars, node)
 			} else {
-				rest = append(rest, n)
+				rest = append(rest, node)
 			}
-		case ast.TypeGuardNode:
-			typeGuards = append(typeGuards, n)
-		case ast.FunctionNode:
-			funcs = append(funcs, n)
-		case *ast.FunctionNode:
-			funcs = append(funcs, n)
+		case ast.TypeGuardNode, *ast.TypeGuardNode:
+			typeGuards = append(typeGuards, node)
+		case ast.FunctionNode, *ast.FunctionNode:
+			funcs = append(funcs, node)
 		default:
-			rest = append(rest, n)
+			rest = append(rest, node)
 		}
 	}
 	out := make([]ast.Node, 0, len(nodes))

--- a/forst/internal/typechecker/compat_memo.go
+++ b/forst/internal/typechecker/compat_memo.go
@@ -1,0 +1,79 @@
+package typechecker
+
+import (
+	"fmt"
+	"forst/internal/ast"
+	"strings"
+
+	logrus "github.com/sirupsen/logrus"
+)
+
+type compatKey struct {
+	actual   string
+	expected string
+}
+
+func compatKeyFor(actual, expected ast.TypeNode) compatKey {
+	return compatKey{
+		actual:   typeNodeCompatKey(actual),
+		expected: typeNodeCompatKey(expected),
+	}
+}
+
+func typeNodeCompatKey(t ast.TypeNode) string {
+	var b strings.Builder
+	b.WriteString(string(t.Ident))
+	b.WriteByte(':')
+	b.WriteString(fmt.Sprint(t.TypeKind))
+	if t.Assertion != nil && t.Assertion.BaseType != nil {
+		b.WriteByte('@')
+		b.WriteString(string(*t.Assertion.BaseType))
+	}
+	for _, p := range t.TypeParams {
+		b.WriteByte('[')
+		b.WriteString(typeNodeCompatKey(p))
+		b.WriteByte(']')
+	}
+	return b.String()
+}
+
+// IsTypeCompatible checks if a type is compatible with an expected type,
+// taking into account subtypes and type guards.
+func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNode) bool {
+	if a, ok := tc.expandTypeDefBinaryIfNeeded(actual); ok {
+		actual = a
+	}
+	if e, ok := tc.expandTypeDefBinaryIfNeeded(expected); ok {
+		expected = e
+	}
+	key := compatKeyFor(actual, expected)
+	if tc.compatMemo != nil {
+		if v, ok := tc.compatMemo[key]; ok {
+			return v
+		}
+	}
+	if tc.log.IsLevelEnabled(logrus.DebugLevel) {
+		tc.log.WithFields(logrus.Fields{
+			"actual":   actual.Ident,
+			"expected": expected.Ident,
+			"function": "IsTypeCompatible",
+		}).Debug("Checking type compatibility")
+	}
+	result := tc.isTypeCompatibleImpl(actual, expected)
+	if tc.compatMemo == nil {
+		tc.compatMemo = make(map[compatKey]bool)
+	}
+	tc.compatMemo[key] = result
+	return result
+}
+
+func (tc *TypeChecker) debugCompat(msg string, fields logrus.Fields) {
+	if !tc.log.IsLevelEnabled(logrus.DebugLevel) {
+		return
+	}
+	if fields == nil {
+		fields = logrus.Fields{}
+	}
+	fields["function"] = "IsTypeCompatible"
+	tc.log.WithFields(fields).Debug(msg)
+}

--- a/forst/internal/typechecker/compat_memo_test.go
+++ b/forst/internal/typechecker/compat_memo_test.go
@@ -27,28 +27,3 @@ func TestIsTypeCompatible_memoizesRepeatedPairs(t *testing.T) {
 		t.Fatal("second call should hit memo")
 	}
 }
-
-func TestShapeAliasIndex_resolvesStructuralHash(t *testing.T) {
-	t.Parallel()
-	tc := testTypeChecker(t)
-	userShape := ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
-		"name": {Type: &ast.TypeNode{Ident: ast.TypeString}},
-	}}
-	h, err := tc.Hasher.HashNode(userShape)
-	if err != nil {
-		t.Fatal(err)
-	}
-	hashIdent := h.ToTypeIdent()
-	tc.registerType(ast.TypeDefNode{
-		Ident: "User",
-		Expr:  ast.TypeDefShapeExpr{Shape: userShape},
-	})
-	tc.Defs[hashIdent] = ast.TypeDefNode{
-		Ident: hashIdent,
-		Expr:  ast.TypeDefShapeExpr{Shape: userShape},
-	}
-	resolved := tc.resolveAliasedType(ast.TypeNode{Ident: hashIdent, TypeKind: ast.TypeKindHashBased})
-	if resolved.Ident != "User" {
-		t.Fatalf("resolveAliasedType(%s) = %s, want User", hashIdent, resolved.Ident)
-	}
-}

--- a/forst/internal/typechecker/compat_memo_test.go
+++ b/forst/internal/typechecker/compat_memo_test.go
@@ -1,0 +1,54 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestIsTypeCompatible_memoizesRepeatedPairs(t *testing.T) {
+	t.Parallel()
+	tc := testTypeChecker(t)
+	tc.compatMemo = make(map[compatKey]bool)
+	actual := ast.TypeNode{Ident: ast.TypeInt}
+	expected := ast.TypeNode{Ident: ast.TypeInt}
+	if !tc.IsTypeCompatible(actual, expected) {
+		t.Fatal("Int should be compatible with Int")
+	}
+	key := compatKeyFor(actual, expected)
+	if len(tc.compatMemo) != 1 {
+		t.Fatalf("expected memo size 1, got %d", len(tc.compatMemo))
+	}
+	if !tc.compatMemo[key] {
+		t.Fatal("memo should record true")
+	}
+	// Force impl to panic if called again by corrupting memo hit path - just verify memo hit returns same
+	if !tc.IsTypeCompatible(actual, expected) {
+		t.Fatal("second call should hit memo")
+	}
+}
+
+func TestShapeAliasIndex_resolvesStructuralHash(t *testing.T) {
+	t.Parallel()
+	tc := testTypeChecker(t)
+	userShape := ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+		"name": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+	}}
+	h, err := tc.Hasher.HashNode(userShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashIdent := h.ToTypeIdent()
+	tc.registerType(ast.TypeDefNode{
+		Ident: "User",
+		Expr:  ast.TypeDefShapeExpr{Shape: userShape},
+	})
+	tc.Defs[hashIdent] = ast.TypeDefNode{
+		Ident: hashIdent,
+		Expr:  ast.TypeDefShapeExpr{Shape: userShape},
+	}
+	resolved := tc.resolveAliasedType(ast.TypeNode{Ident: hashIdent, TypeKind: ast.TypeKindHashBased})
+	if resolved.Ident != "User" {
+		t.Fatalf("resolveAliasedType(%s) = %s, want User", hashIdent, resolved.Ident)
+	}
+}

--- a/forst/internal/typechecker/completion_test.go
+++ b/forst/internal/typechecker/completion_test.go
@@ -102,17 +102,17 @@ func foo(a: Int) {
 	if err := tc.CheckTypes(nodes); err != nil {
 		t.Fatal(err)
 	}
-	var fooFn *ast.FunctionNode
+	var fooScope ast.Node
 	for _, n := range nodes {
 		if fn, ok := n.(ast.FunctionNode); ok && fn.Ident.ID == "foo" {
-			fooFn = &fn
+			fooScope = n
 			break
 		}
 	}
-	if fooFn == nil {
+	if fooScope == nil {
 		t.Fatal("foo not found")
 	}
-	if err := tc.RestoreScope(fooFn); err != nil {
+	if err := tc.RestoreScope(fooScope); err != nil {
 		t.Fatal(err)
 	}
 	ids := tc.VisibleVariableLikeSymbols()
@@ -145,14 +145,17 @@ func main() {
 	if err := tc.CheckTypes(nodes); err != nil {
 		t.Fatal(err)
 	}
-	var mainFn *ast.FunctionNode
+	var mainScope ast.Node
 	for _, n := range nodes {
 		if fn, ok := n.(ast.FunctionNode); ok && fn.Ident.ID == "main" {
-			mainFn = &fn
+			mainScope = n
 			break
 		}
 	}
-	if err := tc.RestoreScope(mainFn); err != nil {
+	if mainScope == nil {
+		t.Fatal("main not found")
+	}
+	if err := tc.RestoreScope(mainScope); err != nil {
 		t.Fatal(err)
 	}
 	types, err := tc.InferExpressionTypeForCompletion(ast.VariableNode{Ident: ast.Ident{ID: "y"}})

--- a/forst/internal/typechecker/go_builtins.go
+++ b/forst/internal/typechecker/go_builtins.go
@@ -6,22 +6,8 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
-// IsTypeCompatible checks if a type is compatible with an expected type,
-// taking into account subtypes and type guards
-func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNode) bool {
-	if a, ok := tc.expandTypeDefBinaryIfNeeded(actual); ok {
-		actual = a
-	}
-	if e, ok := tc.expandTypeDefBinaryIfNeeded(expected); ok {
-		expected = e
-	}
-
-	tc.log.WithFields(logrus.Fields{
-		"actual":   actual.Ident,
-		"expected": expected.Ident,
-		"function": "IsTypeCompatible",
-	}).Debug("Checking type compatibility")
-
+// isTypeCompatibleImpl implements compatibility checking without memoization.
+func (tc *TypeChecker) isTypeCompatibleImpl(actual ast.TypeNode, expected ast.TypeNode) bool {
 	// Same identifier: simple types match; generic built-ins must compare type parameters.
 	if actual.Ident == expected.Ident {
 		switch actual.Ident {
@@ -52,11 +38,11 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 			}
 			return true
 		default:
-			tc.log.WithFields(logrus.Fields{
-				"actual":   actual.Ident,
-				"expected": expected.Ident,
-				"function": "IsTypeCompatible",
-			}).Debug("Direct type match")
+			if tc.log.IsLevelEnabled(logrus.DebugLevel) {
+				tc.debugCompat("Direct type match", logrus.Fields{"actual":   actual.Ident,
+					"expected": expected.Ident,
+					"function": "IsTypeCompatible",})
+			}
 			return true
 		}
 	}
@@ -105,11 +91,9 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 	if expected.Ident == ast.TypeError {
 		if def, ok := tc.Defs[actual.Ident].(ast.TypeDefNode); ok {
 			if _, ok := def.Expr.(ast.TypeDefErrorExpr); ok {
-				tc.log.WithFields(logrus.Fields{
-					"actual":   actual.Ident,
+				tc.debugCompat("Nominal error type assignable to built-in Error", logrus.Fields{"actual":   actual.Ident,
 					"expected": expected.Ident,
-					"function": "IsTypeCompatible",
-				}).Debug("Nominal error type assignable to built-in Error")
+					"function": "IsTypeCompatible",})
 				return true
 			}
 		}
@@ -117,11 +101,9 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 
 	// Assigning to TypeObject mirrors Go assignability to interface{} / any (empty interface).
 	if expected.Ident == ast.TypeObject && actual.Ident != ast.TypeVoid {
-		tc.log.WithFields(logrus.Fields{
-			"actual":   actual.Ident,
+		tc.debugCompat("Actual type assignable to TypeObject", logrus.Fields{"actual":   actual.Ident,
 			"expected": expected.Ident,
-			"function": "IsTypeCompatible",
-		}).Debug("Actual type assignable to TypeObject")
+			"function": "IsTypeCompatible",})
 		return true
 	}
 
@@ -130,11 +112,9 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 	if expected.Ident == ast.TypePointer && len(expected.TypeParams) == 1 {
 		inner := expected.TypeParams[0]
 		if !isScalarTypeIdent(inner.Ident) && tc.IsTypeCompatible(actual, inner) {
-			tc.log.WithFields(logrus.Fields{
-				"actual":   actual.Ident,
+			tc.debugCompat("Actual type compatible with pointer element type", logrus.Fields{"actual":   actual.Ident,
 				"expected": expected.Ident,
-				"function": "IsTypeCompatible",
-			}).Debug("Actual type compatible with pointer element type")
+				"function": "IsTypeCompatible",})
 			return true
 		}
 	}
@@ -169,11 +149,9 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 				if typeDefExpr.Assertion != nil && typeDefExpr.Assertion.BaseType != nil {
 					baseType := ast.TypeNode{Ident: *typeDefExpr.Assertion.BaseType}
 					if tc.IsTypeCompatible(baseType, expected) {
-						tc.log.WithFields(logrus.Fields{
-							"actual":   actual.Ident,
+						tc.debugCompat("Actual type is alias of expected type", logrus.Fields{"actual":   actual.Ident,
 							"expected": expected.Ident,
-							"function": "IsTypeCompatible",
-						}).Debug("Actual type is alias of expected type")
+							"function": "IsTypeCompatible",})
 						return true
 					}
 				}
@@ -189,11 +167,9 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 				if typeDefExpr.Assertion != nil && typeDefExpr.Assertion.BaseType != nil {
 					baseType := ast.TypeNode{Ident: *typeDefExpr.Assertion.BaseType}
 					if tc.IsTypeCompatible(actual, baseType) {
-						tc.log.WithFields(logrus.Fields{
-							"actual":   actual.Ident,
+						tc.debugCompat("Expected type is alias of actual type", logrus.Fields{"actual":   actual.Ident,
 							"expected": expected.Ident,
-							"function": "IsTypeCompatible",
-						}).Debug("Expected type is alias of actual type")
+							"function": "IsTypeCompatible",})
 						return true
 					}
 				}
@@ -203,40 +179,32 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 
 	// Check for structural compatibility between hash-based types and user-defined types
 	if actualDef != nil && expectedDef != nil {
-		tc.log.WithFields(logrus.Fields{
-			"actual":   actual.Ident,
+		tc.debugCompat("Checking structural compatibility", logrus.Fields{"actual":   actual.Ident,
 			"expected": expected.Ident,
-			"function": "IsTypeCompatible",
-		}).Debug("Checking structural compatibility")
+			"function": "IsTypeCompatible",})
 
 		actualShape, actualShapeOk := tc.getShapeFromTypeDef(actualDef)
 		expectedShape, expectedShapeOk := tc.getShapeFromTypeDef(expectedDef)
 
-		tc.log.WithFields(logrus.Fields{
-			"actual":          actual.Ident,
+		tc.debugCompat("Shape extraction results", logrus.Fields{"actual":          actual.Ident,
 			"expected":        expected.Ident,
 			"actualShapeOk":   actualShapeOk,
 			"expectedShapeOk": expectedShapeOk,
-			"function":        "IsTypeCompatible",
-		}).Debug("Shape extraction results")
+			"function":        "IsTypeCompatible",})
 
 		if actualShapeOk && expectedShapeOk {
 			// Prefer shapesHaveSameStructure: it resolves assertion fields and uses assignability for
 			// mismatched type identifiers (e.g. inferred literal ctx vs AppContext).
 			identical := tc.shapesHaveSameStructure(*actualShape, *expectedShape)
-			tc.log.WithFields(logrus.Fields{
-				"actual":    actual.Ident,
+			tc.debugCompat("Structural compatibility check result", logrus.Fields{"actual":    actual.Ident,
 				"expected":  expected.Ident,
 				"identical": identical,
-				"function":  "IsTypeCompatible",
-			}).Debug("Structural compatibility check result")
+				"function":  "IsTypeCompatible",})
 
 			if identical {
-				tc.log.WithFields(logrus.Fields{
-					"actual":   actual.Ident,
+				tc.debugCompat("Shapes are structurally identical", logrus.Fields{"actual":   actual.Ident,
 					"expected": expected.Ident,
-					"function": "IsTypeCompatible",
-				}).Debug("Shapes are structurally identical")
+					"function": "IsTypeCompatible",})
 				return true
 			}
 			if (*expectedShape).IsMethodOnlyContract() &&
@@ -248,22 +216,18 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 				return true
 			}
 		} else {
-			tc.log.WithFields(logrus.Fields{
-				"actual":          actual.Ident,
+			tc.debugCompat("Could not extract shapes for structural comparison", logrus.Fields{"actual":          actual.Ident,
 				"expected":        expected.Ident,
 				"actualShapeOk":   actualShapeOk,
 				"expectedShapeOk": expectedShapeOk,
-				"function":        "IsTypeCompatible",
-			}).Debug("Could not extract shapes for structural comparison")
+				"function":        "IsTypeCompatible",})
 		}
 	} else {
-		tc.log.WithFields(logrus.Fields{
-			"actual":      actual.Ident,
+		tc.debugCompat("Skipping structural compatibility - missing type definitions", logrus.Fields{"actual":      actual.Ident,
 			"expected":    expected.Ident,
 			"actualDef":   actualDef != nil,
 			"expectedDef": expectedDef != nil,
-			"function":    "IsTypeCompatible",
-		}).Debug("Skipping structural compatibility - missing type definitions")
+			"function":    "IsTypeCompatible",})
 	}
 
 	if tc.shapeExpectationMatches(actual, expected) {
@@ -290,11 +254,9 @@ func (tc *TypeChecker) IsTypeCompatible(actual ast.TypeNode, expected ast.TypeNo
 		}
 	}
 
-	tc.log.WithFields(logrus.Fields{
-		"actual":   actual.Ident,
+	tc.debugCompat("Types are not compatible", logrus.Fields{"actual":   actual.Ident,
 		"expected": expected.Ident,
-		"function": "IsTypeCompatible",
-	}).Debug("Types are not compatible")
+		"function": "IsTypeCompatible",})
 	return false
 }
 

--- a/forst/internal/typechecker/infer.go
+++ b/forst/internal/typechecker/infer.go
@@ -26,10 +26,12 @@ func (tc *TypeChecker) inferNodeTypes(nodes []ast.Node, scopeNode ast.Node) ([][
 
 // inferNodeType handles type inference for a single node
 func (tc *TypeChecker) inferNodeType(node ast.Node) ([]ast.TypeNode, error) {
-	tc.log.WithFields(logrus.Fields{
-		"node":     node.String(),
-		"function": "inferNodeType",
-	}).Trace("Inferring node type")
+	if tc.log.IsLevelEnabled(logrus.TraceLevel) {
+		tc.log.WithFields(logrus.Fields{
+			"node":     node.String(),
+			"function": "inferNodeType",
+		}).Trace("Inferring node type")
+	}
 
 	switch n := node.(type) {
 	case ast.PackageNode:

--- a/forst/internal/typechecker/infer.go
+++ b/forst/internal/typechecker/infer.go
@@ -37,7 +37,7 @@ func (tc *TypeChecker) inferNodeType(node ast.Node) ([]ast.TypeNode, error) {
 	case ast.PackageNode:
 		return nil, nil
 	case ast.FunctionNode:
-		return tc.inferFunctionNode(n)
+		return tc.inferFunctionNode(node)
 
 	case ast.SimpleParamNode:
 		if n.Type.Assertion != nil {
@@ -72,11 +72,11 @@ func (tc *TypeChecker) inferNodeType(node ast.Node) ([]ast.TypeNode, error) {
 		return inferredType, nil
 
 	case ast.EnsureNode:
-		return tc.inferEnsureNode(n)
+		return tc.inferEnsureNode(node)
 	case ast.UseNode:
 		return tc.inferUseNode(n)
 	case ast.WithNode:
-		return tc.inferWithNode(n)
+		return tc.inferWithNode(node)
 	case ast.AssignmentNode:
 		if n.IsPackageLevel {
 			if err := tc.ensurePackageLevelVarRegistered(n); err != nil {
@@ -163,12 +163,12 @@ func (tc *TypeChecker) inferNodeType(node ast.Node) ([]ast.TypeNode, error) {
 		return nil, nil
 
 	case ast.TypeGuardNode, *ast.TypeGuardNode:
-		return tc.inferTypeGuardNode(n)
+		return tc.inferTypeGuardNode(node)
 
 	case ast.IfNode:
-		return tc.inferIfStatement(n)
+		return tc.inferIfStatement(&n)
 	case *ast.IfNode:
-		return tc.inferIfStatement(*n)
+		return tc.inferIfStatement(n)
 
 	case *ast.ForNode:
 		return tc.inferForNode(n)
@@ -227,8 +227,6 @@ func (tc *TypeChecker) inferNodeType(node ast.Node) ([]ast.TypeNode, error) {
 		if n == nil {
 			return nil, nil
 		}
-		return tc.inferNodeType(*n)
-	case ast.ElseBlockNode:
 		tc.pushScope(n)
 		for _, node := range n.Body {
 			if _, err := tc.inferNodeType(node); err != nil {
@@ -237,6 +235,9 @@ func (tc *TypeChecker) inferNodeType(node ast.Node) ([]ast.TypeNode, error) {
 		}
 		tc.popScope()
 		return nil, nil
+	case ast.ElseBlockNode:
+		eb := n
+		return tc.inferNodeType(&eb)
 
 	case ast.CommentNode:
 		return nil, nil

--- a/forst/internal/typechecker/infer_ensure_node.go
+++ b/forst/internal/typechecker/infer_ensure_node.go
@@ -1,8 +1,15 @@
 package typechecker
 
-import "forst/internal/ast"
+import (
+	"fmt"
+	"forst/internal/ast"
+)
 
-func (tc *TypeChecker) inferEnsureNode(ensureNode ast.EnsureNode) ([]ast.TypeNode, error) {
+func (tc *TypeChecker) inferEnsureNode(node ast.Node) ([]ast.TypeNode, error) {
+	ensureNode, ok := node.(ast.EnsureNode)
+	if !ok {
+		return nil, fmt.Errorf("inferEnsureNode: unexpected node type %T", node)
+	}
 	variableType, err := tc.inferEnsureType(ensureNode)
 	if err != nil {
 		return nil, err

--- a/forst/internal/typechecker/infer_expression.go
+++ b/forst/internal/typechecker/infer_expression.go
@@ -9,10 +9,12 @@ import (
 )
 
 func (tc *TypeChecker) inferExpressionType(expr ast.Node) ([]ast.TypeNode, error) {
-	tc.log.WithFields(logrus.Fields{
-		"function": "inferExpressionType",
-		"expr":     expr,
-	}).Debugf("Starting type inference for expression")
+	if tc.log.IsLevelEnabled(logrus.DebugLevel) {
+		tc.log.WithFields(logrus.Fields{
+			"function": "inferExpressionType",
+			"expr":     expr,
+		}).Debugf("Starting type inference for expression")
+	}
 	if isLiteralExpression(expr) {
 		if cached, ok, err := tc.lookupCachedExpressionTypes(expr); err != nil {
 			return nil, err

--- a/forst/internal/typechecker/infer_function_node.go
+++ b/forst/internal/typechecker/infer_function_node.go
@@ -1,12 +1,25 @@
 package typechecker
 
 import (
+	"fmt"
 	"forst/internal/ast"
 
 	logrus "github.com/sirupsen/logrus"
 )
 
-func (tc *TypeChecker) inferFunctionNode(functionNode ast.FunctionNode) ([]ast.TypeNode, error) {
+func (tc *TypeChecker) inferFunctionNode(node ast.Node) ([]ast.TypeNode, error) {
+	var functionNode ast.FunctionNode
+	switch n := node.(type) {
+	case ast.FunctionNode:
+		functionNode = n
+	case *ast.FunctionNode:
+		if n == nil {
+			return nil, nil
+		}
+		functionNode = *n
+	default:
+		return nil, fmt.Errorf("inferFunctionNode: unexpected node type %T", node)
+	}
 	prevFn := tc.currentFunction
 	tc.currentFunction = &functionNode
 	prevErrBranchDepth := tc.resultErrIfBranchDepth
@@ -22,7 +35,7 @@ func (tc *TypeChecker) inferFunctionNode(functionNode ast.FunctionNode) ([]ast.T
 		"phase":    "ENTER",
 	}).Debug("Function node type inference")
 
-	if err := tc.RestoreScope(functionNode); err != nil {
+	if err := tc.RestoreScope(node); err != nil {
 		return nil, err
 	}
 	tc.log.WithFields(logrus.Fields{
@@ -49,7 +62,7 @@ func (tc *TypeChecker) inferFunctionNode(functionNode ast.FunctionNode) ([]ast.T
 		params[index] = param
 	}
 
-	paramTypes, err := tc.inferNodeTypes(params, functionNode)
+	paramTypes, err := tc.inferNodeTypes(params, node)
 	if err != nil {
 		return nil, err
 	}

--- a/forst/internal/typechecker/infer_if.go
+++ b/forst/internal/typechecker/infer_if.go
@@ -13,7 +13,10 @@ import (
 //     JoinAfterIfMerge (typeops.go) widens to the outer (pre-if) binding type (§3.2) until unions exist.
 //   - Kotlin/Swift analogy: refinement is scoped to branch bodies; after the full chain, merge
 //     restores the enclosing binding type for uses in the continuation.
-func (tc *TypeChecker) inferIfStatement(n ast.IfNode) ([]ast.TypeNode, error) {
+func (tc *TypeChecker) inferIfStatement(n *ast.IfNode) ([]ast.TypeNode, error) {
+	if n == nil {
+		return nil, nil
+	}
 	tc.beginIfChainForStatement()
 	defer tc.endIfChainApplyJoin()
 
@@ -30,7 +33,7 @@ func (tc *TypeChecker) inferIfStatement(n ast.IfNode) ([]ast.TypeNode, error) {
 		}
 	}
 	incErr := tc.ifConditionIsBuiltinResultErrNarrowing(n.Condition)
-	tc.pushScope(&n)
+	tc.pushScope(n)
 	if incErr {
 		tc.resultErrIfBranchDepth++
 	}
@@ -50,7 +53,8 @@ func (tc *TypeChecker) inferIfStatement(n ast.IfNode) ([]ast.TypeNode, error) {
 	}
 	tc.popScope()
 
-	for _, ei := range n.ElseIfs {
+	for i := range n.ElseIfs {
+		ei := &n.ElseIfs[i]
 		if ei.Condition != nil {
 			if ce, ok := ei.Condition.(ast.ExpressionNode); ok {
 				if _, err := tc.inferExpressionType(ce); err != nil {
@@ -59,7 +63,7 @@ func (tc *TypeChecker) inferIfStatement(n ast.IfNode) ([]ast.TypeNode, error) {
 			}
 		}
 		incErrEI := tc.ifConditionIsBuiltinResultErrNarrowing(ei.Condition)
-		tc.pushScope(&ei)
+		tc.pushScope(ei)
 		if incErrEI {
 			tc.resultErrIfBranchDepth++
 		}

--- a/forst/internal/typechecker/infer_typeguard_node.go
+++ b/forst/internal/typechecker/infer_typeguard_node.go
@@ -7,17 +7,18 @@ import (
 
 func (tc *TypeChecker) inferTypeGuardNode(typeGuardNode ast.Node) ([]ast.TypeNode, error) {
 	var guardNode ast.TypeGuardNode
-	if ptr, ok := typeGuardNode.(*ast.TypeGuardNode); ok {
-		tc.pushScope(ptr)
-		guardNode = *ptr
-	} else {
-		guardNode = typeGuardNode.(ast.TypeGuardNode)
-		if stored, ok := tc.Defs[ast.TypeIdent(guardNode.Ident)].(*ast.TypeGuardNode); ok {
-			tc.pushScope(stored)
-		} else {
-			tc.pushScope(guardNode)
+	switch n := typeGuardNode.(type) {
+	case *ast.TypeGuardNode:
+		if n == nil {
+			return nil, nil
 		}
+		guardNode = *n
+	case ast.TypeGuardNode:
+		guardNode = n
+	default:
+		return nil, fmt.Errorf("inferTypeGuardNode: unexpected node type %T", typeGuardNode)
 	}
+	tc.pushScope(typeGuardNode)
 
 	for _, param := range guardNode.Parameters() {
 		switch typedParam := param.(type) {
@@ -43,14 +44,14 @@ func (tc *TypeChecker) inferTypeGuardNode(typeGuardNode ast.Node) ([]ast.TypeNod
 			if binExpr, ok := stmt.Condition.(ast.BinaryExpressionNode); !ok || binExpr.Operator != ast.TokenIs {
 				return nil, fmt.Errorf("type guard conditions must use 'is' operator")
 			}
-			if _, err := tc.inferIfStatement(stmt); err != nil {
+			if _, err := tc.inferIfStatement(&stmt); err != nil {
 				return nil, err
 			}
 		case *ast.IfNode:
 			if binExpr, ok := stmt.Condition.(ast.BinaryExpressionNode); !ok || binExpr.Operator != ast.TokenIs {
 				return nil, fmt.Errorf("type guard conditions must use 'is' operator")
 			}
-			if _, err := tc.inferIfStatement(*stmt); err != nil {
+			if _, err := tc.inferIfStatement(stmt); err != nil {
 				return nil, err
 			}
 		case ast.EnsureNode:

--- a/forst/internal/typechecker/providers_with.go
+++ b/forst/internal/typechecker/providers_with.go
@@ -7,7 +7,11 @@ import (
 	"forst/internal/astwalk"
 )
 
-func (tc *TypeChecker) inferWithNode(with ast.WithNode) ([]ast.TypeNode, error) {
+func (tc *TypeChecker) inferWithNode(node ast.Node) ([]ast.TypeNode, error) {
+	with, ok := node.(ast.WithNode)
+	if !ok {
+		return nil, fmt.Errorf("inferWithNode: unexpected node type %T", node)
+	}
 	eng := tc.providersEngine()
 	inner, err := tc.ambientFromWiringExpr(with.Wiring, with.Span)
 	if err != nil {
@@ -32,7 +36,7 @@ func (tc *TypeChecker) inferWithNode(with ast.WithNode) ([]ast.TypeNode, error) 
 	})
 
 	eng.ScopeStack = append(eng.ScopeStack, merged)
-	tc.pushScope(with)
+	tc.pushScope(node)
 
 	for _, node := range with.Body {
 		if _, err := tc.inferNodeType(node); err != nil {

--- a/forst/internal/typechecker/scope_if_reparse_test.go
+++ b/forst/internal/typechecker/scope_if_reparse_test.go
@@ -1,0 +1,71 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+)
+
+const ifAfterAssignSrc = `package demo
+
+func f(cells []String, a Int): String {
+	x0 := cells[a]
+	if x0 == "" {
+		return ""
+	}
+	return x0
+}
+`
+
+func findIfAfterAssign(t *testing.T, nodes []ast.Node) *ast.IfNode {
+	t.Helper()
+	fn := findFunctionNode(t, nodes, "f")
+	ifn, ok := fn.Body[1].(*ast.IfNode)
+	if !ok {
+		t.Fatalf("body[1] want *IfNode, got %T", fn.Body[1])
+	}
+	return ifn
+}
+
+func TestRestoreScope_ifNodeAfterReparse_withoutRebind(t *testing.T) {
+	t.Parallel()
+	nodesA := parseNodesForTest(t, []byte(ifAfterAssignSrc))
+	tc := testTypeChecker(t)
+	if err := tc.CheckTypes(nodesA); err != nil {
+		t.Fatalf("CheckTypes(A): %v", err)
+	}
+
+	nodesB := parseNodesForTest(t, []byte(ifAfterAssignSrc))
+	ifNodeB := findIfAfterAssign(t, nodesB)
+
+	err := tc.RestoreScope(ifNodeB)
+	if err == nil {
+		t.Fatal("expected RestoreScope to fail on re-parsed if without rebind")
+	}
+	if !strings.Contains(err.Error(), "scope not found") {
+		t.Fatalf("RestoreScope error = %q, want scope not found", err)
+	}
+}
+
+func TestRestoreScope_ifNodeAfterRebind(t *testing.T) {
+	t.Parallel()
+	nodesA := parseNodesForTest(t, []byte(ifAfterAssignSrc))
+	tc := testTypeChecker(t)
+	if err := tc.CheckTypes(nodesA); err != nil {
+		t.Fatalf("CheckTypes(A): %v", err)
+	}
+
+	nodesB := parseNodesForTest(t, []byte(ifAfterAssignSrc))
+	if err := tc.CheckTypes(nodesB); err != nil {
+		t.Fatalf("CheckTypes(B): %v", err)
+	}
+	ifNodeB := findIfAfterAssign(t, nodesB)
+
+	if err := tc.RestoreScope(ifNodeB); err != nil {
+		t.Fatalf("RestoreScope(ifFromB): %v", err)
+	}
+	if !tc.HasScopeForNode(ifNodeB) {
+		t.Fatal("expected scope registered on re-parsed if after rebind")
+	}
+}

--- a/forst/internal/typechecker/scope_if_restore_test.go
+++ b/forst/internal/typechecker/scope_if_restore_test.go
@@ -1,0 +1,76 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestRestoreScope_ifElseBranches_matchSymbolScope(t *testing.T) {
+	t.Parallel()
+	src := []byte(`package demo
+
+func main(): Void {
+	n := 2
+	if n > 10 {
+		z := 1
+		println(string(z))
+	} else if n < 5 {
+		y := 2
+		println(string(y))
+	} else {
+		w := 3
+		println(string(w))
+	}
+}
+`)
+	nodes := parseNodesForTest(t, src)
+	tc := testTypeChecker(t)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	fn := findFunctionNode(t, nodes, "main")
+	ifn, ok := fn.Body[1].(*ast.IfNode)
+	if !ok {
+		t.Fatalf("body[1] want *IfNode, got %T", fn.Body[1])
+	}
+
+	cases := []struct {
+		name     string
+		scopeKey ast.Node
+		varName  string
+	}{
+		{"if then", ifn, "z"},
+		{"else if", &ifn.ElseIfs[0], "y"},
+		{"else", ifn.Else, "w"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := tc.RestoreScope(c.scopeKey); err != nil {
+				t.Fatalf("RestoreScope: %v", err)
+			}
+			sym, ok := tc.CurrentScope().LookupVariable(ast.Identifier(c.varName))
+			if !ok || sym.Scope == nil {
+				t.Fatalf("lookup %s: ok=%v", c.varName, ok)
+			}
+			if err := tc.RestoreScope(c.scopeKey); err != nil {
+				t.Fatalf("RestoreScope again: %v", err)
+			}
+			if tc.CurrentScope() != sym.Scope {
+				t.Fatalf("RestoreScope scope pointer != symbol scope for %s", c.varName)
+			}
+		})
+	}
+}
+
+func findFunctionNode(t *testing.T, nodes []ast.Node, name string) ast.FunctionNode {
+	t.Helper()
+	for _, n := range nodes {
+		fn, ok := n.(ast.FunctionNode)
+		if ok && fn.Ident.ID == ast.Identifier(name) {
+			return fn
+		}
+	}
+	t.Fatalf("function %q not found", name)
+	return ast.FunctionNode{}
+}

--- a/forst/internal/typechecker/scope_key_restore_test.go
+++ b/forst/internal/typechecker/scope_key_restore_test.go
@@ -1,0 +1,61 @@
+package typechecker
+
+import (
+	"io"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/lexer"
+	"forst/internal/parser"
+
+	"github.com/sirupsen/logrus"
+)
+
+func testTypeChecker(t *testing.T) *TypeChecker {
+	t.Helper()
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	return New(log, false)
+}
+
+func parseNodesForTest(t *testing.T, src []byte) []ast.Node {
+	t.Helper()
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	toks := lexer.New(src, "test.ft", log).Lex()
+	nodes, err := parser.New(toks, "test.ft", log).ParseFile()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return nodes
+}
+
+func TestRestoreScope_distinctEnsureSubjectsDistinctScopes(t *testing.T) {
+	t.Parallel()
+	src := []byte(`package demo
+
+type Named = { name: String }
+
+func F(a: Named, b: Named): Void {
+	ensure a.name is Min(1) {}
+	ensure b.name is Min(1) {}
+}
+`)
+	nodes := parseNodesForTest(t, src)
+	tc := testTypeChecker(t)
+	if err := tc.CollectTypes(nodes); err != nil {
+		t.Fatalf("CollectTypes: %v", err)
+	}
+	var ensureScopes int
+	for _, scope := range tc.scopeStack.scopes {
+		if scope.Node == nil {
+			continue
+		}
+		if _, ok := (*scope.Node).(ast.EnsureNode); ok {
+			ensureScopes++
+		}
+	}
+	if ensureScopes < 2 {
+		t.Fatalf("expected at least 2 ensure scopes, got %d", ensureScopes)
+	}
+}

--- a/forst/internal/typechecker/scope_owner.go
+++ b/forst/internal/typechecker/scope_owner.go
@@ -1,0 +1,48 @@
+package typechecker
+
+import "forst/internal/ast"
+
+// ScopeNode is the ast.Node interface box registered with pushScope during typecheck.
+type ScopeNode = ast.Node
+
+type scopeOwners struct {
+	typeGuards map[ast.Identifier]ScopeNode
+	functions  map[ast.Identifier]ScopeNode
+}
+
+func newScopeOwners() scopeOwners {
+	return scopeOwners{
+		typeGuards: make(map[ast.Identifier]ScopeNode),
+		functions:  make(map[ast.Identifier]ScopeNode),
+	}
+}
+
+func (tc *TypeChecker) resetScopeOwners() {
+	tc.scopeOwners = newScopeOwners()
+}
+
+func (tc *TypeChecker) registerTypeGuardScope(id ast.Identifier, node ScopeNode) {
+	if tc.scopeOwners.typeGuards == nil {
+		tc.scopeOwners.typeGuards = make(map[ast.Identifier]ScopeNode)
+	}
+	tc.scopeOwners.typeGuards[id] = node
+}
+
+func (tc *TypeChecker) registerFunctionScope(id ast.Identifier, node ScopeNode) {
+	if tc.scopeOwners.functions == nil {
+		tc.scopeOwners.functions = make(map[ast.Identifier]ScopeNode)
+	}
+	tc.scopeOwners.functions[id] = node
+}
+
+// ScopeNodeForTypeGuard returns the ScopeNode registered at collect for a type guard ident.
+func (tc *TypeChecker) ScopeNodeForTypeGuard(id ast.Identifier) (ScopeNode, bool) {
+	n, ok := tc.scopeOwners.typeGuards[id]
+	return n, ok
+}
+
+// ScopeNodeForFunction returns the ScopeNode registered at collect for a function ident.
+func (tc *TypeChecker) ScopeNodeForFunction(id ast.Identifier) (ScopeNode, bool) {
+	n, ok := tc.scopeOwners.functions[id]
+	return n, ok
+}

--- a/forst/internal/typechecker/scope_owner_test.go
+++ b/forst/internal/typechecker/scope_owner_test.go
@@ -1,0 +1,110 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestScopeOwnerRegistry_populatedAtCollect(t *testing.T) {
+	t.Parallel()
+	src := []byte(`package demo
+
+type Logger = {info(msg String)}
+
+type NopLogger = {}
+
+func (NopLogger) info(msg String) {}
+
+type Name = String
+
+is (n Name) Active(min Int) {
+	ensure n is Min(min)
+}
+
+func host() {
+	with { Logger: &NopLogger{} } {
+		use logger: Logger
+	}
+}
+`)
+	nodes := parseNodesForTest(t, src)
+	tc := testTypeChecker(t)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+
+	var fnNode ast.Node
+	var guardNode ast.Node
+	for _, n := range nodes {
+		switch x := n.(type) {
+		case ast.FunctionNode:
+			if x.Ident.ID == "host" {
+				fnNode = n
+			}
+		case *ast.FunctionNode:
+			if x != nil && x.Ident.ID == "host" {
+				fnNode = n
+			}
+		case ast.TypeGuardNode:
+			if x.Ident == "Active" {
+				guardNode = n
+			}
+		case *ast.TypeGuardNode:
+			if x != nil && x.Ident == "Active" {
+				guardNode = n
+			}
+		}
+	}
+	if fnNode == nil {
+		t.Fatal("host function node not found")
+	}
+	if guardNode == nil {
+		t.Fatal("Active type guard node not found")
+	}
+
+	regFn, ok := tc.ScopeNodeForFunction(ast.Identifier("host"))
+	if !ok {
+		t.Fatal("ScopeNodeForFunction(host): missing")
+	}
+	if !tc.HasScopeForNode(fnNode) {
+		t.Fatal("parse host node missing registered scope")
+	}
+	regGuard, ok := tc.ScopeNodeForTypeGuard(ast.Identifier("Active"))
+	if !ok {
+		t.Fatal("ScopeNodeForTypeGuard(Active): missing")
+	}
+	if !tc.HasScopeForNode(guardNode) {
+		t.Fatal("parse Active guard node missing registered scope")
+	}
+
+	if err := tc.RestoreScope(regFn); err != nil {
+		t.Fatalf("RestoreScope via registry fn: %v", err)
+	}
+	if err := tc.RestoreScope(regGuard); err != nil {
+		t.Fatalf("RestoreScope via registry guard: %v", err)
+	}
+}
+
+func TestScopeOwnerRegistry_resetOnCollectTypes(t *testing.T) {
+	t.Parallel()
+	src := []byte(`package demo
+
+func f() {}
+`)
+	nodes := parseNodesForTest(t, src)
+	tc := testTypeChecker(t)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes re-run: %v", err)
+	}
+	second, ok := tc.ScopeNodeForFunction(ast.Identifier("f"))
+	if !ok {
+		t.Fatal("expected ScopeNodeForFunction after re-run CheckTypes")
+	}
+	if err := tc.RestoreScope(second); err != nil {
+		t.Fatalf("RestoreScope after re-run CheckTypes: %v", err)
+	}
+}

--- a/forst/internal/typechecker/scope_stack.go
+++ b/forst/internal/typechecker/scope_stack.go
@@ -44,22 +44,22 @@ func NewScopeStack(h *hasher.StructuralHasher, log *logrus.Logger) *ScopeStack {
 
 // pushScope creates and pushes a new scope for the given AST node
 func (ss *ScopeStack) pushScope(node ast.Node) *Scope {
-	hash, err := ss.Hasher.HashNode(node)
+	hash, err := ss.resolveScopeHash(node)
 	if err != nil {
 		ss.log.WithError(err).Error("failed to hash node during pushScope")
 		return nil
+	}
+	if existing, ok := ss.scopes[hash]; ok && scopeNodesMatch(existing, node) && existing.Parent == ss.current {
+		ss.current = existing
+		ss.cacheNodeScopeHash(node, hash)
+		return existing
 	}
 	scope := NewScope(ss.current, &node, ss.log)
 	scope.hash = hash
 	ss.current.Children = append(ss.current.Children, scope)
 	ss.current = scope
 	ss.scopes[hash] = scope
-	if ss.nodeScopeHash == nil {
-		ss.nodeScopeHash = make(map[hasher.NodeIdentity]NodeHash)
-	}
-	if key, ok := hasher.NodeIdentityKey(node); ok {
-		ss.nodeScopeHash[key] = hash
-	}
+	ss.cacheNodeScopeHash(node, hash)
 	return scope
 }
 
@@ -97,18 +97,70 @@ func (ss *ScopeStack) findScope(node ast.Node) (*Scope, bool) {
 			}
 		}
 	}
-	hash, err := ss.Hasher.HashNode(node)
+	baseHash, err := ss.Hasher.HashScopeKey(node)
 	if err != nil {
 		ss.log.WithError(err).Error("failed to hash node during findScope")
 		return nil, false
 	}
-	scope, exists := ss.scopes[hash]
-	if exists {
-		if key, ok := hasher.NodeIdentityKey(node); ok {
-			ss.nodeScopeHash[key] = hash
+	if scope, ok := ss.scopes[baseHash]; ok {
+		if scopeNodesMatch(scope, node) {
+			ss.cacheNodeScopeHash(node, baseHash)
+			return scope, true
 		}
+		disHash, err := ss.Hasher.HashScopeKeyDisambiguated(node, baseHash)
+		if err != nil {
+			ss.log.WithError(err).Error("failed to disambiguate scope hash during findScope")
+			return nil, false
+		}
+		if disScope, ok := ss.scopes[disHash]; ok {
+			ss.cacheNodeScopeHash(node, disHash)
+			return disScope, true
+		}
+		ss.cacheNodeScopeHash(node, baseHash)
+		return scope, true
 	}
-	return scope, exists
+	disHash, err := ss.Hasher.HashScopeKeyDisambiguated(node, baseHash)
+	if err != nil {
+		ss.log.WithError(err).Error("failed to disambiguate scope hash during findScope")
+		return nil, false
+	}
+	if scope, ok := ss.scopes[disHash]; ok {
+		ss.cacheNodeScopeHash(node, disHash)
+		return scope, true
+	}
+	return nil, false
+}
+
+func (ss *ScopeStack) resolveScopeHash(node ast.Node) (NodeHash, error) {
+	baseHash, err := ss.Hasher.HashScopeKey(node)
+	if err != nil {
+		return 0, err
+	}
+	if existing, ok := ss.scopes[baseHash]; ok && !scopeNodesMatch(existing, node) {
+		return ss.Hasher.HashScopeKeyDisambiguated(node, baseHash)
+	}
+	return baseHash, nil
+}
+
+func (ss *ScopeStack) cacheNodeScopeHash(node ast.Node, hash NodeHash) {
+	if ss.nodeScopeHash == nil {
+		ss.nodeScopeHash = make(map[hasher.NodeIdentity]NodeHash)
+	}
+	if key, ok := hasher.NodeIdentityKey(node); ok {
+		ss.nodeScopeHash[key] = hash
+	}
+}
+
+func scopeNodesMatch(scope *Scope, node ast.Node) bool {
+	if scope == nil || scope.Node == nil {
+		return false
+	}
+	idNode, okNode := hasher.NodeIdentityKey(node)
+	idScope, okScope := hasher.NodeIdentityKey(*scope.Node)
+	if okNode && okScope {
+		return idNode == idScope
+	}
+	return false
 }
 
 // globalScope returns the root scope

--- a/forst/internal/typechecker/scope_stack.go
+++ b/forst/internal/typechecker/scope_stack.go
@@ -77,9 +77,17 @@ func (ss *ScopeStack) currentScope() *Scope {
 
 // restoreScope restores a scope by its AST node
 func (ss *ScopeStack) restoreScope(node ast.Node) error {
+	if node == nil {
+		ss.current = ss.globalScope()
+		return nil
+	}
 	scope, exists := ss.findScope(node)
 	if !exists {
-		return fmt.Errorf("scope not found for node %s", node.String())
+		desc := "<nil>"
+		if node != nil {
+			desc = node.String()
+		}
+		return fmt.Errorf("scope not found for node %s", desc)
 	}
 	ss.current = scope
 	return nil
@@ -116,8 +124,7 @@ func (ss *ScopeStack) findScope(node ast.Node) (*Scope, bool) {
 			ss.cacheNodeScopeHash(node, disHash)
 			return disScope, true
 		}
-		ss.cacheNodeScopeHash(node, baseHash)
-		return scope, true
+		return nil, false
 	}
 	disHash, err := ss.Hasher.HashScopeKeyDisambiguated(node, baseHash)
 	if err != nil {

--- a/forst/internal/typechecker/scope_stack_restore_test.go
+++ b/forst/internal/typechecker/scope_stack_restore_test.go
@@ -10,6 +10,25 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func TestRestoreScope_nilGlobal_afterCheckTypes(t *testing.T) {
+	t.Parallel()
+	src := []byte(`package demo
+
+func main() {}
+`)
+	nodes := parseNodesForTest(t, src)
+	tc := testTypeChecker(t)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	if err := tc.RestoreScope(nil); err != nil {
+		t.Fatalf("RestoreScope(nil): %v", err)
+	}
+	if !tc.CurrentScope().IsGlobal() {
+		t.Fatal("expected global scope after RestoreScope(nil)")
+	}
+}
+
 func TestRestoreScope_reusesCachedHash(t *testing.T) {
 	t.Parallel()
 	var body []ast.Node
@@ -20,18 +39,20 @@ func TestRestoreScope_reusesCachedHash(t *testing.T) {
 		})
 	}
 	fn := ast.FunctionNode{Ident: ast.Ident{ID: "f"}, Body: body}
+	nodes := []ast.Node{fn}
 	log := logrus.New()
 	log.SetOutput(io.Discard)
 	tc := New(log, false)
-	if err := tc.CollectTypes([]ast.Node{fn}); err != nil {
+	if err := tc.CollectTypes(nodes); err != nil {
 		t.Fatalf("CollectTypes: %v", err)
 	}
-	want, ok := tc.scopeStack.findScope(fn)
+	scopeNode := nodes[0]
+	want, ok := tc.scopeStack.findScope(scopeNode)
 	if !ok {
 		t.Fatal("scope not found for fn after collect")
 	}
 	for i := 0; i < 1000; i++ {
-		if err := tc.RestoreScope(fn); err != nil {
+		if err := tc.RestoreScope(scopeNode); err != nil {
 			t.Fatalf("RestoreScope iteration %d: %v", i, err)
 		}
 		if tc.scopeStack.current != want {

--- a/forst/internal/typechecker/scope_symbol.go
+++ b/forst/internal/typechecker/scope_symbol.go
@@ -105,3 +105,9 @@ func (tc *TypeChecker) storeSymbol(ident ast.Identifier, types []ast.TypeNode, k
 func (tc *TypeChecker) CurrentScope() *Scope {
 	return tc.scopeStack.currentScope()
 }
+
+// HasScopeForNode reports whether a scope was registered for node during typecheck.
+func (tc *TypeChecker) HasScopeForNode(node ast.Node) bool {
+	_, ok := tc.scopeStack.findScope(node)
+	return ok
+}

--- a/forst/internal/typechecker/scope_typeguard_restore_test.go
+++ b/forst/internal/typechecker/scope_typeguard_restore_test.go
@@ -50,6 +50,11 @@ is (password Password) Strong(min Int) {
 		t.Fatal("type guard node not found")
 	}
 
+	regGuard, ok := tc.ScopeNodeForTypeGuard(guard.Ident)
+	if !ok || regGuard != guardNode {
+		t.Fatalf("ScopeNodeForTypeGuard: got %v ok=%v want parse node %v", regGuard, ok, guardNode)
+	}
+
 	t.Run("guard param scope", func(t *testing.T) {
 		if err := tc.RestoreScope(guardNode); err != nil {
 			t.Fatalf("RestoreScope guard: %v", err)

--- a/forst/internal/typechecker/scope_typeguard_restore_test.go
+++ b/forst/internal/typechecker/scope_typeguard_restore_test.go
@@ -1,0 +1,127 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestRestoreScope_typeGuardBody_matchSymbolScope(t *testing.T) {
+	t.Parallel()
+	src := []byte(`package demo
+
+type Password = String
+
+is (password Password) Strong(min Int) {
+	ensure password is Min(min)
+	if password is Min(min) {
+		println("ok")
+	} else if password is Max(100) {
+		println("mid")
+	} else {
+		println("no")
+	}
+}
+`)
+	nodes := parseNodesForTest(t, src)
+	tc := testTypeChecker(t)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+
+	var guardNode ast.Node
+	var guard ast.TypeGuardNode
+	for _, n := range nodes {
+		switch g := n.(type) {
+		case ast.TypeGuardNode:
+			guardNode = n
+			guard = g
+		case *ast.TypeGuardNode:
+			if g != nil {
+				guardNode = n
+				guard = *g
+			}
+		}
+		if guardNode != nil {
+			break
+		}
+	}
+	if guardNode == nil {
+		t.Fatal("type guard node not found")
+	}
+
+	t.Run("guard param scope", func(t *testing.T) {
+		if err := tc.RestoreScope(guardNode); err != nil {
+			t.Fatalf("RestoreScope guard: %v", err)
+		}
+		sym, ok := tc.CurrentScope().LookupVariable(ast.Identifier("password"))
+		if !ok || sym.Scope == nil {
+			t.Fatal("password not in guard scope")
+		}
+		if err := tc.RestoreScope(guardNode); err != nil {
+			t.Fatalf("RestoreScope guard again: %v", err)
+		}
+		if tc.CurrentScope() != sym.Scope {
+			t.Fatal("RestoreScope guard scope pointer != symbol scope")
+		}
+	})
+
+	var ifNode *ast.IfNode
+	var ensureNode ast.Node
+	for _, bodyNode := range guard.Body {
+		switch n := bodyNode.(type) {
+		case ast.EnsureNode:
+			ensureNode = bodyNode
+		case *ast.IfNode:
+			ifNode = n
+		}
+	}
+	if ensureNode == nil {
+		t.Fatal("ensure node not found in guard body")
+	}
+	if ifNode == nil {
+		t.Fatal("if node not found in guard body")
+	}
+
+	t.Run("ensure scope", func(t *testing.T) {
+		if err := tc.RestoreScope(ensureNode); err != nil {
+			t.Fatalf("RestoreScope ensure: %v", err)
+		}
+	})
+
+	t.Run("if then", func(t *testing.T) {
+		if err := tc.RestoreScope(ifNode); err != nil {
+			t.Fatalf("RestoreScope if: %v", err)
+		}
+	})
+
+	if len(ifNode.ElseIfs) > 0 {
+		t.Run("else if", func(t *testing.T) {
+			if err := tc.RestoreScope(&ifNode.ElseIfs[0]); err != nil {
+				t.Fatalf("RestoreScope else-if: %v", err)
+			}
+		})
+	}
+
+	if ifNode.Else != nil {
+		t.Run("else", func(t *testing.T) {
+			if err := tc.RestoreScope(ifNode.Else); err != nil {
+				t.Fatalf("RestoreScope else: %v", err)
+			}
+		})
+	}
+
+	// Value copies must not match registered scopes.
+	t.Run("unboxed guard value misses", func(t *testing.T) {
+		if err := tc.RestoreScope(ast.Node(guard)); err == nil {
+			t.Fatal("expected RestoreScope on unboxed guard value to fail")
+		}
+	})
+	if en, ok := ensureNode.(ast.EnsureNode); ok {
+		t.Run("unboxed ensure value misses", func(t *testing.T) {
+			if err := tc.RestoreScope(en); err == nil {
+				t.Fatal("expected RestoreScope on unboxed ensure value to fail")
+			}
+		})
+	}
+}

--- a/forst/internal/typechecker/scope_with_restore_test.go
+++ b/forst/internal/typechecker/scope_with_restore_test.go
@@ -1,0 +1,70 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestRestoreScope_withBody_matchSymbolScope(t *testing.T) {
+	t.Parallel()
+	src := []byte(`package demo
+
+type Logger = {info(msg String)}
+
+type NopLogger = {}
+
+func (NopLogger) info(msg String) {}
+
+func host() {
+	with { Logger: &NopLogger{} } {
+		use logger: Logger
+		logger.info("hi")
+	}
+}
+`)
+	nodes := parseNodesForTest(t, src)
+	tc := testTypeChecker(t)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+
+	var withNode ast.Node
+	var with ast.WithNode
+	for _, n := range nodes {
+		fn, ok := n.(ast.FunctionNode)
+		if !ok || fn.Ident.ID != "host" {
+			continue
+		}
+		for _, stmt := range fn.Body {
+			if w, ok := stmt.(ast.WithNode); ok {
+				withNode = stmt
+				with = w
+				break
+			}
+		}
+	}
+	if withNode == nil {
+		t.Fatal("with node not found in host body")
+	}
+
+	if err := tc.RestoreScope(withNode); err != nil {
+		t.Fatalf("RestoreScope with: %v", err)
+	}
+	sym, ok := tc.CurrentScope().LookupVariable(ast.Identifier("logger"))
+	if !ok || sym.Scope == nil {
+		t.Fatal("logger not in with scope after RestoreScope")
+	}
+	if err := tc.RestoreScope(withNode); err != nil {
+		t.Fatalf("RestoreScope with again: %v", err)
+	}
+	if tc.CurrentScope() != sym.Scope {
+		t.Fatal("RestoreScope with scope pointer != symbol scope")
+	}
+
+	t.Run("unboxed with value misses", func(t *testing.T) {
+		if err := tc.RestoreScope(ast.Node(with)); err == nil {
+			t.Fatal("expected RestoreScope on unboxed with value to fail")
+		}
+	})
+}

--- a/forst/internal/typechecker/shape_alias_index.go
+++ b/forst/internal/typechecker/shape_alias_index.go
@@ -3,6 +3,7 @@ package typechecker
 import (
 	"forst/internal/ast"
 	"forst/internal/hasher"
+	"sort"
 	"strings"
 )
 
@@ -19,6 +20,8 @@ func (tc *TypeChecker) shapeAliasIndexOrBuild() *shapeAliasIndex {
 		byShapeHash:          make(map[hasher.NodeHash]ast.TypeIdent),
 		byAssertionTypeIdent: make(map[ast.TypeIdent]ast.TypeIdent),
 	}
+	shapeCandidates := make(map[hasher.NodeHash][]ast.TypeIdent)
+	assertionCandidates := make(map[ast.TypeIdent][]ast.TypeIdent)
 	for _, def := range tc.Defs {
 		userDef, ok := def.(ast.TypeDefNode)
 		if !ok || userDef.Ident == "" || strings.HasPrefix(string(userDef.Ident), "T_") {
@@ -29,7 +32,7 @@ func (tc *TypeChecker) shapeAliasIndexOrBuild() *shapeAliasIndex {
 			if err != nil {
 				continue
 			}
-			idx.byShapeHash[h] = userDef.Ident
+			shapeCandidates[h] = append(shapeCandidates[h], userDef.Ident)
 		}
 		if _, ok := typeDefAssertionFromExpr(userDef.Expr); ok {
 			bt := userDef.Ident
@@ -38,11 +41,28 @@ func (tc *TypeChecker) shapeAliasIndexOrBuild() *shapeAliasIndex {
 			if err != nil {
 				continue
 			}
-			idx.byAssertionTypeIdent[h.ToTypeIdent()] = userDef.Ident
+			key := h.ToTypeIdent()
+			assertionCandidates[key] = append(assertionCandidates[key], userDef.Ident)
 		}
+	}
+	for h, idents := range shapeCandidates {
+		idx.byShapeHash[h] = stableTypeIdentWinner(idents)
+	}
+	for key, idents := range assertionCandidates {
+		idx.byAssertionTypeIdent[key] = stableTypeIdentWinner(idents)
 	}
 	tc.shapeAliasIndex = idx
 	return idx
+}
+
+func stableTypeIdentWinner(idents []ast.TypeIdent) ast.TypeIdent {
+	if len(idents) == 0 {
+		return ""
+	}
+	sort.Slice(idents, func(i, j int) bool {
+		return idents[i] < idents[j]
+	})
+	return idents[0]
 }
 
 func (tc *TypeChecker) lookupShapeAliasForHashType(typeNode ast.TypeNode) (ast.TypeIdent, bool) {

--- a/forst/internal/typechecker/shape_alias_index.go
+++ b/forst/internal/typechecker/shape_alias_index.go
@@ -1,0 +1,72 @@
+package typechecker
+
+import (
+	"forst/internal/ast"
+	"forst/internal/hasher"
+	"strings"
+)
+
+type shapeAliasIndex struct {
+	byShapeHash          map[hasher.NodeHash]ast.TypeIdent
+	byAssertionTypeIdent map[ast.TypeIdent]ast.TypeIdent
+}
+
+func (tc *TypeChecker) shapeAliasIndexOrBuild() *shapeAliasIndex {
+	if tc.shapeAliasIndex != nil {
+		return tc.shapeAliasIndex
+	}
+	idx := &shapeAliasIndex{
+		byShapeHash:          make(map[hasher.NodeHash]ast.TypeIdent),
+		byAssertionTypeIdent: make(map[ast.TypeIdent]ast.TypeIdent),
+	}
+	for _, def := range tc.Defs {
+		userDef, ok := def.(ast.TypeDefNode)
+		if !ok || userDef.Ident == "" || strings.HasPrefix(string(userDef.Ident), "T_") {
+			continue
+		}
+		if payload, ok := ast.PayloadShape(userDef.Expr); ok {
+			h, err := tc.Hasher.HashNode(*payload)
+			if err != nil {
+				continue
+			}
+			idx.byShapeHash[h] = userDef.Ident
+		}
+		if _, ok := typeDefAssertionFromExpr(userDef.Expr); ok {
+			bt := userDef.Ident
+			a := ast.AssertionNode{BaseType: &bt}
+			h, err := tc.Hasher.HashNode(a)
+			if err != nil {
+				continue
+			}
+			idx.byAssertionTypeIdent[h.ToTypeIdent()] = userDef.Ident
+		}
+	}
+	tc.shapeAliasIndex = idx
+	return idx
+}
+
+func (tc *TypeChecker) lookupShapeAliasForHashType(typeNode ast.TypeNode) (ast.TypeIdent, bool) {
+	hashDef, ok := tc.Defs[typeNode.Ident]
+	if !ok {
+		return "", false
+	}
+	hashTypeDef, ok := hashDef.(ast.TypeDefNode)
+	if !ok {
+		return "", false
+	}
+	hashShapeExpr, ok := hashTypeDef.Expr.(ast.TypeDefShapeExpr)
+	if !ok {
+		return "", false
+	}
+	h, err := tc.Hasher.HashNode(hashShapeExpr.Shape)
+	if err != nil {
+		return "", false
+	}
+	alias, ok := tc.shapeAliasIndexOrBuild().byShapeHash[h]
+	return alias, ok
+}
+
+func (tc *TypeChecker) lookupAssertionAliasForHashIdent(ident ast.TypeIdent) (ast.TypeIdent, bool) {
+	alias, ok := tc.shapeAliasIndexOrBuild().byAssertionTypeIdent[ident]
+	return alias, ok
+}

--- a/forst/internal/typechecker/shape_alias_index_test.go
+++ b/forst/internal/typechecker/shape_alias_index_test.go
@@ -1,0 +1,80 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestShapeAliasIndex_resolvesStructuralHash(t *testing.T) {
+	t.Parallel()
+	tc := testTypeChecker(t)
+	userShape := ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+		"name": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+	}}
+	h, err := tc.Hasher.HashNode(userShape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashIdent := h.ToTypeIdent()
+	tc.registerType(ast.TypeDefNode{
+		Ident: "User",
+		Expr:  ast.TypeDefShapeExpr{Shape: userShape},
+	})
+	tc.Defs[hashIdent] = ast.TypeDefNode{
+		Ident: hashIdent,
+		Expr:  ast.TypeDefShapeExpr{Shape: userShape},
+	}
+	alias, ok := tc.lookupShapeAliasForHashType(ast.TypeNode{Ident: hashIdent, TypeKind: ast.TypeKindHashBased})
+	if !ok || alias != "User" {
+		t.Fatalf("lookupShapeAliasForHashType(%s) = %q, %v; want User, true", hashIdent, alias, ok)
+	}
+	resolved := tc.resolveAliasedType(ast.TypeNode{Ident: hashIdent, TypeKind: ast.TypeKindHashBased})
+	if resolved.Ident != "User" {
+		t.Fatalf("resolveAliasedType(%s) = %s, want User", hashIdent, resolved.Ident)
+	}
+}
+
+func TestShapeAliasIndex_stableTieBreakForDuplicateShapeHash(t *testing.T) {
+	t.Parallel()
+	tc := testTypeChecker(t)
+	shape := ast.ShapeNode{Fields: map[string]ast.ShapeFieldNode{
+		"x": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+	}}
+	tc.registerType(ast.TypeDefNode{Ident: "Zebra", Expr: ast.TypeDefShapeExpr{Shape: shape}})
+	tc.registerType(ast.TypeDefNode{Ident: "Alpha", Expr: ast.TypeDefShapeExpr{Shape: shape}})
+	idx := tc.shapeAliasIndexOrBuild()
+	if len(idx.byShapeHash) != 1 {
+		t.Fatalf("expected one shape hash entry, got %d", len(idx.byShapeHash))
+	}
+	for _, alias := range idx.byShapeHash {
+		if alias != "Alpha" {
+			t.Fatalf("stable winner = %q, want Alpha", alias)
+		}
+	}
+}
+
+func TestShapeAliasIndex_resolvesAssertionRefinementHash(t *testing.T) {
+	t.Parallel()
+	tc := testTypeChecker(t)
+	tc.registerType(ast.TypeDefNode{
+		Ident: "LoggedIn",
+		Expr: ast.TypeDefAssertionExpr{
+			Assertion: &ast.AssertionNode{BaseType: ptrTypeIdent("User")},
+		},
+	})
+	bt := ast.TypeIdent("LoggedIn")
+	h, err := tc.Hasher.HashNode(ast.AssertionNode{BaseType: &bt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashIdent := h.ToTypeIdent()
+	alias, ok := tc.lookupAssertionAliasForHashIdent(hashIdent)
+	if !ok || alias != "LoggedIn" {
+		t.Fatalf("lookupAssertionAliasForHashIdent(%s) = %q, %v; want LoggedIn, true", hashIdent, alias, ok)
+	}
+}
+
+func ptrTypeIdent(id ast.TypeIdent) *ast.TypeIdent {
+	return &id
+}

--- a/forst/internal/typechecker/type_alias_display.go
+++ b/forst/internal/typechecker/type_alias_display.go
@@ -17,35 +17,32 @@ func (tc *TypeChecker) resolveAliasedType(typeNode ast.TypeNode) ast.TypeNode {
 	if !isHashLike {
 		return typeNode
 	}
-	hashDef, hashExists := tc.Defs[typeNode.Ident]
-	if hashExists {
-		if hashTypeDef, ok := hashDef.(ast.TypeDefNode); ok {
-			if _, ok := hashTypeDef.Expr.(ast.TypeDefShapeExpr); ok {
-				if alias, ok := tc.lookupShapeAliasForHashType(typeNode); ok {
-					tc.log.WithFields(logrus.Fields{
-						"hashType":    typeNode.Ident,
-						"aliasedType": alias,
-						"function":    "resolveAliasedType",
-					}).Debug("Resolved hash-based type to aliased type")
-					return ast.TypeNode{
-						Ident:      alias,
-						TypeKind:   ast.TypeKindUserDefined,
-						Assertion:  typeNode.Assertion,
-						TypeParams: typeNode.TypeParams,
-					}
-				}
-			}
+	if alias, ok := tc.lookupShapeAliasForHashType(typeNode); ok {
+		if tc.log.IsLevelEnabled(logrus.DebugLevel) {
+			tc.log.WithFields(logrus.Fields{
+				"hashType":    typeNode.Ident,
+				"aliasedType": alias,
+				"function":    "resolveAliasedType",
+			}).Debug("Resolved hash-based type to aliased type")
+		}
+		return ast.TypeNode{
+			Ident:      alias,
+			TypeKind:   ast.TypeKindUserDefined,
+			Assertion:  typeNode.Assertion,
+			TypeParams: typeNode.TypeParams,
 		}
 	}
 	// type Name = <assertion>: narrowing `x is Name` uses InferAssertionType's structural hash (T_…).
 	// That hash matches HashNode(AssertionNode{BaseType: Name}), not the typedef's inner assertion.
 	if strings.HasPrefix(string(typeNode.Ident), "T_") {
 		if alias, ok := tc.lookupAssertionAliasForHashIdent(typeNode.Ident); ok {
-			tc.log.WithFields(logrus.Fields{
-				"hashType":    typeNode.Ident,
-				"aliasedType": alias,
-				"function":    "resolveAliasedType",
-			}).Debug("Resolved assertion refinement hash to type alias")
+			if tc.log.IsLevelEnabled(logrus.DebugLevel) {
+				tc.log.WithFields(logrus.Fields{
+					"hashType":    typeNode.Ident,
+					"aliasedType": alias,
+					"function":    "resolveAliasedType",
+				}).Debug("Resolved assertion refinement hash to type alias")
+			}
 			return ast.TypeNode{
 				Ident:      alias,
 				TypeKind:   ast.TypeKindUserDefined,

--- a/forst/internal/typechecker/type_alias_display.go
+++ b/forst/internal/typechecker/type_alias_display.go
@@ -20,30 +20,18 @@ func (tc *TypeChecker) resolveAliasedType(typeNode ast.TypeNode) ast.TypeNode {
 	hashDef, hashExists := tc.Defs[typeNode.Ident]
 	if hashExists {
 		if hashTypeDef, ok := hashDef.(ast.TypeDefNode); ok {
-			if hashShapeExpr, ok := hashTypeDef.Expr.(ast.TypeDefShapeExpr); ok {
-				hashShape := hashShapeExpr.Shape
-				for _, def := range tc.Defs {
-					if userDef, ok := def.(ast.TypeDefNode); ok && userDef.Ident != "" {
-						// RegisterHashBasedType stores the hash under T_… with a TypeDefShapeExpr; do not
-						// treat that entry (or any other hash typedef) as a display alias for itself.
-						if userDef.Ident == typeNode.Ident || strings.HasPrefix(string(userDef.Ident), "T_") {
-							continue
-						}
-						if userPayload, ok := ast.PayloadShape(userDef.Expr); ok {
-							if tc.shapesAreStructurallyIdentical(hashShape, *userPayload) {
-								tc.log.WithFields(logrus.Fields{
-									"hashType":    typeNode.Ident,
-									"aliasedType": userDef.Ident,
-									"function":    "resolveAliasedType",
-								}).Debug("Resolved hash-based type to aliased type")
-								return ast.TypeNode{
-									Ident:      userDef.Ident,
-									TypeKind:   ast.TypeKindUserDefined, // Mark as user-defined
-									Assertion:  typeNode.Assertion,
-									TypeParams: typeNode.TypeParams,
-								}
-							}
-						}
+			if _, ok := hashTypeDef.Expr.(ast.TypeDefShapeExpr); ok {
+				if alias, ok := tc.lookupShapeAliasForHashType(typeNode); ok {
+					tc.log.WithFields(logrus.Fields{
+						"hashType":    typeNode.Ident,
+						"aliasedType": alias,
+						"function":    "resolveAliasedType",
+					}).Debug("Resolved hash-based type to aliased type")
+					return ast.TypeNode{
+						Ident:      alias,
+						TypeKind:   ast.TypeKindUserDefined,
+						Assertion:  typeNode.Assertion,
+						TypeParams: typeNode.TypeParams,
 					}
 				}
 			}
@@ -52,32 +40,17 @@ func (tc *TypeChecker) resolveAliasedType(typeNode ast.TypeNode) ast.TypeNode {
 	// type Name = <assertion>: narrowing `x is Name` uses InferAssertionType's structural hash (T_…).
 	// That hash matches HashNode(AssertionNode{BaseType: Name}), not the typedef's inner assertion.
 	if strings.HasPrefix(string(typeNode.Ident), "T_") {
-		for _, def := range tc.Defs {
-			userDef, ok := def.(ast.TypeDefNode)
-			if !ok || userDef.Ident == "" || strings.HasPrefix(string(userDef.Ident), "T_") {
-				continue
-			}
-			if _, ok := typeDefAssertionFromExpr(userDef.Expr); !ok {
-				continue
-			}
-			bt := userDef.Ident
-			a := ast.AssertionNode{BaseType: &bt}
-			h, err := tc.Hasher.HashNode(a)
-			if err != nil {
-				continue
-			}
-			if h.ToTypeIdent() == typeNode.Ident {
-				tc.log.WithFields(logrus.Fields{
-					"hashType":    typeNode.Ident,
-					"aliasedType": userDef.Ident,
-					"function":    "resolveAliasedType",
-				}).Debug("Resolved assertion refinement hash to type alias")
-				return ast.TypeNode{
-					Ident:      userDef.Ident,
-					TypeKind:   ast.TypeKindUserDefined,
-					Assertion:  typeNode.Assertion,
-					TypeParams: typeNode.TypeParams,
-				}
+		if alias, ok := tc.lookupAssertionAliasForHashIdent(typeNode.Ident); ok {
+			tc.log.WithFields(logrus.Fields{
+				"hashType":    typeNode.Ident,
+				"aliasedType": alias,
+				"function":    "resolveAliasedType",
+			}).Debug("Resolved assertion refinement hash to type alias")
+			return ast.TypeNode{
+				Ident:      alias,
+				TypeKind:   ast.TypeKindUserDefined,
+				Assertion:  typeNode.Assertion,
+				TypeParams: typeNode.TypeParams,
 			}
 		}
 	}

--- a/forst/internal/typechecker/typechecker.go
+++ b/forst/internal/typechecker/typechecker.go
@@ -93,6 +93,10 @@ type TypeChecker struct {
 	siblingTypeDefCache map[ast.TypeIdent]cachedSiblingTypeDef
 	// siblingImportTypeDefCache memoizes resolveForstSiblingTypeInImports (hit and miss).
 	siblingImportTypeDefCache map[string]cachedSiblingTypeDef
+	// shapeAliasIndex lazily maps structural shape / assertion hashes to user type names.
+	shapeAliasIndex *shapeAliasIndex
+	// compatMemo caches IsTypeCompatible results for a single CheckTypes pass.
+	compatMemo map[compatKey]bool
 	// goPackagesPreloaded skips go/packages load in InferTypes when set by InitGoPackagesFromBatch.
 	goPackagesPreloaded bool
 	Warnings              []Diagnostic
@@ -143,6 +147,8 @@ func (tc *TypeChecker) HasDotImportPackages() bool {
 // 1. Collects explicit type declarations and function signatures
 // 2. Infers types for expressions and statements
 func (tc *TypeChecker) CheckTypes(nodes []ast.Node) error {
+	tc.shapeAliasIndex = nil
+	tc.compatMemo = nil
 	if err := tc.CollectTypes(nodes); err != nil {
 		return err
 	}

--- a/forst/internal/typechecker/typechecker.go
+++ b/forst/internal/typechecker/typechecker.go
@@ -100,6 +100,10 @@ type TypeChecker struct {
 	// goPackagesPreloaded skips go/packages load in InferTypes when set by InitGoPackagesFromBatch.
 	goPackagesPreloaded bool
 	Warnings              []Diagnostic
+	// scopeOwners maps declaration idents to the ScopeNode registered at collect (for transform restore).
+	scopeOwners scopeOwners
+	// typecheckNodes is the nodes slice from the last CheckTypes call (scope identity for transform).
+	typecheckNodes []ast.Node
 }
 
 // New creates a new TypeChecker.
@@ -127,6 +131,7 @@ func New(log *logrus.Logger, reportPhases bool) *TypeChecker {
 		variableGoTypes:                             make(map[ast.Identifier]types.Type),
 		log:                                         log,
 		reportPhases:                                reportPhases,
+		scopeOwners:                                 newScopeOwners(),
 	}
 
 	return tc
@@ -147,6 +152,7 @@ func (tc *TypeChecker) HasDotImportPackages() bool {
 // 1. Collects explicit type declarations and function signatures
 // 2. Infers types for expressions and statements
 func (tc *TypeChecker) CheckTypes(nodes []ast.Node) error {
+	tc.typecheckNodes = nodes
 	tc.shapeAliasIndex = nil
 	tc.compatMemo = nil
 	if err := tc.CollectTypes(nodes); err != nil {
@@ -155,8 +161,14 @@ func (tc *TypeChecker) CheckTypes(nodes []ast.Node) error {
 	return tc.InferTypes(nodes)
 }
 
+// TypecheckNodes returns the nodes slice from the last CheckTypes call.
+func (tc *TypeChecker) TypecheckNodes() []ast.Node {
+	return tc.typecheckNodes
+}
+
 // CollectTypes runs the first pass: explicit types, imports, and function signatures.
 func (tc *TypeChecker) CollectTypes(nodes []ast.Node) error {
+	tc.resetScopeOwners()
 	if tc.reportPhases {
 		tc.log.WithFields(logrus.Fields{
 			"function": "CollectTypes",


### PR DESCRIPTION
## Summary

Cheap scope keys (`HashScopeKey`) replace full `HashNode` for scope lookup, excluding function/guard/ensure bodies. Adds directional `IsTypeCompatible` memo, shape alias index, debug log gating, and E2E benchmarks for `tictactoe` and `providers`. Full `HashNode` type-identity semantics are unchanged.

`RestoreScope` drops from ~53 µs to ~80 ns. Tictactoe compile improves ~18%; large typecheck ~31%.

### Benchmark results (darwin/arm64, median of 5 runs)

| Benchmark | Purpose | Original | Pre-PR | Post-PR | Δ (original→post) | Δ (pre→post) |
|-----------|---------|----------|--------|---------|-------------------|--------------|
| `RestoreScope_functionBody` | Scope restore hot path | 89.2 µs | 53.5 µs | $\textcolor{green}{\textbf{30 ns}}$ | $\textcolor{green}{\textbf{-99.97\\%}}$ | $\textcolor{green}{\textbf{-99.94\\%}}$ |
| `HashNode_functionBody` | Full structural hash (unchanged semantics) | 87.4 µs | 160 µs | 183 µs | $\textcolor{red}{+109\\%}$ | $\textcolor{red}{+14\\%}$ |
| `HashNode_functionBody_walkMemo` | Walk-local memo only | — | 59 µs | 64 µs | — | $\textcolor{red}{+8\\%}$ |
| `Compile_basic` | Small-file E2E control | 14.82 ms | 14.86 ms | $\textcolor{green}{\textbf{14.3 ms}}$ | $\textcolor{green}{\textbf{-3.5\\%}}$ | $\textcolor{green}{\textbf{-3.8\\%}}$ |
| `Compile_shapeGuard` | Guard micro E2E | — | 4.30 ms | 4.67 ms | — | $\textcolor{red}{+8.6\\%}$ |
| `Compile_tictactoe` | Large guard-heavy merged package | — | 8.42 ms | $\textcolor{green}{\textbf{6.47 ms}}$ | — | $\textcolor{green}{\textbf{-23.2\\%}}$ |
| `Compile_providers` | Large merged providers demo | — | 2.45 ms | $\textcolor{green}{\textbf{2.31 ms}}$ | — | $\textcolor{green}{\textbf{-5.7\\%}}$ |
| `CheckTypes_largeFunction` | Large typecheck-only proxy | — | 1.09 ms | $\textcolor{green}{\textbf{0.87 ms}}$ | — | $\textcolor{green}{\textbf{-20.2\\%}}$ |

### Details

Replace full `HashNode` scope keys with `HashScopeKey` for functions, type guards, `ensure` nodes, and `ensure` blocks so `RestoreScope` avoids hashing large bodies. Add identity-based disambiguation when structural keys collide, and reuse existing scopes only when the parent stack frame matches.

Memoize `IsTypeCompatible` with a directional per-`CheckTypes` cache, index shape and assertion aliases for $\mathcal{O}(1)$ `resolveAliasedType` lookup, and gate hot-path debug logging behind `IsLevelEnabled`.

Add E2E compile benchmarks for merged `tictactoe` and `providers` packages. Re-run typecheck on entry-file AST for `examples/in` single-file compiles so scopes stay aligned with the AST used for codegen when modulecheck merges the directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structural and assertion-based type alias resolution.
  * Fixed scope restoration and matching for `ensure`, type-guards, functions, and `with`, improving editor navigation and completion accuracy.
  * Avoided incorrect reuse of type-checking state when a fresh per-pass check is required.
* **Performance**
  * Added memoization and more reliable scope identity handling to reduce repeated compatibility and scope computations.
* **Tests**
  * Added coverage for scope restoration, alias indexing, and compatibility memoization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->