### PR TITLE
feat(lsp): add go-to-definition for import node bindings

### DIFF
--- a/docs/workflow/editor.mdx
+++ b/docs/workflow/editor.mdx
@@ -29,7 +29,7 @@ The extension starts the language server automatically and fetches the matching 
 | --- | --- |
 | Open or edit a `.ft` file | Diagnostics update as you type |
 | Hover a symbol | Types, docs, Provider obligations, and Go import signatures (with godoc when available) |
-| **Go to definition** / **Find references** | Jump across same-package `.ft` files and cross-package Forst imports in the same module |
+| **Go to definition** / **Find references** | Jump across same-package `.ft` files, cross-package Forst imports in the same module, and **`import node`** bindings to resolved `.ts`/`.js` files (module path, alias, and export names like `payment.create`) |
 | **Rename symbol** | Rename across merged package sources |
 | **Format document** | Format the current file (experimental) |
 | **Command palette → Forst** | Focus logs or restart the language server |
@@ -37,6 +37,8 @@ The extension starts the language server automatically and fetches the matching 
 Completion covers keywords, locals, same-package symbols, and members on Go-typed bindings where inference ran. Completion for Go package names after `pkg.` is not available yet.
 
 **Go interop in the editor:** qualified imports (`fmt.Println`) and same-package `.go` functions show `go/types` signatures; godoc is included when loads succeed. Cross-package Forst imports (e.g. Providers `auth` → `api`) use module-level typechecking so diagnostics match compile-time arity—not emitted `z_forst_gen.go` stubs. See [Go interop](/interop/go).
+
+**Node interop in the editor:** `import node` path strings, module aliases, and qualified calls (`payment.create`) support **go to definition** into the resolved TypeScript or JavaScript module. Export names jump to the indexed symbol when the compiler has indexed the module. See [Node interop](/interop/node).
 
 ## Settings
 

--- a/forst/cmd/forst/lsp/definition.go
+++ b/forst/cmd/forst/lsp/definition.go
@@ -65,7 +65,16 @@ func (s *LSPServer) findDefinitionForPosition(uri string, position LSPPosition) 
 	}
 	tokens := ctx.Tokens
 	tok := tokenAtLSPPosition(tokens, position)
-	if tok == nil || tok.Type != ast.TokenIdentifier {
+	if tok == nil {
+		return nil
+	}
+	if tok.Type == ast.TokenStringLiteral {
+		if loc := s.definingLocationForNodeImportPath(ctx, tok); loc != nil {
+			return loc
+		}
+		return nil
+	}
+	if tok.Type != ast.TokenIdentifier {
 		return nil
 	}
 	if ctx.PackageMerge != nil {
@@ -83,6 +92,12 @@ func (s *LSPServer) findDefinitionForPosition(uri string, position LSPPosition) 
 	}
 	if defTok := definingTokenForLocalBinding(ctx, tokIdx, tok); defTok != nil {
 		return lspLocationPtrFromToken(uri, defTok)
+	}
+	if loc := s.definingLocationForQualifiedNodeImport(ctx, tokIdx); loc != nil {
+		return loc
+	}
+	if loc := s.definingLocationForNodeImportLocal(ctx, tokIdx, tok); loc != nil {
+		return loc
 	}
 	if loc := s.definingLocationForQualifiedImport(ctx, tokIdx); loc != nil {
 		return loc

--- a/forst/cmd/forst/lsp/node_definition.go
+++ b/forst/cmd/forst/lsp/node_definition.go
@@ -1,0 +1,117 @@
+package lsp
+
+import (
+	"strconv"
+	"unicode/utf8"
+
+	"forst/internal/ast"
+	"forst/internal/nodeinterop"
+)
+
+func lspLocationPtrFromAbsPath(absPath string, loc nodeinterop.IndexSourceLocation) *LSPLocation {
+	if absPath == "" {
+		return nil
+	}
+	uri := fileURIForLocalPath(absPath)
+	if !loc.IsSet() {
+		return &LSPLocation{
+			URI: uri,
+			Range: LSPRange{
+				Start: LSPPosition{Line: 0, Character: 0},
+				End:   LSPPosition{Line: 0, Character: 0},
+			},
+		}
+	}
+	line0 := max(loc.Line-1, 0)
+	col0 := max(loc.Column, 0)
+	endLine0 := line0
+	endCol0 := col0 + 1
+	if loc.EndLine > 0 {
+		endLine0 = max(loc.EndLine-1, line0)
+	}
+	if loc.EndColumn > col0 {
+		endCol0 = loc.EndColumn
+	} else if loc.EndColumn == col0 {
+		endCol0 = col0 + 1
+	}
+	return &LSPLocation{
+		URI: uri,
+		Range: LSPRange{
+			Start: LSPPosition{Line: line0, Character: col0},
+			End:   LSPPosition{Line: endLine0, Character: endCol0},
+		},
+	}
+}
+
+func lspLocationPtrFromExportName(absPath string, loc nodeinterop.IndexSourceLocation, exportName string) *LSPLocation {
+	if loc.IsSet() {
+		return lspLocationPtrFromAbsPath(absPath, loc)
+	}
+	width := max(utf8.RuneCountInString(exportName), 1)
+	return &LSPLocation{
+		URI: fileURIForLocalPath(absPath),
+		Range: LSPRange{
+			Start: LSPPosition{Line: 0, Character: 0},
+			End:   LSPPosition{Line: 0, Character: width},
+		},
+	}
+}
+
+func (s *LSPServer) definingLocationForNodeImportPath(ctx *forstDocumentContext, tok *ast.Token) *LSPLocation {
+	if ctx == nil || ctx.TC == nil || tok == nil || tok.Type != ast.TokenStringLiteral {
+		return nil
+	}
+	i := tokenSliceIndex(ctx.Tokens, tok)
+	if i < 0 || !importPathStringInImportClause(ctx.Tokens, i) {
+		return nil
+	}
+	rawPath := tok.Value
+	if unquoted, err := strconv.Unquote(rawPath); err == nil {
+		rawPath = unquoted
+	}
+	abs, ok := ctx.TC.NodeImportPathAbsPath(rawPath)
+	if !ok {
+		return nil
+	}
+	return lspLocationPtrFromAbsPath(abs, nodeinterop.IndexSourceLocation{})
+}
+
+func (s *LSPServer) definingLocationForQualifiedNodeImport(ctx *forstDocumentContext, tokIdx int) *LSPLocation {
+	moduleLocal, exportName, ok := qualifiedImportSymbolAt(ctx.Tokens, tokIdx)
+	if !ok || ctx.TC == nil || !ctx.TC.IsNodeImportLocal(moduleLocal) {
+		return nil
+	}
+	abs, loc, ok := ctx.TC.NodeExportDefinitionLocation(moduleLocal, exportName)
+	if !ok {
+		return nil
+	}
+	return lspLocationPtrFromExportName(abs, loc, exportName)
+}
+
+func (s *LSPServer) definingLocationForNodeImportLocal(ctx *forstDocumentContext, tokIdx int, tok *ast.Token) *LSPLocation {
+	if ctx == nil || ctx.TC == nil || tok == nil || tok.Type != ast.TokenIdentifier {
+		return nil
+	}
+	tc := ctx.TC
+	moduleLocal := tok.Value
+	if !tc.IsNodeImportLocal(moduleLocal) {
+		return nil
+	}
+	if tokIdx+2 < len(ctx.Tokens) &&
+		ctx.Tokens[tokIdx+1].Type == ast.TokenDot &&
+		ctx.Tokens[tokIdx+2].Type == ast.TokenIdentifier {
+		abs, ok := tc.NodeImportAbsPath(moduleLocal)
+		if !ok {
+			return nil
+		}
+		return lspLocationPtrFromAbsPath(abs, nodeinterop.IndexSourceLocation{})
+	}
+	if nodeImportAliasBindingAt(ctx.Tokens, tokIdx) {
+		abs, ok := tc.NodeImportAbsPath(moduleLocal)
+		if !ok {
+			return nil
+		}
+		return lspLocationPtrFromAbsPath(abs, nodeinterop.IndexSourceLocation{})
+	}
+	return nil
+}

--- a/forst/cmd/forst/lsp/node_definition_test.go
+++ b/forst/cmd/forst/lsp/node_definition_test.go
@@ -1,0 +1,167 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"forst/internal/nodeinterop"
+
+	"github.com/sirupsen/logrus"
+)
+
+func writeNodeInteropLSPFixture(t *testing.T) (ftPath, tsPath, src string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module node_def_test\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ftconfig.json"), []byte(`{"node":{"enabled":true,"importPolicy":"explicit"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	legacyDir := filepath.Join(dir, "legacy")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tsPath = filepath.Join(legacyDir, "payment.ts")
+	const tsSrc = `export function create(amount: number, currency: string) {
+  return { id: "pay_1", amount, currency };
+}
+`
+	if err := os.WriteFile(tsPath, []byte(tsSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src = `package main
+
+import node payment "./legacy/payment"
+
+func main() {
+  payment.create(1.0, "USD")
+}
+`
+	ftPath = filepath.Join(dir, "main.ft")
+	if err := os.WriteFile(ftPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return ftPath, tsPath, src
+}
+
+func skipUnlessNodeIndexer(t *testing.T, boundaryRoot string) {
+	t.Helper()
+	if _, err := nodeinterop.RunIndexer(boundaryRoot, []string{"legacy/payment.ts"}); err != nil {
+		t.Skipf("node indexer unavailable: %v", err)
+	}
+}
+
+func TestFindDefinition_nodeImportPathString(t *testing.T) {
+	t.Parallel()
+	ftPath, tsPath, src := writeNodeInteropLSPFixture(t)
+	skipUnlessNodeIndexer(t, filepath.Dir(ftPath))
+
+	log := logrus.New()
+	s := NewLSPServer("8080", log)
+	uri := mustFileURI(t, ftPath)
+	wantTSURI := mustFileURI(t, tsPath)
+
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	pos := lspPositionOfStringLiteral(src, `"./legacy/payment"`)
+	loc := s.findDefinitionForPosition(uri, pos)
+	if loc == nil {
+		t.Fatal("expected definition for node import path string")
+	}
+	if loc.URI != wantTSURI {
+		t.Fatalf("definition URI: got %q want %q", loc.URI, wantTSURI)
+	}
+	if loc.Range.Start.Line != 0 || loc.Range.Start.Character != 0 {
+		t.Fatalf("expected file start, got %+v", loc.Range.Start)
+	}
+}
+
+func TestFindDefinition_nodeImportAlias(t *testing.T) {
+	t.Parallel()
+	ftPath, tsPath, src := writeNodeInteropLSPFixture(t)
+	skipUnlessNodeIndexer(t, filepath.Dir(ftPath))
+
+	s := NewLSPServer("8080", logrus.New())
+	uri := mustFileURI(t, ftPath)
+	wantTSURI := mustFileURI(t, tsPath)
+
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	pos := lspPositionOfIdentifier(src, "payment")
+	// first "payment" is in import clause
+	lines := strings.Split(src, "\n")
+	if !strings.Contains(lines[pos.Line], "import node") {
+		t.Fatalf("expected import-clause payment at %+v", pos)
+	}
+
+	loc := s.findDefinitionForPosition(uri, pos)
+	if loc == nil {
+		t.Fatal("expected definition for node import alias")
+	}
+	if loc.URI != wantTSURI {
+		t.Fatalf("definition URI: got %q want %q", loc.URI, wantTSURI)
+	}
+}
+
+func TestFindDefinition_nodeImportExport(t *testing.T) {
+	t.Parallel()
+	ftPath, tsPath, src := writeNodeInteropLSPFixture(t)
+	skipUnlessNodeIndexer(t, filepath.Dir(ftPath))
+
+	s := NewLSPServer("8080", logrus.New())
+	uri := mustFileURI(t, ftPath)
+	wantTSURI := mustFileURI(t, tsPath)
+
+	s.documentMu.Lock()
+	s.openDocuments[uri] = src
+	s.documentMu.Unlock()
+
+	pos := lspPositionOfIdentifier(src, "create")
+	loc := s.findDefinitionForPosition(uri, pos)
+	if loc == nil {
+		t.Fatal("expected definition for node export create")
+	}
+	if loc.URI != wantTSURI {
+		t.Fatalf("definition URI: got %q want %q", loc.URI, wantTSURI)
+	}
+	if loc.Range.Start.Line != 0 {
+		t.Fatalf("expected create on line 1 (0-based 0), got line %d", loc.Range.Start.Line)
+	}
+	if loc.Range.Start.Character != 17 {
+		t.Fatalf("expected create at column 17, got %d", loc.Range.Start.Character)
+	}
+}
+
+func lspPositionOfStringLiteral(content, literal string) LSPPosition {
+	lines := strings.Split(content, "\n")
+	for li, line := range lines {
+		idx := strings.Index(line, literal)
+		if idx >= 0 {
+			return LSPPosition{Line: li, Character: idx + 1}
+		}
+	}
+	return LSPPosition{}
+}
+
+func TestLspLocationPtrFromAbsPath_withDefinitionSpan(t *testing.T) {
+	t.Parallel()
+	loc := lspLocationPtrFromAbsPath("/tmp/payment.ts", nodeinterop.IndexSourceLocation{
+		Line: 1, Column: 17, EndLine: 1, EndColumn: 23,
+	})
+	if loc == nil {
+		t.Fatal("nil location")
+	}
+	if loc.Range.Start.Line != 0 || loc.Range.Start.Character != 17 {
+		t.Fatalf("start = %+v", loc.Range.Start)
+	}
+	if loc.Range.End.Character != 23 {
+		t.Fatalf("end = %+v", loc.Range.End)
+	}
+}

--- a/forst/internal/nodeinterop/index_v1.go
+++ b/forst/internal/nodeinterop/index_v1.go
@@ -3,6 +3,7 @@ package nodeinterop
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -17,11 +18,26 @@ type IndexV1 struct {
 
 // IndexExport describes one callable export from a TypeScript module.
 type IndexExport struct {
-	Name       string       `json:"name"`
-	Kind       string       `json:"kind"`
-	Parameters []IndexParam `json:"parameters,omitempty"`
-	ReturnType *IndexType   `json:"returnType,omitempty"`
-	YieldType  *IndexType   `json:"yieldType,omitempty"`
+	Name       string               `json:"name"`
+	Kind       string               `json:"kind"`
+	Parameters []IndexParam         `json:"parameters,omitempty"`
+	ReturnType *IndexType           `json:"returnType,omitempty"`
+	YieldType  *IndexType           `json:"yieldType,omitempty"`
+	Definition *IndexSourceLocation `json:"definition,omitempty"`
+}
+
+// IndexSourceLocation is a source span for go-to-definition (1-based line, 0-based column).
+type IndexSourceLocation struct {
+	File      string `json:"file,omitempty"`
+	Line      int    `json:"line"`
+	Column    int    `json:"column"`
+	EndLine   int    `json:"endLine,omitempty"`
+	EndColumn int    `json:"endColumn,omitempty"`
+}
+
+// IsSet reports whether the location has a usable start position.
+func (loc IndexSourceLocation) IsSet() bool {
+	return loc.Line > 0
 }
 
 // IndexParam is a function parameter in the index.
@@ -89,4 +105,23 @@ func (idx *IndexV1) ExportByName(name string) (*IndexExport, bool) {
 		}
 	}
 	return nil, false
+}
+
+// DefinitionAbsPath resolves the absolute path for an export definition location.
+// When def is nil or unset, returns moduleAbsPath.
+func DefinitionAbsPath(boundaryRoot, moduleID, moduleAbsPath string, def *IndexSourceLocation) (string, bool) {
+	if moduleAbsPath == "" {
+		return "", false
+	}
+	if def == nil || !def.IsSet() {
+		return moduleAbsPath, true
+	}
+	rel := moduleID
+	if strings.TrimSpace(def.File) != "" {
+		rel = def.File
+	}
+	if boundaryRoot == "" {
+		return moduleAbsPath, true
+	}
+	return filepath.Join(boundaryRoot, filepath.FromSlash(rel)), true
 }

--- a/forst/internal/typechecker/node_navigation.go
+++ b/forst/internal/typechecker/node_navigation.go
@@ -1,0 +1,54 @@
+package typechecker
+
+import (
+	"strings"
+
+	"forst/internal/nodeinterop"
+)
+
+// NodeImportAbsPath returns the absolute path to the resolved TS/JS module for a node import local name.
+func (tc *TypeChecker) NodeImportAbsPath(local string) (string, bool) {
+	mod, ok := tc.nodeModuleForLocal(local)
+	if !ok || mod.AbsPath == "" {
+		return "", false
+	}
+	return mod.AbsPath, true
+}
+
+// NodeImportPathAbsPath returns the absolute path for a node import path string literal value.
+func (tc *TypeChecker) NodeImportPathAbsPath(importPath string) (string, bool) {
+	if tc == nil || strings.TrimSpace(importPath) == "" {
+		return "", false
+	}
+	for _, binding := range tc.nodeImportsByLocal {
+		if binding.Import.Path != importPath || binding.AbsPath == "" {
+			continue
+		}
+		return binding.AbsPath, true
+	}
+	return "", false
+}
+
+// NodeExportDefinitionLocation returns the absolute path and source span for a node export.
+// When the index has no definition span, ok is true with a zero loc (open module file).
+func (tc *TypeChecker) NodeExportDefinitionLocation(moduleLocal, exportName string) (absPath string, loc nodeinterop.IndexSourceLocation, ok bool) {
+	if tc == nil || moduleLocal == "" || exportName == "" {
+		return "", nodeinterop.IndexSourceLocation{}, false
+	}
+	mod, ok := tc.nodeModuleForLocal(moduleLocal)
+	if !ok || mod.Index == nil {
+		return "", nodeinterop.IndexSourceLocation{}, false
+	}
+	exp, ok := mod.Index.ExportByName(exportName)
+	if !ok {
+		return "", nodeinterop.IndexSourceLocation{}, false
+	}
+	abs, ok := nodeinterop.DefinitionAbsPath(tc.nodeBoundaryRoot(), mod.ModuleID, mod.AbsPath, exp.Definition)
+	if !ok {
+		return "", nodeinterop.IndexSourceLocation{}, false
+	}
+	if exp.Definition != nil {
+		loc = *exp.Definition
+	}
+	return abs, loc, true
+}

--- a/forst/internal/typechecker/node_navigation_test.go
+++ b/forst/internal/typechecker/node_navigation_test.go
@@ -1,0 +1,112 @@
+package typechecker
+
+import (
+	"path/filepath"
+	"testing"
+
+	"forst/internal/ast"
+	"forst/internal/nodeinterop"
+)
+
+func TestNodeImportAbsPath_returnsBindingPath(t *testing.T) {
+	t.Parallel()
+	tc := New(nil, false)
+	tc.nodeImportsByLocal = map[string]nodeImportBinding{
+		"payment": {AbsPath: "/proj/legacy/payment.ts"},
+	}
+	abs, ok := tc.NodeImportAbsPath("payment")
+	if !ok || abs != "/proj/legacy/payment.ts" {
+		t.Fatalf("NodeImportAbsPath = %q, %v", abs, ok)
+	}
+}
+
+func TestNodeImportPathAbsPath_matchesImportPath(t *testing.T) {
+	t.Parallel()
+	tc := New(nil, false)
+	tc.nodeImportsByLocal = map[string]nodeImportBinding{
+		"payment": {
+			Import:  ast.ImportNode{Path: "./legacy/payment", NodeOptIn: true},
+			AbsPath: "/proj/legacy/payment.ts",
+		},
+	}
+	abs, ok := tc.NodeImportPathAbsPath("./legacy/payment")
+	if !ok || abs != "/proj/legacy/payment.ts" {
+		t.Fatalf("NodeImportPathAbsPath = %q, %v", abs, ok)
+	}
+}
+
+func TestNodeExportDefinitionLocation_withDefinitionSpan(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	tsPath := filepath.Join(root, "legacy", "payment.ts")
+	tc := New(nil, false)
+	tc.NodeBoundaryRoot = root
+	tc.nodeImportsByLocal = map[string]nodeImportBinding{
+		"payment": {
+			ModuleID: "legacy/payment.ts",
+			AbsPath:  tsPath,
+			Index: &nodeinterop.IndexV1{
+				ModuleID: "legacy/payment.ts",
+				Exports: []nodeinterop.IndexExport{{
+					Name: "create",
+					Kind: nodeinterop.ExportKindFunction,
+					Definition: &nodeinterop.IndexSourceLocation{
+						Line: 1, Column: 17, EndLine: 1, EndColumn: 23,
+					},
+				}},
+			},
+		},
+	}
+	abs, loc, ok := tc.NodeExportDefinitionLocation("payment", "create")
+	if !ok || abs != tsPath || loc.Line != 1 || loc.Column != 17 {
+		t.Fatalf("got abs=%q loc=%+v ok=%v", abs, loc, ok)
+	}
+}
+
+func TestNodeExportDefinitionLocation_crossFileDefinition(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	tc := New(nil, false)
+	tc.NodeBoundaryRoot = root
+	tc.nodeImportsByLocal = map[string]nodeImportBinding{
+		"barrel": {
+			ModuleID: "re-export-barrel.ts",
+			AbsPath:  filepath.Join(root, "re-export-barrel.ts"),
+			Index: &nodeinterop.IndexV1{
+				ModuleID: "re-export-barrel.ts",
+				Exports: []nodeinterop.IndexExport{{
+					Name: "greet",
+					Kind: nodeinterop.ExportKindFunction,
+					Definition: &nodeinterop.IndexSourceLocation{
+						File: "re-export-source.ts", Line: 1, Column: 17,
+					},
+				}},
+			},
+		},
+	}
+	want := filepath.Join(root, "re-export-source.ts")
+	abs, _, ok := tc.NodeExportDefinitionLocation("barrel", "greet")
+	if !ok || abs != want {
+		t.Fatalf("abs = %q want %q ok=%v", abs, want, ok)
+	}
+}
+
+func TestNodeExportDefinitionLocation_fallbackWithoutDefinition(t *testing.T) {
+	t.Parallel()
+	tsPath := "/proj/legacy/payment.ts"
+	tc := New(nil, false)
+	tc.nodeImportsByLocal = map[string]nodeImportBinding{
+		"payment": {
+			ModuleID: "legacy/payment.ts",
+			AbsPath:  tsPath,
+			Index: &nodeinterop.IndexV1{
+				ModuleID: "legacy/payment.ts",
+				Exports:  []nodeinterop.IndexExport{{Name: "create", Kind: nodeinterop.ExportKindFunction}},
+			},
+		},
+	}
+	abs, loc, ok := tc.NodeExportDefinitionLocation("payment", "create")
+	if !ok || abs != tsPath || loc.IsSet() {
+		t.Fatalf("abs=%q loc=%+v ok=%v", abs, loc, ok)
+	}
+}

--- a/packages/node-runtime/src/indexer/cli.test.ts
+++ b/packages/node-runtime/src/indexer/cli.test.ts
@@ -53,6 +53,12 @@ describe("forst-node-index CLI", () => {
           id: { kind: "string" },
         },
       },
+      definition: {
+        line: 1,
+        column: 17,
+        endLine: 1,
+        endColumn: 23,
+      },
     });
 
     expect(parseForstIndexModuleV1(module).exports[0]?.name).toBe("create");
@@ -95,6 +101,13 @@ describe("forst-node-index CLI", () => {
       kind: "function",
       parameters: [{ name: "name", type: { kind: "string" } }],
       returnType: { kind: "string" },
+      definition: {
+        file: "re-export-source.ts",
+        line: 1,
+        column: 17,
+        endLine: 1,
+        endColumn: 22,
+      },
     });
   });
 

--- a/packages/node-runtime/src/indexer/emit-forst-index-v1.ts
+++ b/packages/node-runtime/src/indexer/emit-forst-index-v1.ts
@@ -4,6 +4,7 @@ import type {
   ForstIndexExportV1,
   ForstIndexModuleV1,
   ForstIndexParameterV1,
+  ForstIndexSourceLocationV1,
   ForstIndexTypeNode,
   ForstNodeExportKind,
 } from "../manifest/schema.js";
@@ -242,7 +243,43 @@ function getFunctionLikeFromExport(node: Node):
   return undefined;
 }
 
-function indexCallableExport(name: string, node: Node): ForstIndexExportV1 | undefined {
+function exportNameNode(node: Node): Node | undefined {
+  if (Node.isFunctionDeclaration(node)) {
+    return node.getNameNode() ?? undefined;
+  }
+  if (Node.isVariableDeclaration(node)) {
+    return node.getNameNode();
+  }
+  return undefined;
+}
+
+function sourceLocationForNameNode(
+  nameNode: Node,
+  indexedModuleId: string,
+  root: string,
+): ForstIndexSourceLocationV1 | undefined {
+  const sourceFile = nameNode.getSourceFile();
+  const file = toPosixModuleId(root, sourceFile.getFilePath());
+  const startPos = sourceFile.getLineAndColumnAtPos(nameNode.getStart());
+  const endPos = sourceFile.getLineAndColumnAtPos(nameNode.getEnd());
+  const loc: ForstIndexSourceLocationV1 = {
+    line: startPos.line,
+    column: startPos.column,
+    endLine: endPos.line,
+    endColumn: endPos.column,
+  };
+  if (file !== indexedModuleId) {
+    loc.file = file;
+  }
+  return loc;
+}
+
+function indexCallableExport(
+  name: string,
+  node: Node,
+  indexedModuleId: string,
+  root: string,
+): ForstIndexExportV1 | undefined {
   if (!isCallableExport(node)) {
     return undefined;
   }
@@ -263,6 +300,14 @@ function indexCallableExport(name: string, node: Node): ForstIndexExportV1 | und
     kind,
     parameters,
   };
+
+  const nameNode = exportNameNode(node);
+  if (nameNode) {
+    const definition = sourceLocationForNameNode(nameNode, indexedModuleId, root);
+    if (definition) {
+      exportEntry.definition = definition;
+    }
+  }
 
   if (kind === "generator" || kind === "asyncGenerator") {
     const yieldType = generatorYieldType(fn.returnTypeNode);
@@ -317,7 +362,7 @@ function indexSourceFile(sourceFile: SourceFile, root: string): ForstIndexModule
   for (const [name, declarations] of sourceFile.getExportedDeclarations()) {
     for (const declaration of declarations) {
       const target = resolveCallableExportDeclaration(declaration);
-      const indexed = indexCallableExport(name, target);
+      const indexed = indexCallableExport(name, target, moduleId, root);
       if (indexed) {
         exports.push(indexed);
         break;

--- a/packages/node-runtime/src/manifest/schema.test.ts
+++ b/packages/node-runtime/src/manifest/schema.test.ts
@@ -99,6 +99,12 @@ describe("forst-index-v1", () => {
             kind: "object",
             fields: { id: { kind: "string" } },
           },
+          definition: {
+            line: 1,
+            column: 17,
+            endLine: 1,
+            endColumn: 23,
+          },
         },
         {
           name: "readChunks",
@@ -115,7 +121,35 @@ describe("forst-index-v1", () => {
     expect(FORST_INDEX_V1_FORMAT).toBe("forst-index-v1");
     expect(index.moduleId).toBe("legacy/payment.ts");
     expect(index.exports[0]?.returnType?.fields?.id?.kind).toBe("string");
+    expect(index.exports[0]?.definition).toMatchObject({
+      line: 1,
+      column: 17,
+      endLine: 1,
+      endColumn: 23,
+    });
     expect(index.exports[1]?.yieldType?.$binary).toBe(true);
+  });
+
+  it("parses definition with cross-file file field", () => {
+    const index = parseForstIndexModuleV1({
+      moduleId: "re-export-barrel.ts",
+      exports: [
+        {
+          name: "greet",
+          kind: "function",
+          parameters: [{ name: "name", type: { kind: "string" } }],
+          returnType: { kind: "string" },
+          definition: {
+            file: "re-export-source.ts",
+            line: 1,
+            column: 17,
+            endLine: 1,
+            endColumn: 22,
+          },
+        },
+      ],
+    });
+    expect(index.exports[0]?.definition?.file).toBe("re-export-source.ts");
   });
 
   it("rejects invalid moduleId in index", () => {

--- a/packages/node-runtime/src/manifest/schema.ts
+++ b/packages/node-runtime/src/manifest/schema.ts
@@ -54,12 +54,23 @@ export interface ForstIndexParameterV1 {
   type: ForstIndexTypeNode;
 }
 
+/** Source span for go-to-definition (1-based line, 0-based column). */
+export interface ForstIndexSourceLocationV1 {
+  /** Project-relative POSIX path; omitted when same as the indexed module. */
+  file?: string;
+  line: number;
+  column: number;
+  endLine?: number;
+  endColumn?: number;
+}
+
 export interface ForstIndexExportV1 {
   name: string;
   kind: ForstNodeExportKind;
   parameters: ForstIndexParameterV1[];
   returnType?: ForstIndexTypeNode;
   yieldType?: ForstIndexTypeNode;
+  definition?: ForstIndexSourceLocationV1;
 }
 
 export interface ForstIndexModuleV1 {
@@ -232,6 +243,48 @@ function parseIndexParameter(value: unknown, path: string): ForstIndexParameterV
   };
 }
 
+function assertNonNegativeInt(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new ForstNodeSchemaValidationError(path, "expected non-negative integer");
+  }
+  return value;
+}
+
+function assertPositiveInt(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new ForstNodeSchemaValidationError(path, "expected positive integer");
+  }
+  return value;
+}
+
+function parseIndexSourceLocation(
+  value: unknown,
+  path: string,
+): ForstIndexSourceLocationV1 {
+  const record = assertRecord(value, path);
+  const parsed: ForstIndexSourceLocationV1 = {
+    line: assertPositiveInt(record.line, `${path}.line`),
+    column: assertNonNegativeInt(record.column, `${path}.column`),
+  };
+  if (record.file !== undefined) {
+    const file = assertString(record.file, `${path}.file`);
+    if (!isValidModuleId(file)) {
+      throw new ForstNodeSchemaValidationError(
+        `${path}.file`,
+        "must be a project-relative POSIX path without .. or absolute segments",
+      );
+    }
+    parsed.file = file;
+  }
+  if (record.endLine !== undefined) {
+    parsed.endLine = assertPositiveInt(record.endLine, `${path}.endLine`);
+  }
+  if (record.endColumn !== undefined) {
+    parsed.endColumn = assertNonNegativeInt(record.endColumn, `${path}.endColumn`);
+  }
+  return parsed;
+}
+
 function parseIndexExport(value: unknown, path: string): ForstIndexExportV1 {
   const record = assertRecord(value, path);
   if (!Array.isArray(record.parameters)) {
@@ -256,6 +309,9 @@ function parseIndexExport(value: unknown, path: string): ForstIndexExportV1 {
   }
   if (record.yieldType !== undefined) {
     parsed.yieldType = parseIndexTypeNode(record.yieldType, `${path}.yieldType`);
+  }
+  if (record.definition !== undefined) {
+    parsed.definition = parseIndexSourceLocation(record.definition, `${path}.definition`);
   }
   return parsed;
 }


### PR DESCRIPTION
Wire `textDocument`/`definition` for import node so Cmd+click on path strings, module aliases, and qualified exports (e.g. `payment.create`) opens the resolved TypeScript or JavaScript module. Export names jump to indexed symbol spans; missing spans fall back to the module file.

Extend forst-index-v1 with optional export definition locations from the `ts-morph` indexer, including cross-file re-exports. Add typechecker navigation helpers and LSP handlers ahead of existing Go/Forst import resolution. Document the behavior in the editor workflow guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Go-to-definition and find-references now support `import node` paths, aliases, and exported symbols.
  * Navigate directly from an imported module or export to its TypeScript/JavaScript source location.
  * Export indexes now include source-location metadata for more precise navigation.

* **Documentation**
  * Expanded workflow documentation with Node interop navigation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->