### PR TITLE
test(testutil): add shared compiler pipeline test harness

### DIFF
--- a/forst/cmd/forst/lsp/testsupport.go
+++ b/forst/cmd/forst/lsp/testsupport.go
@@ -1,0 +1,46 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"forst/internal/testmod"
+
+	"github.com/sirupsen/logrus"
+)
+
+// NewTestLSPServer creates an LSP server backed by a temp module directory.
+func NewTestLSPServer(tb testing.TB, module string) (*LSPServer, string) {
+	tb.Helper()
+	dir := tb.TempDir()
+	if module == "" {
+		module = "testmod"
+	}
+	testmod.WriteGoMod(tb, dir, module)
+	log := logrus.New()
+	log.SetOutput(os.Stderr)
+	return NewLSPServer("0", log), dir
+}
+
+// OpenTestBuffer writes content to relPath under moduleRoot and registers it on the server.
+func OpenTestBuffer(tb testing.TB, srv *LSPServer, moduleRoot, relPath, content string) string {
+	tb.Helper()
+	path := filepath.Join(moduleRoot, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		tb.Fatal(err)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	uri := fileURIForLocalPath(abs)
+	if srv.openDocuments == nil {
+		srv.openDocuments = make(map[string]string)
+	}
+	srv.openDocuments[uri] = content
+	return uri
+}

--- a/forst/cmd/forst/main_examples_helpers_test.go
+++ b/forst/cmd/forst/main_examples_helpers_test.go
@@ -10,14 +10,12 @@ import (
 	"strings"
 	"testing"
 
-	"forst/internal/ast"
 	"forst/internal/forstpkg"
-	"forst/internal/generators"
 	"forst/internal/goload"
 	"forst/internal/parser"
 	"forst/internal/printer"
 	transformergo "forst/internal/transformer/go"
-	"forst/internal/typechecker"
+	"forst/internal/testutil"
 
 	"github.com/sirupsen/logrus"
 )
@@ -122,46 +120,28 @@ func exampleFtFormattedSourceParses(p *parser.Parser) (ok bool) {
 func compileExampleForGolden(t *testing.T, absEntry string, opts exampleGoldenCompileOpts) string {
 	t.Helper()
 	log := exampleTestLogger()
-
-	var nodes []ast.Node
-	var err error
+	compileOpts := testutil.CompileOpts{
+		TypecheckOpts: testutil.TypecheckOpts{
+			FileID: filepath.Base(absEntry),
+			Logger: log,
+		},
+		ExportStructFields: opts.exportStructFields,
+	}
+	if modRoot := goload.FindModuleRoot(filepath.Dir(absEntry)); modRoot != "" {
+		compileOpts.GoWorkspaceDir = modRoot
+	}
 	if opts.packageRoot != "" {
 		paths, err := collectSamePackageExampleFtPaths(log, opts.packageRoot, absEntry)
 		if err != nil {
 			t.Fatalf("collectSamePackageExampleFtPaths(%s): %v", absEntry, err)
 		}
-		nodes, _, err = forstpkg.ParseAndMergePackage(log, paths)
-	} else {
-		data, err := os.ReadFile(absEntry)
-		if err != nil {
-			t.Fatalf("read %s: %v", absEntry, err)
-		}
-		p := parser.NewTestParser(string(data), log)
-		nodes, err = p.ParseFile()
+		return transformergo.MustCompileMergedGo(t, paths, compileOpts)
 	}
+	data, err := os.ReadFile(absEntry)
 	if err != nil {
-		t.Fatalf("parse %s: %v", absEntry, err)
+		t.Fatalf("read %s: %v", absEntry, err)
 	}
-
-	tc := typechecker.New(log, false)
-	if modRoot := goload.FindModuleRoot(filepath.Dir(absEntry)); modRoot != "" {
-		tc.GoWorkspaceDir = modRoot
-	}
-	if err := tc.CheckTypes(nodes); err != nil {
-		t.Fatalf("typecheck %s: %v", absEntry, err)
-	}
-
-	tr := transformergo.New(tc, log, opts.exportStructFields)
-	goFile, err := tr.TransformForstFileToGo(nodes)
-	if err != nil {
-		t.Fatalf("transform %s: %v", absEntry, err)
-	}
-
-	code, err := generators.GenerateGoCode(goFile)
-	if err != nil {
-		t.Fatalf("format %s: %v", absEntry, err)
-	}
-	return code
+	return transformergo.MustCompileGo(t, string(data), compileOpts)
 }
 
 func collectSamePackageExampleFtPaths(log *logrus.Logger, rootDir, entryPath string) ([]string, error) {

--- a/forst/internal/goload/load_test.go
+++ b/forst/internal/goload/load_test.go
@@ -7,9 +7,10 @@ import (
 
 	"forst/internal/testmod"
 
-	"golang.org/x/tools/go/packages"
 	"go/types"
 	"strings"
+
+	"golang.org/x/tools/go/packages"
 )
 
 func moduleRootFromWD(t *testing.T) string {

--- a/forst/internal/testutil/assert.go
+++ b/forst/internal/testutil/assert.go
@@ -1,0 +1,37 @@
+package testutil
+
+import (
+	"fmt"
+	"testing"
+
+	"forst/internal/ast"
+)
+
+// AssertSingleType fails when types does not contain exactly one node with ident want.
+func AssertSingleType(tb testing.TB, types []ast.TypeNode, want ast.TypeIdent) {
+	tb.Helper()
+	if len(types) != 1 {
+		tb.Fatalf("expected exactly one type, got %d: %v", len(types), types)
+	}
+	if types[0].Ident != want {
+		tb.Fatalf("expected type %q, got %q", want, types[0].Ident)
+	}
+}
+
+// AssertSingleTypeString is like AssertSingleType with a string ident.
+func AssertSingleTypeString(tb testing.TB, types []ast.TypeNode, want string) {
+	tb.Helper()
+	AssertSingleType(tb, types, ast.TypeIdent(want))
+}
+
+// FormatTypes returns a compact string for test failure messages.
+func FormatTypes(types []ast.TypeNode) string {
+	if len(types) == 0 {
+		return "[]"
+	}
+	parts := make([]string, len(types))
+	for i, ty := range types {
+		parts[i] = string(ty.Ident)
+	}
+	return fmt.Sprintf("[%s]", fmt.Sprint(parts))
+}

--- a/forst/internal/testutil/doc.go
+++ b/forst/internal/testutil/doc.go
@@ -1,0 +1,12 @@
+// Package testutil provides shared helpers for Forst compiler pipeline tests.
+//
+// Layering (avoids Go import cycles):
+//   - testutil: logger, module root, parse, assert, opts, mixed-module fixtures
+//   - typechecker: Typecheck / MustTypecheck / MustTypecheckMerged (harness.go)
+//   - transformergo: MustCompileGo / MustCompileMergedGo (harness.go)
+//
+// Use MustTypecheck / MustCompileGo for in-process parse → typecheck → transform
+// tests. For end-to-end CLI/compiler benchmarks, keep using compiler.CompileFile
+// (see internal/compiler/bench_test.go) — that path exercises module providers,
+// discovery, and file I/O not covered here.
+package testutil

--- a/forst/internal/testutil/fixture_mixed.go
+++ b/forst/internal/testutil/fixture_mixed.go
@@ -1,0 +1,43 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"forst/internal/testmod"
+)
+
+const mixedGoHelpersSource = `package mixed
+
+func Add(a, b int) int {
+	return a + b
+}
+
+func unexported() int {
+	return 0
+}
+
+func OpenValue() (int, error) {
+	return 42, nil
+}
+`
+
+// WriteMixedGoForstModule creates a temp module with mixedtest/<module>/helpers.go.
+func WriteMixedGoForstModule(tb testing.TB, module string) (root, importPath string) {
+	tb.Helper()
+	if module == "" {
+		module = "mixed"
+	}
+	root = tb.TempDir()
+	modName := "mixedtest"
+	testmod.WriteGoMod(tb, root, modName)
+	mixedDir := filepath.Join(root, module)
+	if err := os.MkdirAll(mixedDir, 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mixedDir, "helpers.go"), []byte(mixedGoHelpersSource), 0o644); err != nil {
+		tb.Fatal(err)
+	}
+	return root, modName + "/" + module
+}

--- a/forst/internal/testutil/logger.go
+++ b/forst/internal/testutil/logger.go
@@ -1,0 +1,21 @@
+package testutil
+
+import (
+	"bytes"
+	"testing"
+
+	"forst/internal/ast"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TestLogger returns a logger suitable for tests: ast.SetupTestLogger with output
+// discarded unless testing.Verbose().
+func TestLogger(tb testing.TB, opts *ast.TestLoggerOptions) *logrus.Logger {
+	tb.Helper()
+	log := ast.SetupTestLogger(opts)
+	if !testing.Verbose() {
+		log.SetOutput(bytes.NewBuffer(nil))
+	}
+	return log
+}

--- a/forst/internal/testutil/modroot.go
+++ b/forst/internal/testutil/modroot.go
@@ -1,0 +1,59 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"forst/internal/goload"
+)
+
+// ModuleRoot walks upward from the process cwd until go.mod is found.
+func ModuleRoot(tb testing.TB) string {
+	tb.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			tb.Fatal("go.mod not found from cwd")
+		}
+		dir = parent
+	}
+}
+
+// ModuleRootFrom returns the module root for start using goload.FindModuleRoot.
+func ModuleRootFrom(tb testing.TB, start string) string {
+	tb.Helper()
+	root := goload.FindModuleRoot(start)
+	if root == "" {
+		tb.Fatalf("module root not found from %q", start)
+	}
+	return root
+}
+
+// ExamplePath resolves examples/in/<rel> from any package test working directory.
+func ExamplePath(tb testing.TB, rel string) string {
+	tb.Helper()
+	candidates := []string{
+		filepath.Join("..", "..", "..", "examples", "in", rel),
+		filepath.Join("..", "..", "examples", "in", rel),
+		filepath.Join("examples", "in", rel),
+	}
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				tb.Fatal(err)
+			}
+			return abs
+		}
+	}
+	tb.Fatalf("example file not found: %s (tried %v)", rel, candidates)
+	return ""
+}

--- a/forst/internal/testutil/opts.go
+++ b/forst/internal/testutil/opts.go
@@ -1,0 +1,23 @@
+package testutil
+
+import "github.com/sirupsen/logrus"
+
+// TypecheckOpts configures typecheck harness helpers in typechecker and testpipeline packages.
+type TypecheckOpts struct {
+	FileID              string // default "test.ft"
+	GoWorkspaceDir      string // explicit; use UseModuleRoot to set from cwd walk
+	UseModuleRoot       bool   // set GoWorkspaceDir from ModuleRoot(tb)
+	SamePackageGoImport string // sets tc.SetSamePackageGoImportPath
+	ModuleProviders     bool   // run modulecheck.CheckModuleProviders before CheckTypes
+	SkipUnlessGoImport  string // tb.Skip if import local name not loaded
+	SkipUnlessDotImport bool
+	ExpectError         string // non-empty: require CheckTypes error containing substring
+	Logger              *logrus.Logger
+}
+
+// CompileOpts configures compile harness helpers in testpipeline and transformergo tests.
+type CompileOpts struct {
+	TypecheckOpts
+	ExportStructFields bool
+	FormatGo           bool // run go/format.Source on output
+}

--- a/forst/internal/testutil/parse.go
+++ b/forst/internal/testutil/parse.go
@@ -1,0 +1,45 @@
+package testutil
+
+import (
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/lexer"
+	"forst/internal/parser"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ParseSource lexes and parses src into AST nodes.
+func ParseSource(tb testing.TB, src, fileID string, log *logrus.Logger) []ast.Node {
+	tb.Helper()
+	if fileID == "" {
+		fileID = "test.ft"
+	}
+	if log == nil {
+		log = TestLogger(tb, nil)
+	}
+	toks := lexer.New([]byte(src), fileID, log).Lex()
+	nodes, err := parser.New(toks, fileID, log).ParseFile()
+	if err != nil {
+		tb.Fatalf("parse %s: %v", fileID, err)
+	}
+	return nodes
+}
+
+// ParseSourceForBench is like ParseSource but for benchmarks (no testing.TB fatals on setup).
+func ParseSourceForBench(b *testing.B, src []byte, fileID string) []ast.Node {
+	b.Helper()
+	if fileID == "" {
+		fileID = "bench.ft"
+	}
+	log := logrus.New()
+	log.SetOutput(nil)
+	log.SetLevel(logrus.PanicLevel)
+	toks := lexer.New(src, fileID, log).Lex()
+	nodes, err := parser.New(toks, fileID, log).ParseFile()
+	if err != nil {
+		b.Fatalf("parse: %v", err)
+	}
+	return nodes
+}

--- a/forst/internal/testutil/testutil_test.go
+++ b/forst/internal/testutil/testutil_test.go
@@ -1,0 +1,45 @@
+package testutil
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+)
+
+func TestModuleRoot_findsGoMod(t *testing.T) {
+	root := ModuleRoot(t)
+	if !strings.HasSuffix(root, "forst") && !strings.Contains(root, "forst") {
+		t.Fatalf("unexpected module root: %s", root)
+	}
+}
+
+func TestAssertSingleType(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		AssertSingleTypeString(t, []ast.TypeNode{{Ident: "Int"}}, "Int")
+	})
+}
+
+func TestWriteMixedGoForstModule(t *testing.T) {
+	root, importPath := WriteMixedGoForstModule(t, "mixed")
+	if root == "" || importPath != "mixedtest/mixed" {
+		t.Fatalf("got root=%q importPath=%q", root, importPath)
+	}
+}
+
+func TestParseSource(t *testing.T) {
+	src := `package main
+func main() {}
+`
+	nodes := ParseSource(t, src, "test.ft", nil)
+	if len(nodes) == 0 {
+		t.Fatal("expected nodes")
+	}
+}
+
+func TestExamplePath(t *testing.T) {
+	path := ExamplePath(t, "basic.ft")
+	if !strings.HasSuffix(path, "basic.ft") {
+		t.Fatalf("unexpected path: %s", path)
+	}
+}

--- a/forst/internal/transformer/go/harness.go
+++ b/forst/internal/transformer/go/harness.go
@@ -1,0 +1,82 @@
+// Compile harness helpers for parse → typecheck → transform → Go emit tests.
+package transformergo
+
+import (
+	"go/format"
+	"testing"
+
+	"forst/internal/generators"
+	"forst/internal/modulecheck"
+	"forst/internal/testutil"
+	"forst/internal/typechecker"
+)
+
+// MustCompileGo parses, typechecks, transforms, and generates Go source from src.
+func MustCompileGo(tb testing.TB, src string, opts testutil.CompileOpts) string {
+	tb.Helper()
+	if opts.ModuleProviders {
+		moduleRoot := opts.GoWorkspaceDir
+		if moduleRoot == "" && opts.UseModuleRoot {
+			moduleRoot = testutil.ModuleRoot(tb)
+		}
+		if moduleRoot == "" {
+			tb.Fatal("ModuleProviders requires GoWorkspaceDir or UseModuleRoot")
+		}
+		log := opts.Logger
+		if log == nil {
+			log = testutil.TestLogger(tb, nil)
+		}
+		if _, err := modulecheck.CheckModuleProviders(log, modulecheck.Options{ModuleRoot: moduleRoot}); err != nil {
+			tb.Fatalf("module providers: %v", err)
+		}
+	}
+	tc, nodes := typechecker.MustTypecheck(tb, src, opts.TypecheckOpts)
+	log := opts.Logger
+	if log == nil {
+		log = testutil.TestLogger(tb, nil)
+	}
+	tr := New(tc, log, opts.ExportStructFields)
+	goFile, err := tr.TransformForstFileToGo(nodes)
+	if err != nil {
+		tb.Fatalf("transform: %v", err)
+	}
+	code, err := generators.GenerateGoCode(goFile)
+	if err != nil {
+		tb.Fatalf("generate Go: %v", err)
+	}
+	if opts.FormatGo {
+		formatted, err := format.Source([]byte(code))
+		if err != nil {
+			tb.Fatalf("format Go: %v", err)
+		}
+		code = string(formatted)
+	}
+	return code
+}
+
+// MustCompileMergedGo merges paths, typechecks, transforms, and generates Go source.
+func MustCompileMergedGo(tb testing.TB, paths []string, opts testutil.CompileOpts) string {
+	tb.Helper()
+	tc, nodes := typechecker.MustTypecheckMerged(tb, paths, opts.TypecheckOpts)
+	log := opts.Logger
+	if log == nil {
+		log = testutil.TestLogger(tb, nil)
+	}
+	tr := New(tc, log, opts.ExportStructFields)
+	goFile, err := tr.TransformForstFileToGo(nodes)
+	if err != nil {
+		tb.Fatalf("transform: %v", err)
+	}
+	code, err := generators.GenerateGoCode(goFile)
+	if err != nil {
+		tb.Fatalf("generate Go: %v", err)
+	}
+	if opts.FormatGo {
+		formatted, err := format.Source([]byte(code))
+		if err != nil {
+			tb.Fatalf("format Go: %v", err)
+		}
+		code = string(formatted)
+	}
+	return code
+}

--- a/forst/internal/transformer/go/harness_test.go
+++ b/forst/internal/transformer/go/harness_test.go
@@ -1,0 +1,18 @@
+package transformergo
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/testutil"
+)
+
+func TestHarness_mustCompileGo_smoke(t *testing.T) {
+	src := `package main
+func main() {}
+`
+	code := MustCompileGo(t, src, testutil.CompileOpts{})
+	if !strings.Contains(code, "package main") {
+		t.Fatalf("expected package main in output, got: %s", code)
+	}
+}

--- a/forst/internal/transformer/go/pipeline_integration_test.go
+++ b/forst/internal/transformer/go/pipeline_integration_test.go
@@ -4,15 +4,12 @@ import (
 	"bytes"
 	"go/format"
 	"go/token"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"forst/internal/ast"
-	"forst/internal/forstpkg"
-	"forst/internal/generators"
 	"forst/internal/parser"
+	"forst/internal/testutil"
 	"forst/internal/typechecker"
 )
 
@@ -21,6 +18,16 @@ type pipelineOpts struct {
 	goWorkspaceDir      string
 	skipUnlessGoImport  string // if set, t.Skip when go/packages did not load this import local name
 	skipUnlessDotImport bool   // if true, t.Skip when go/packages did not populate dot-import packages
+}
+
+func pipelineOptsToCompile(opts pipelineOpts) testutil.CompileOpts {
+	return testutil.CompileOpts{
+		TypecheckOpts: testutil.TypecheckOpts{
+			GoWorkspaceDir:      opts.goWorkspaceDir,
+			SkipUnlessGoImport:  opts.skipUnlessGoImport,
+			SkipUnlessDotImport: opts.skipUnlessDotImport,
+		},
+	}
 }
 
 // compileForstPipeline runs parse → typecheck → transform → generators.GenerateGoCode on Forst source.
@@ -32,92 +39,18 @@ func compileForstPipeline(t *testing.T, src string) string {
 // compileForstPipelineExt runs parse → typecheck → transform → generators.GenerateGoCode with optional GoWorkspaceDir.
 func compileForstPipelineExt(t *testing.T, src string, opts pipelineOpts) string {
 	t.Helper()
-	log := ast.SetupTestLogger(nil)
-	if !testing.Verbose() {
-		log.SetOutput(bytes.NewBuffer(nil))
-	}
-
-	p := parser.NewTestParser(src, log)
-	nodes, err := p.ParseFile()
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-
-	tc := typechecker.New(log, false)
-	tc.GoWorkspaceDir = opts.goWorkspaceDir
-	if err := tc.CheckTypes(nodes); err != nil {
-		t.Fatalf("typecheck: %v", err)
-	}
-	if opts.skipUnlessGoImport != "" && !tc.GoImportPackageLoaded(opts.skipUnlessGoImport) {
-		t.Skipf("%s not loaded (go/packages or workspace)", opts.skipUnlessGoImport)
-	}
-	if opts.skipUnlessDotImport && !tc.HasDotImportPackages() {
-		t.Skip("dot-import packages not loaded (go/packages or workspace)")
-	}
-
-	tr := New(tc, log)
-	goFile, err := tr.TransformForstFileToGo(nodes)
-	if err != nil {
-		t.Fatalf("transform: %v", err)
-	}
-
-	code, err := generators.GenerateGoCode(goFile)
-	if err != nil {
-		t.Fatalf("generate Go: %v", err)
-	}
-	return code
+	return MustCompileGo(t, src, pipelineOptsToCompile(opts))
 }
 
 // compileMergedForstFilesPipeline merges multiple .ft files in one package, then typechecks and transforms.
 func compileMergedForstFilesPipeline(t *testing.T, paths []string, opts pipelineOpts) string {
 	t.Helper()
-	log := ast.SetupTestLogger(nil)
-	if !testing.Verbose() {
-		log.SetOutput(bytes.NewBuffer(nil))
-	}
-	merged, _, err := forstpkg.ParseAndMergePackage(log, paths)
-	if err != nil {
-		t.Fatalf("merge package: %v", err)
-	}
-	tc := typechecker.New(log, false)
-	tc.GoWorkspaceDir = opts.goWorkspaceDir
-	if err := tc.CheckTypes(merged); err != nil {
-		t.Fatalf("typecheck: %v", err)
-	}
-	if opts.skipUnlessGoImport != "" && !tc.GoImportPackageLoaded(opts.skipUnlessGoImport) {
-		t.Skipf("%s not loaded (go/packages or workspace)", opts.skipUnlessGoImport)
-	}
-	if opts.skipUnlessDotImport && !tc.HasDotImportPackages() {
-		t.Skip("dot-import packages not loaded (go/packages or workspace)")
-	}
-	tr := New(tc, log)
-	goFile, err := tr.TransformForstFileToGo(merged)
-	if err != nil {
-		t.Fatalf("transform: %v", err)
-	}
-	code, err := generators.GenerateGoCode(goFile)
-	if err != nil {
-		t.Fatalf("generate Go: %v", err)
-	}
-	return code
+	return MustCompileMergedGo(t, paths, pipelineOptsToCompile(opts))
 }
 
 func moduleRootFromWD(t *testing.T) string {
 	t.Helper()
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("go.mod not found from cwd")
-		}
-		dir = parent
-	}
+	return testutil.ModuleRoot(t)
 }
 
 func TestPipeline_parse_typecheck_transform_goFormat(t *testing.T) {

--- a/forst/internal/typechecker/bench_test.go
+++ b/forst/internal/typechecker/bench_test.go
@@ -3,20 +3,16 @@ package typechecker
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"forst/internal/ast"
-	"forst/internal/lexer"
-	"forst/internal/parser"
-
-	"github.com/sirupsen/logrus"
+	"forst/internal/testutil"
 )
 
 func benchExampleSource(b *testing.B, rel string) []byte {
 	b.Helper()
-	path := filepath.Join("..", "..", "..", "examples", "in", rel)
+	path := testutil.ExamplePath(b, rel)
 	src, err := os.ReadFile(path)
 	if err != nil {
 		b.Fatalf("read example %s: %v", rel, err)
@@ -26,23 +22,12 @@ func benchExampleSource(b *testing.B, rel string) []byte {
 
 func benchParseNodes(b *testing.B, src []byte) []ast.Node {
 	b.Helper()
-	log := logrus.New()
-	log.SetOutput(nil)
-	log.SetLevel(logrus.PanicLevel)
-	toks := lexer.New(src, "bench.ft", log).Lex()
-	nodes, err := parser.New(toks, "bench.ft", log).ParseFile()
-	if err != nil {
-		b.Fatalf("parse: %v", err)
-	}
-	return nodes
+	return testutil.ParseSourceForBench(b, src, "bench.ft")
 }
 
 func benchTypeChecker(b *testing.B) *TypeChecker {
 	b.Helper()
-	log := logrus.New()
-	log.SetOutput(nil)
-	log.SetLevel(logrus.PanicLevel)
-	return New(log, false)
+	return NewTypeCheckerForBench(b)
 }
 
 func BenchmarkCheckTypes_basic(b *testing.B) {

--- a/forst/internal/typechecker/check_types_snippets_test.go
+++ b/forst/internal/typechecker/check_types_snippets_test.go
@@ -3,7 +3,7 @@ package typechecker
 import (
 	"testing"
 
-	"forst/internal/parser"
+	"forst/internal/testutil"
 )
 
 // TestCheckTypes_manyMinimalPrograms exercises common CheckTypes paths (parse → collect → infer).
@@ -685,16 +685,7 @@ func main() {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			log := setupTestLogger(nil)
-			p := parser.NewTestParser(tc.src, log)
-			nodes, err := p.ParseFile()
-			if err != nil {
-				t.Fatalf("parse: %v", err)
-			}
-			chk := New(log, false)
-			if err := chk.CheckTypes(nodes); err != nil {
-				t.Fatalf("CheckTypes: %v", err)
-			}
+			MustTypecheck(t, tc.src, testutil.TypecheckOpts{})
 		})
 	}
 }

--- a/forst/internal/typechecker/ensure_test.go
+++ b/forst/internal/typechecker/ensure_test.go
@@ -7,16 +7,5 @@ import (
 )
 
 func setupTestLogger(opts *ast.TestLoggerOptions) *logrus.Logger {
-	logger := logrus.New()
-	logger.SetLevel(logrus.DebugLevel)
-
-	if opts != nil {
-		logger.SetLevel(opts.ForceLevel)
-	}
-
-	logger.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp:   true,
-		TimestampFormat: "2006-01-02 15:04:05.000",
-	})
-	return logger
+	return ast.SetupTestLogger(opts)
 }

--- a/forst/internal/typechecker/example_ft_bundle_test.go
+++ b/forst/internal/typechecker/example_ft_bundle_test.go
@@ -2,10 +2,9 @@ package typechecker
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
-	"forst/internal/parser"
+	"forst/internal/testutil"
 )
 
 // TestCheckTypes_examplesBundle loads several large example files to cover builtin dispatch,
@@ -32,25 +31,17 @@ func TestCheckTypes_examplesBundle(t *testing.T) {
 		"rfc/guard/shape_guard.ft",
 		"rfc/providers/providers.ft",
 	}
-	root := filepath.Join("..", "..", "..", "examples", "in")
 	for _, name := range rel {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			p := filepath.Join(root, name)
-			src, err := os.ReadFile(p)
+			path := testutil.ExamplePath(t, name)
+			srcBytes, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("read: %v", err)
 			}
-			log := setupTestLogger(nil)
-			pr := parser.NewTestParser(string(src), log)
-			nodes, err := pr.ParseFile()
-			if err != nil {
-				t.Fatalf("parse %s: %v", name, err)
-			}
-			chk := New(log, false)
-			if err := chk.CheckTypes(nodes); err != nil {
-				t.Fatalf("CheckTypes %s: %v", name, err)
-			}
+			MustTypecheck(t, string(srcBytes), testutil.TypecheckOpts{
+				FileID: name,
+			})
 		})
 	}
 }

--- a/forst/internal/typechecker/examples_tree_test.go
+++ b/forst/internal/typechecker/examples_tree_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"forst/internal/parser"
+	"forst/internal/testutil"
 
 	"github.com/sirupsen/logrus"
 )
@@ -43,13 +43,12 @@ func TestCheckTypes_examplesInTree(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			nodes, err := parser.NewTestParser(string(src), log).ParseFile()
+			_, _, err = Typecheck(t, string(src), testutil.TypecheckOpts{
+				FileID:        filepath.Base(path),
+				UseModuleRoot: true,
+				Logger:        log,
+			})
 			if err != nil {
-				t.Skipf("parse: %v", err)
-			}
-			chk := New(log, false)
-			chk.GoWorkspaceDir = moduleRootForProvidersTest(t)
-			if err := chk.CheckTypes(nodes); err != nil {
 				t.Skipf("typecheck: %v", err)
 			}
 		})

--- a/forst/internal/typechecker/go_interop_test.go
+++ b/forst/internal/typechecker/go_interop_test.go
@@ -3,15 +3,13 @@ package typechecker
 import (
 	"errors"
 	"go/types"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"forst/internal/ast"
 	"forst/internal/goload"
 	"forst/internal/lexer"
 	"forst/internal/parser"
-	"forst/internal/testmod"
+	"forst/internal/testutil"
 
 	"github.com/sirupsen/logrus"
 )
@@ -62,24 +60,6 @@ func main() {
 	}
 	if tc.goPkgsByLocal == nil || tc.goPkgsByLocal["strings"] == nil {
 		t.Skip("strings not loaded")
-	}
-}
-
-func moduleRootFromWD(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("go.mod not found from cwd")
-		}
-		dir = parent
 	}
 }
 
@@ -807,58 +787,8 @@ func main() {
 	}
 }
 
-func writeMixedPackageModule(t *testing.T) (root, importPath string) {
-	t.Helper()
-	root = t.TempDir()
-	testmod.WriteGoMod(t, root, "mixedtest")
-	mixedDir := filepath.Join(root, "mixed")
-	if err := os.MkdirAll(mixedDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	goSrc := `package mixed
-
-func Add(a, b int) int {
-	return a + b
-}
-
-func unexported() int {
-	return 0
-}
-
-func OpenValue() (int, error) {
-	return 42, nil
-}
-`
-	if err := os.WriteFile(filepath.Join(mixedDir, "helpers.go"), []byte(goSrc), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	goload.ClearLoadCacheForTest()
-	return root, "mixedtest/mixed"
-}
-
-func typecheckMixedPackageSource(t *testing.T, root, importPath, src string) (*TypeChecker, []ast.Node) {
-	t.Helper()
-	log := logrus.New()
-	log.SetLevel(logrus.PanicLevel)
-	toks := lexer.New([]byte(src), "mixed/main.ft", log).Lex()
-	nodes, err := parser.New(toks, "mixed/main.ft", log).ParseFile()
-	if err != nil {
-		t.Fatal(err)
-	}
-	tc := New(log, false)
-	tc.GoWorkspaceDir = root
-	tc.SetSamePackageGoImportPath(importPath)
-	if err := tc.CheckTypes(nodes); err != nil {
-		t.Fatalf("typecheck: %v", err)
-	}
-	if tc.samePackageGo == nil {
-		t.Skip("same-package Go not loaded (go/packages or environment)")
-	}
-	return tc, nodes
-}
-
 func TestSamePackageGoCall_unqualifiedExportedFunc_typechecks(t *testing.T) {
-	root, importPath := writeMixedPackageModule(t)
+	root, importPath := testutil.WriteMixedGoForstModule(t, "mixed")
 	src := `package mixed
 
 func main() {
@@ -866,7 +796,7 @@ func main() {
 	println(x)
 }
 `
-	tc, nodes := typecheckMixedPackageSource(t, root, importPath, src)
+	tc, nodes := MustTypecheckMixedPackage(t, root, importPath, src)
 	var call ast.FunctionCallNode
 	for _, n := range nodes {
 		fn, ok := n.(ast.FunctionNode)
@@ -894,7 +824,7 @@ func main() {
 }
 
 func TestSamePackageGoCall_wrongArgType_returnsDiagnostic(t *testing.T) {
-	root, importPath := writeMixedPackageModule(t)
+	root, importPath := testutil.WriteMixedGoForstModule(t, "mixed")
 	src := `package mixed
 
 func main() {
@@ -923,7 +853,7 @@ func main() {
 }
 
 func TestSamePackageGoCall_forstFuncShadowsGoFunc(t *testing.T) {
-	root, importPath := writeMixedPackageModule(t)
+	root, importPath := testutil.WriteMixedGoForstModule(t, "mixed")
 	src := `package mixed
 
 func Add(x Int) {
@@ -934,11 +864,11 @@ func main() {
 	Add(1)
 }
 `
-	typecheckMixedPackageSource(t, root, importPath, src)
+	MustTypecheckMixedPackage(t, root, importPath, src)
 }
 
 func TestSamePackageGoCall_twoValueAssignment_recordsVariableGoTypes(t *testing.T) {
-	root, importPath := writeMixedPackageModule(t)
+	root, importPath := testutil.WriteMixedGoForstModule(t, "mixed")
 	src := `package mixed
 
 func main() {
@@ -947,7 +877,7 @@ func main() {
 	println(err)
 }
 `
-	tc, _ := typecheckMixedPackageSource(t, root, importPath, src)
+	tc, _ := MustTypecheckMixedPackage(t, root, importPath, src)
 	if tc.variableGoTypes[ast.Identifier("v")] == nil {
 		t.Fatal("expected variableGoTypes[\"v\"] after same-package two-value Go call")
 	}
@@ -957,7 +887,7 @@ func main() {
 }
 
 func TestSamePackageGoCall_unexportedGoFunc_notFound(t *testing.T) {
-	root, importPath := writeMixedPackageModule(t)
+	root, importPath := testutil.WriteMixedGoForstModule(t, "mixed")
 	src := `package mixed
 
 func main() {

--- a/forst/internal/typechecker/harness.go
+++ b/forst/internal/typechecker/harness.go
@@ -1,0 +1,162 @@
+// Test harness helpers for parse → typecheck. Used from tests across the module.
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/forstpkg"
+	"forst/internal/goload"
+	"forst/internal/parser"
+	"forst/internal/testutil"
+
+	"github.com/sirupsen/logrus"
+)
+
+func applyTypecheckOpts(tb testing.TB, tc *TypeChecker, opts testutil.TypecheckOpts) {
+	tb.Helper()
+	switch {
+	case opts.GoWorkspaceDir != "":
+		tc.GoWorkspaceDir = opts.GoWorkspaceDir
+	case opts.UseModuleRoot:
+		tc.GoWorkspaceDir = testutil.ModuleRoot(tb)
+	}
+	if opts.SamePackageGoImport != "" {
+		tc.SetSamePackageGoImportPath(opts.SamePackageGoImport)
+	}
+}
+
+func finishTypecheck(tb testing.TB, tc *TypeChecker, opts testutil.TypecheckOpts, checkErr error) {
+	tb.Helper()
+	if opts.ExpectError != "" {
+		if checkErr == nil {
+			tb.Fatalf("expected typecheck error containing %q, got nil", opts.ExpectError)
+		}
+		if !strings.Contains(checkErr.Error(), opts.ExpectError) {
+			tb.Fatalf("typecheck error %q does not contain %q", checkErr.Error(), opts.ExpectError)
+		}
+		return
+	}
+	if checkErr != nil {
+		tb.Fatalf("typecheck: %v", checkErr)
+	}
+	if opts.SkipUnlessGoImport != "" && !tc.GoImportPackageLoaded(opts.SkipUnlessGoImport) {
+		tb.Skipf("%s not loaded (go/packages or workspace)", opts.SkipUnlessGoImport)
+	}
+	if opts.SkipUnlessDotImport && !tc.HasDotImportPackages() {
+		tb.Skip("dot-import packages not loaded (go/packages or workspace)")
+	}
+}
+
+func runCheckTypes(tb testing.TB, log *logrus.Logger, nodes []ast.Node, opts testutil.TypecheckOpts) (*TypeChecker, error) {
+	tb.Helper()
+	if opts.ModuleProviders {
+		tb.Fatal("ModuleProviders is not supported in typechecker.Typecheck; use transformergo.MustCompileGo")
+	}
+	tc := New(log, false)
+	applyTypecheckOpts(tb, tc, opts)
+	return tc, tc.CheckTypes(nodes)
+}
+
+// Typecheck parses and typechecks src. Returns typecheck/module errors without fataling.
+func Typecheck(tb testing.TB, src string, opts testutil.TypecheckOpts) (*TypeChecker, []ast.Node, error) {
+	tb.Helper()
+	fileID := opts.FileID
+	if fileID == "" {
+		fileID = "test.ft"
+	}
+	log := opts.Logger
+	if log == nil {
+		log = testutil.TestLogger(tb, nil)
+	}
+	p := parser.NewTestParser(src, log)
+	nodes, err := p.ParseFile()
+	if err != nil {
+		tb.Fatalf("parse: %v", err)
+	}
+	tc, checkErr := runCheckTypes(tb, log, nodes, opts)
+	if opts.ExpectError != "" {
+		finishTypecheck(tb, tc, opts, checkErr)
+		return tc, nodes, checkErr
+	}
+	if checkErr != nil {
+		return tc, nodes, checkErr
+	}
+	finishTypecheck(tb, tc, opts, checkErr)
+	return tc, nodes, nil
+}
+
+// MustTypecheck parses and typechecks src, fatals on unexpected errors.
+func MustTypecheck(tb testing.TB, src string, opts testutil.TypecheckOpts) (*TypeChecker, []ast.Node) {
+	tb.Helper()
+	tc, nodes, err := Typecheck(tb, src, opts)
+	if opts.ExpectError != "" {
+		return tc, nodes
+	}
+	if err != nil {
+		tb.Fatalf("typecheck: %v", err)
+	}
+	return tc, nodes
+}
+
+// MustTypecheckMerged merges paths into one package, then typechecks.
+func MustTypecheckMerged(tb testing.TB, paths []string, opts testutil.TypecheckOpts) (*TypeChecker, []ast.Node) {
+	tb.Helper()
+	log := opts.Logger
+	if log == nil {
+		log = testutil.TestLogger(tb, nil)
+	}
+	merged, _, err := forstpkg.ParseAndMergePackage(log, paths)
+	if err != nil {
+		tb.Fatalf("merge package: %v", err)
+	}
+	tc, checkErr := runCheckTypes(tb, log, merged, opts)
+	finishTypecheck(tb, tc, opts, checkErr)
+	return tc, merged
+}
+
+// MustTypecheckMixedPackage typechecks src in a mixed Go/Forst module fixture.
+func MustTypecheckMixedPackage(tb testing.TB, root, importPath, src string) (*TypeChecker, []ast.Node) {
+	tb.Helper()
+	goload.ClearLoadCacheForTest()
+	tc, nodes := MustTypecheck(tb, src, testutil.TypecheckOpts{
+		FileID:              "mixed/main.ft",
+		GoWorkspaceDir:      root,
+		SamePackageGoImport: importPath,
+	})
+	if !tc.SamePackageGoLoaded() {
+		tb.Skip("same-package Go not loaded (go/packages or environment)")
+	}
+	return tc, nodes
+}
+
+// NewTypeCheckerForBench returns a silent TypeChecker for benchmarks.
+func NewTypeCheckerForBench(b *testing.B) *TypeChecker {
+	b.Helper()
+	log := logrus.New()
+	log.SetOutput(nil)
+	log.SetLevel(logrus.PanicLevel)
+	return New(log, false)
+}
+
+func moduleRootFromWD(tb testing.TB) string {
+	tb.Helper()
+	return testutil.ModuleRoot(tb)
+}
+
+func moduleRootForProvidersTest(tb testing.TB) string {
+	tb.Helper()
+	return testutil.ModuleRoot(tb)
+}
+
+func moduleRootForResultTests(tb testing.TB) string {
+	tb.Helper()
+	return testutil.ModuleRoot(tb)
+}
+
+func parseAndCheck(tb testing.TB, src string) (*TypeChecker, error) {
+	tb.Helper()
+	tc, _, err := Typecheck(tb, src, testutil.TypecheckOpts{UseModuleRoot: true})
+	return tc, err
+}

--- a/forst/internal/typechecker/harness_test.go
+++ b/forst/internal/typechecker/harness_test.go
@@ -1,0 +1,54 @@
+package typechecker
+
+import (
+	"testing"
+
+	"forst/internal/testutil"
+)
+
+func TestHarness_mustTypecheck_minimalProgram(t *testing.T) {
+	src := `package main
+func main() {}
+`
+	tc, nodes := MustTypecheck(t, src, testutil.TypecheckOpts{})
+	if tc == nil || len(nodes) == 0 {
+		t.Fatal("expected typechecker and nodes")
+	}
+}
+
+func TestHarness_mustTypecheck_expectError(t *testing.T) {
+	src := `package main
+func main() {
+	x := 1 + "two"
+}
+`
+	tc, _ := MustTypecheck(t, src, testutil.TypecheckOpts{ExpectError: "type mismatch"})
+	if tc == nil {
+		t.Fatal("expected typechecker even on error path")
+	}
+}
+
+func TestHarness_mustTypecheck_useModuleRoot(t *testing.T) {
+	src := `package main
+func main() {}
+`
+	tc, _ := MustTypecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
+	if tc.GoWorkspaceDir == "" {
+		t.Fatal("expected GoWorkspaceDir when UseModuleRoot is set")
+	}
+}
+
+func TestHarness_mustTypecheckMixedPackage(t *testing.T) {
+	root, importPath := testutil.WriteMixedGoForstModule(t, "mixed")
+	src := `package mixed
+
+func main() {
+	x := Add(1, 2)
+	println(x)
+}
+`
+	tc, nodes := MustTypecheckMixedPackage(t, root, importPath, src)
+	if tc == nil || len(nodes) == 0 {
+		t.Fatal("expected typechecker and nodes")
+	}
+}

--- a/forst/internal/typechecker/providers_scope_test.go
+++ b/forst/internal/typechecker/providers_scope_test.go
@@ -1,0 +1,113 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/testutil"
+)
+
+func TestProvidersScope_nilWiringRejected(t *testing.T) {
+	src := `package main
+
+import "testing"
+
+type Logger = { info(msg String) }
+
+func TestX(t *testing.T) {
+	with { Logger: nil } {
+		x := 1
+	}
+}
+`
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
+	if err == nil {
+		t.Fatal("expected error for nil wiring")
+	}
+	diag, ok := err.(*Diagnostic)
+	if !ok || diag.Code != "providers-nil-wiring" {
+		t.Fatalf("expected providers-nil-wiring, got %T: %v", err, err)
+	}
+}
+
+func TestProvidersScope_unknownWiringKeyRejected(t *testing.T) {
+	src := `package main
+
+import "testing"
+
+type Logger = { info(msg String) }
+
+func TestX(t *testing.T) {
+	with { NotAContract: &NopLogger {} } {
+		x := 1
+	}
+}
+
+type NopLogger = {}
+func (NopLogger) info(msg String) {}
+`
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
+	if err == nil {
+		t.Fatal("expected error for unknown wiring key")
+	}
+	diag, ok := err.(*Diagnostic)
+	if !ok || diag.Code != "providers-unknown-key" {
+		t.Fatalf("expected providers-unknown-key, got %T: %v", err, err)
+	}
+}
+
+func TestProvidersScope_withBlockSatisfiesLogger(t *testing.T) {
+	src := `package main
+
+import "testing"
+
+type Logger = { info(msg String) }
+
+type NopLogger = {}
+func (NopLogger) info(msg String) {}
+
+func needsLogger() {
+	use logger: Logger
+}
+
+func TestX(t *testing.T) {
+	with { Logger: &NopLogger {} } {
+		needsLogger()
+	}
+}
+`
+	MustTypecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
+}
+
+func TestProvidersScope_wiringTypeMismatch(t *testing.T) {
+	src := `package main
+
+import "testing"
+
+type Logger = { info(msg String) }
+type Clock = { now(): Int }
+
+type NopLogger = {}
+func (NopLogger) info(msg String) {}
+
+func TestX(t *testing.T) {
+	with { Logger: &FakeClock { fixedMs: 1 } } {
+		x := 1
+	}
+}
+
+type FakeClock = { fixedMs: Int }
+func (c FakeClock) now(): Int { return c.fixedMs }
+`
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
+	if err == nil {
+		t.Fatal("expected wiring type mismatch error")
+	}
+	diag, ok := err.(*Diagnostic)
+	if !ok || diag.Code != "providers-wiring-type" {
+		t.Fatalf("expected providers-wiring-type, got %T: %v", err, err)
+	}
+	if !strings.Contains(diag.Msg, "Logger") {
+		t.Fatalf("expected Logger in message: %q", diag.Msg)
+	}
+}

--- a/forst/internal/typechecker/providers_test.go
+++ b/forst/internal/typechecker/providers_test.go
@@ -1,49 +1,11 @@
 package typechecker
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
-	"forst/internal/lexer"
-	"forst/internal/parser"
-
-	"github.com/sirupsen/logrus"
+	"forst/internal/testutil"
 )
-
-func moduleRootForProvidersTest(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("go.mod not found from cwd")
-		}
-		dir = parent
-	}
-}
-
-func parseAndCheck(t *testing.T, src string) (*TypeChecker, error) {
-	t.Helper()
-	log := logrus.New()
-	log.SetLevel(logrus.PanicLevel)
-	toks := lexer.New([]byte(src), "t.ft", log).Lex()
-	nodes, err := parser.New(toks, "t.ft", log).ParseFile()
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	tc := New(log, false)
-	tc.GoWorkspaceDir = moduleRootForProvidersTest(t)
-	err = tc.CheckTypes(nodes)
-	return tc, err
-}
 
 func providerRootNames(slots []ProviderSlot) []string {
 	out := make([]string, len(slots))
@@ -84,7 +46,7 @@ func expireToken(token Token) {
 	use clock: Clock
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("typecheck: %v", err)
 	}
@@ -110,7 +72,7 @@ func outer() {
 	inner()
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	roots := providerRootNames(tc.FunctionProviders["outer"])
 	if !containsAll(roots, "Logger") {
 		t.Fatalf("FunctionProviders(outer) = %v, want Logger from inner()", roots)
@@ -140,7 +102,7 @@ func outer() {
 	}
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("typecheck: %v", err)
 	}
@@ -180,7 +142,7 @@ func TestNestedWith(t *testing.T) {
 	}
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("typecheck: %v", err)
 	}
@@ -199,7 +161,7 @@ func f() {
 	use x: AuditLogger
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("typecheck: %v", err)
 	}
@@ -244,7 +206,7 @@ func TestExpireToken(t *testing.T) {
 	}
 }
 `
-	_, err := parseAndCheck(t, src)
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("vertical slice should typecheck: %v", err)
 	}
@@ -266,7 +228,7 @@ func TestX(t *testing.T) {
 type NopLogger = {}
 func (NopLogger) info(msg String) {}
 `
-	_, err := parseAndCheck(t, src)
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err == nil {
 		t.Fatal("expected error for unknown wiring key")
 	}
@@ -294,7 +256,7 @@ func TestX(t *testing.T) {
 	needsLogger()
 }
 `
-	_, err := parseAndCheck(t, src)
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err == nil {
 		t.Fatal("expected error for unsatisfied Logger")
 	}
@@ -337,7 +299,7 @@ func TestX(t *testing.T) {
 type NopLogger = {}
 func (NopLogger) info(msg String) {}
 `
-	_, err := parseAndCheck(t, src)
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err == nil {
 		t.Fatal("expected error for second unsatisfied needsLogger() call")
 	}
@@ -370,7 +332,7 @@ func TestX(t *testing.T) {
 	}
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("typecheck: %v", err)
 	}
@@ -413,7 +375,7 @@ func TestAssignCall(t *testing.T) {
 	}
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("typecheck: %v", err)
 	}
@@ -451,7 +413,7 @@ func TestX(t *testing.T) {
 	}
 }
 `
-	_, err := parseAndCheck(t, src)
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err == nil {
 		t.Fatal("expected error for alias wiring key")
 	}
@@ -477,7 +439,7 @@ func TestX(t *testing.T) {
 	}
 }
 `
-	_, err := parseAndCheck(t, src)
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err == nil {
 		t.Fatal("expected error for nil wiring")
 	}
@@ -498,7 +460,7 @@ import "testing"
 func TestX(t *testing.T) {
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("typecheck: %v", err)
 	}
@@ -516,15 +478,7 @@ func PublicApi() {
 	use logger: Logger
 }
 `
-	log := logrus.New()
-	log.SetLevel(logrus.PanicLevel)
-	toks := lexer.New([]byte(src), "t.ft", log).Lex()
-	nodes, err := parser.New(toks, "t.ft", log).ParseFile()
-	if err != nil {
-		t.Fatal(err)
-	}
-	tc := New(log, false)
-	err = tc.CheckTypes(nodes)
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{})
 	if err == nil {
 		t.Fatal("expected sidecar export error")
 	}
@@ -556,7 +510,7 @@ func TestRoot(t *testing.T) {
 type NopLogger = {}
 func (NopLogger) info(msg String) {}
 `
-	_, err := parseAndCheck(t, src)
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err == nil {
 		t.Fatal("expected wiring root error for missing Clock")
 	}
@@ -593,7 +547,7 @@ func TestRoot(t *testing.T) {
 	}
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("typecheck: %v", err)
 	}
@@ -615,7 +569,7 @@ func TestRoot(t *testing.T) {
 	}
 }
 `
-	_, err := parseAndCheck(t, src)
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err == nil {
 		t.Fatal("expected unknown wiring key error")
 	}
@@ -636,7 +590,7 @@ func writeAudit(msg String) {
 	use w: AuditWriter
 }
 `
-	tc, err := parseAndCheck(t, src)
+	tc, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
 	if err != nil {
 		t.Fatalf("typecheck: %v", err)
 	}

--- a/forst/internal/typechecker/result_narrowing_test.go
+++ b/forst/internal/typechecker/result_narrowing_test.go
@@ -1,32 +1,12 @@
 package typechecker
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"forst/internal/ast"
 	"forst/internal/parser"
 )
-
-func moduleRootForResultTests(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("go.mod not found from cwd")
-		}
-		dir = parent
-	}
-}
 
 func TestIfResult_isOk_narrowsSuccessType(t *testing.T) {
 	t.Parallel()

--- a/forst/internal/typechecker/typechecker.go
+++ b/forst/internal/typechecker/typechecker.go
@@ -148,6 +148,11 @@ func (tc *TypeChecker) HasDotImportPackages() bool {
 	return len(tc.dotImportPkgs) > 0
 }
 
+// SamePackageGoLoaded reports whether same-package Go interop loaded via SetSamePackageGoImportPath.
+func (tc *TypeChecker) SamePackageGoLoaded() bool {
+	return tc.samePackageGo != nil
+}
+
 // CheckTypes performs type inference in two passes:
 // 1. Collects explicit type declarations and function signatures
 // 2. Infers types for expressions and statements

--- a/forst/internal/typechecker/unify_typeguard_test.go
+++ b/forst/internal/typechecker/unify_typeguard_test.go
@@ -1,0 +1,90 @@
+package typechecker
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/testutil"
+)
+
+func TestUnifyTypeguard_rejectsNominalErrorBareIsGuard(t *testing.T) {
+	src := `package main
+
+error ParseError { code: Int }
+
+func main() {
+	x := mk()
+	if x is ParseError {
+		println(x)
+	}
+}
+
+func mk(): Result(Int, ParseError) {
+	return 0
+}
+`
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
+	if err == nil {
+		t.Fatal("expected error for bare nominal error is guard")
+	}
+	if !strings.Contains(err.Error(), "nominal error type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUnifyTypeguard_presentRequiresPointer(t *testing.T) {
+	src := `package main
+
+func main() {
+	n := 1
+	if n is Present() {
+		println(n)
+	}
+}
+`
+	_, _, err := Typecheck(t, src, testutil.TypecheckOpts{})
+	if err == nil {
+		t.Fatal("expected error for Present on non-pointer")
+	}
+	if !strings.Contains(err.Error(), "present assertion requires a pointer") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUnifyTypeguard_okDiscriminatorOnResult(t *testing.T) {
+	src := `package main
+
+func main() {
+	x := mk()
+	if x is Ok() {
+		println(x)
+	}
+}
+
+func mk(): Result(Int, String) {
+	return 0
+}
+`
+	MustTypecheck(t, src, testutil.TypecheckOpts{})
+}
+
+func TestUnifyTypeguard_typeGuardSubjectMismatch(t *testing.T) {
+	tc := New(setupTestLogger(nil), false)
+	tc.Defs["Positive"] = ast.TypeGuardNode{
+		Ident: ast.Identifier("Positive"),
+		Subject: ast.SimpleParamNode{
+			Ident: ast.Ident{ID: "n"},
+			Type:  ast.TypeNode{Ident: ast.TypeInt},
+		},
+	}
+	err := tc.validateAssertionNode(ast.AssertionNode{
+		Constraints: []ast.ConstraintNode{{Name: "Positive"}},
+	}, ast.TypeNode{Ident: ast.TypeString})
+	if err == nil {
+		t.Fatal("expected type guard subject mismatch error")
+	}
+	if !strings.Contains(err.Error(), "type guard 'Positive' requires subject type Int") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Introduce `internal/testutil` for shared logger, module-root, parse, assert, and fixture helpers, with `typechecker` and `transformergo` harness entry points for `Typecheck` and `MustCompileGo` to avoid import cycles.

Migrate providers, snippet, golden, go interop, example-tree, and benchmark tests onto the harness and remove duplicated parse/typecheck wiring. Add stem coverage for `unify_typeguard` and `providers_scope`, LSP test fixtures, and `TypeChecker.SamePackageGoLoaded` for mixed Go/Forst module tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared test helpers for parsing, typechecking, logging, module-root lookup, and example-file resolution.
  * Added streamlined test harnesses for compiling Forst to Go and for LSP test setup.

* **Bug Fixes**
  * Expanded coverage for provider wiring, typeguard validation, same-package Go interop, and mixed-package scenarios.
  * Simplified several tests to use common helpers, improving consistency and reliability.

* **Tests**
  * Added new smoke tests and helper tests to verify the new shared test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->