### PR TITLE
fix(nodert): prevent duplicate host binds, restore piped colors

### DIFF
--- a/docs/interop/node/call-javascript.mdx
+++ b/docs/interop/node/call-javascript.mdx
@@ -147,7 +147,7 @@ Use host mode when the legacy app must share **module cache, globals, and instru
 
 **Readiness model:** the host socket may listen before the app is safe for RPC. The ready file uses `phase: "app"`; Go dials only after app readiness is signaled.
 
-**Default (third-party shims like remix-serve):** Go auto-injects a blocking `register.mjs` preload when `hostMode` is enabled (`hostAutoRegister`, default `true`). For shims that do not need a custom init hook, omit `hostAppReadyModule` — `register.mjs` signals readiness as soon as the host socket is listening. Only set `hostAppReadyModule` when you need to run setup code **before** RPC (must be a tiny, side-effect-free module — never your full server bundle):
+**Default (third-party shims like remix-serve):** Go auto-injects a blocking `register.mjs` preload when `hostMode` is enabled (`hostAutoRegister`, default `true`). The preload is passed as a **`node --import`** flag on the **direct** shim spawn only — not via `NODE_OPTIONS` — so Vite/Remix worker processes do not each try to bind the host socket. For shims that do not need a custom init hook, omit `hostAppReadyModule` — `register.mjs` signals readiness as soon as the host socket is listening. Only set `hostAppReadyModule` when you need to run setup code **before** RPC (must be a tiny, side-effect-free module — never your full server bundle):
 
 ```json
 {
@@ -175,19 +175,38 @@ await signalForstAppReady();
 **Manual preload** (advanced; opt out with `hostAutoRegister: false`):
 
 ```text
-NODE_OPTIONS="--import @forst/node-runtime/host/register.mjs"
+node --import @forst/node-runtime/host/register.mjs ./your-server.mjs
 ```
 
 | Field | Purpose |
 | --- | --- |
 | `node.hostMode` | When `true`, Go spawns `node.binary` with `node.args` instead of bootstrap |
 | `node.args` | **Required** when `hostMode` is true — argv passed to the app shim |
-| `node.hostAutoRegister` | Inject blocking `register.mjs` via `NODE_OPTIONS --import` (default `true` when `hostMode`) |
+| `node.hostAutoRegister` | Prepend `--import register.mjs` on the direct shim argv (default `true` when `hostMode`) |
 | `node.hostAppReadyModule` | Optional module loaded before `signalForstAppReady()` when auto-register needs deferred readiness (not your server entry) |
 | `node.hostSocket` | Relative path under boundary root for the Unix socket (default `.forst/node.sock`) |
 | `node.hostReadyTimeoutSeconds` | Max wait for `phase: "app"` ready marker (default `120`) |
 
-Go sets `FORST_NODE_HOST=1`, `FORST_NODE_SOCKET`, and `FORST_NODE_HOST_READY` on the spawned child. The host listens on the socket; Go dials after the ready file reports `phase: "app"`.
+### Host mode environment variables
+
+Go sets the following on the **direct** app-shim child when `node.hostMode` is true. They are read by `@forst/node-runtime/host` and `host/register.mjs`. Do not set them manually in normal workflows.
+
+| Variable | Set by | Purpose |
+| --- | --- | --- |
+| `FORST_NODE_HOST` | Go (`"1"`) | Enables in-process host RPC. When unset, `startForstNodeHost()` no-ops. Bootstrap mode does not set this. |
+| `FORST_NODE_HOST_LEADER` | Go (`"1"`) | Marks the process Go spawned as the **sole** host leader. `startForstNodeHost()` requires this **and** `register.mjs` in `process.execArgv`. Child Node processes (Vite workers, etc.) may inherit `FORST_NODE_HOST` but must not bind the socket — they lack leader + preload and skip with `host_skip_non_leader`. |
+| `FORST_NODE_SOCKET` | Go | Absolute path to the Unix socket (TCP URL on Windows) where the host listens for Go RPC. Defaults to `{boundaryRoot}/{node.hostSocket}` (default `.forst/node.sock`). If set in the **parent** environment before spawn, `ResolveHostSocketPath` uses it for planning. |
+| `FORST_NODE_HOST_READY` | Go | Absolute path to a JSON readiness file (typically `{socket}.ready`). The host writes `{"pid", "socket", "phase"}`; Go polls until `phase` is `"app"` before dialing. Defers RPC until Remix/Vite or your entry calls `signalForstAppReady()` when `hostAppReadyModule` is set. |
+| `FORST_NODE_APP_READY_MODULE` | Go (optional) | When `node.hostAppReadyModule` is set in ftconfig, path to a small module `register.mjs` loads before signaling app readiness. |
+| `FORCE_COLOR` | Go (optional) | Set to `"1"` when the Forst parent stdout is a TTY and `NO_COLOR` is unset, so piped Vite/Remix output keeps ANSI colors. |
+
+Typical spawn layout:
+
+```text
+node --import tsx/loader.mjs --import @forst/node-runtime/dist/host/register.mjs node_modules/.bin/vite dev
+```
+
+Go dials `FORST_NODE_SOCKET` after `FORST_NODE_HOST_READY` reports `phase: "app"`.
 
 <Warning>
   **Do not use stdio RPC inside app shims** (remix-serve, vitest reporters, morgan, etc.). Those tools write to stdout and corrupt the wire protocol. Host mode uses a **socket** so app stdout stays free.
@@ -202,6 +221,8 @@ Go sets `FORST_NODE_HOST=1`, `FORST_NODE_SOCKET`, and `FORST_NODE_HOST_READY` on
 | `host ready timeout` | App never signaled readiness (`phase: "app"`) | For third-party shims, omit `hostAppReadyModule`; or call `signalForstAppReady()` after init |
 | `ErrNodeRuntimeDied` during RPC | App process crashed; socket closed |
 | Second Go client | Host rejects duplicate connections (single client invariant) |
+| `EADDRINUSE` on `.forst/node.sock` | Stale host or duplicate leader (often from putting `register.mjs` in `NODE_OPTIONS`) | Use default `hostAutoRegister` (argv preload); ensure only one `forst run` owns the socket |
+| Multiple `host_listening` lines | Vite/Remix workers attempted host bind | Fixed when register is argv-only; workers should log `host_skip_non_leader` if they inherit host env |
 
 Compile-time **indexing always uses bootstrap mode** — the indexer runs `forst-node-index` CLI, never the app shim.
 

--- a/examples/in/rfc/node-interop/host/README.md
+++ b/examples/in/rfc/node-interop/host/README.md
@@ -11,6 +11,10 @@ Fixture for **host mode**: Go spawns an app shim (`node app/server.mjs`) and con
 | `legacy/counter.ts` | TypeScript export reading `globalThis.__forstTest` |
 | `main.ft` | Forst entry calling `counter.inc` at runtime |
 
+## Host environment variables
+
+Go sets `FORST_NODE_HOST`, `FORST_NODE_HOST_LEADER`, `FORST_NODE_SOCKET`, and `FORST_NODE_HOST_READY` on the direct shim child. See [Call JavaScript from Forst — host mode environment variables](https://docs.forst.dev/interop/node/call-javascript#host-mode-environment-variables) for semantics, readiness phases, and worker vs leader behavior.
+
 ## Compile
 
 From repo root:

--- a/forst/nodert/host_worker_test.go
+++ b/forst/nodert/host_worker_test.go
@@ -1,0 +1,83 @@
+package nodert
+
+import (
+	"encoding/json"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestHostMode_workerEnvWithoutRegisterImportDoesNotBindSocket(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not on PATH")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("host integration uses unix sockets")
+	}
+
+	root, _ := setupHostIntegrationRoot(t, hostServerWithSingleton)
+	manifest := hostCounterManifest(root)
+	socketPath := shortHostSocketPath(t)
+	readyPath := socketPath + ".ready"
+
+	resetSupervisorForTest()
+	t.Setenv(envNodeBootstrap, "")
+	t.Setenv(envNodeBinary, "")
+
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := configureFromManifest(string(manifestJSON)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := GetClient(); err != nil {
+		t.Fatalf("GetClient: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = Shutdown()
+	})
+
+	markerBefore, ok := readHostReadyMarker(readyPath)
+	if !ok {
+		t.Fatal("ready marker missing before worker spawn")
+	}
+
+	hostCmd, err := BuildHostSpawnCommand(HostSpawnInput{
+		BoundaryRoot:     root,
+		Executable:       "node",
+		ShimArgs:         []string{"app/server.mjs"},
+		WorkDir:          root,
+		Loader:           "tsx",
+		SocketPath:       socketPath,
+		ReadyPath:        readyPath,
+		HostAutoRegister: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeOpts := lookupEnvValue(hostCmd.Env, "NODE_OPTIONS")
+	if strings.Contains(nodeOpts, "register.mjs") {
+		t.Fatalf("register.mjs must not be in NODE_OPTIONS, got %q", nodeOpts)
+	}
+
+	worker := exec.Command("node", "-e", "")
+	worker.Dir = root
+	worker.Env = filterEnv(hostCmd.Env, envNodeHostLeader)
+	if err := worker.Run(); err != nil {
+		t.Fatalf("worker node: %v", err)
+	}
+
+	markerAfter, ok := readHostReadyMarker(readyPath)
+	if !ok {
+		t.Fatal("ready marker missing after worker spawn")
+	}
+	if !processAlive(markerAfter.PID) {
+		t.Fatalf("leader pid %d not alive after worker spawn", markerAfter.PID)
+	}
+	if markerAfter.PID != markerBefore.PID {
+		t.Fatalf("ready pid before=%d after=%d", markerBefore.PID, markerAfter.PID)
+	}
+}

--- a/forst/nodert/process_forward_test.go
+++ b/forst/nodert/process_forward_test.go
@@ -40,6 +40,30 @@ func TestForwardChildOutput_copiesToDestination(t *testing.T) {
 	}
 }
 
+func TestForwardChildOutput_preservesAnsi(t *testing.T) {
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	rec := &writeRecorder{}
+	log := logrus.New()
+	log.SetLevel(logrus.PanicLevel)
+
+	go func() {
+		forwardChildOutput(pr, rec, log, "stdout")
+		close(done)
+	}()
+
+	colored := "\x1b[32mgreen\x1b[0m\n"
+	if _, err := pw.Write([]byte(colored)); err != nil {
+		t.Fatal(err)
+	}
+	_ = pw.Close()
+	<-done
+
+	if got := rec.buf.String(); got != colored {
+		t.Fatalf("forwarded = %q want %q", got, colored)
+	}
+}
+
 func TestForwardChildOutput_logsAtDebug(t *testing.T) {
 	pr, pw := io.Pipe()
 	done := make(chan struct{})

--- a/forst/nodert/spawn.go
+++ b/forst/nodert/spawn.go
@@ -9,10 +9,43 @@ import (
 	"strings"
 )
 
+// Host-mode environment variable names.
+//
+// Go sets these on the direct app-shim child when ftconfig node.hostMode is true
+// (BuildHostSpawnCommand → buildSpawnEnv). @forst/node-runtime reads them in
+// host/register.mjs and host.ts. Child processes spawned by the shim (Vite workers,
+// cluster forks, etc.) may inherit the values but must not act as host leaders —
+// see FORST_NODE_HOST_LEADER and register preload via argv, not NODE_OPTIONS.
+//
+//   FORST_NODE_HOST
+//     Gate for host RPC in Node. When "1", startForstNodeHost() may bind the RPC
+//     socket; when unset, host code no-ops. Set only in host mode; bootstrap mode
+//     uses stdio RPC and does not set this variable.
+//
+//   FORST_NODE_HOST_LEADER
+//     Marks the process Go spawned as the sole host leader. startForstNodeHost()
+//     requires "1" and register.mjs in process.execArgv; workers that inherit
+//     FORST_NODE_HOST without leader/preload skip binding (host_skip_non_leader).
+//     Do not set manually except for tests.
+//
+//   FORST_NODE_SOCKET
+//     Absolute path to the Unix domain socket (loopback TCP URL on Windows) where
+//     the in-process host listens for Go RPC. Defaults from node.hostSocket under
+//     the boundary root (.forst/node.sock). Go dials this after readiness; may
+//     also be read at spawn planning time via ResolveHostSocketPath when set in
+//     the parent environment.
+//
+//   FORST_NODE_HOST_READY
+//     Absolute path to a JSON readiness marker (typically socketPath + ".ready").
+//     The host writes {"pid", "socket", "phase"} after listen and/or app init;
+//     Go polls until phase is "app" before connecting. Used to avoid dialing
+//     before third-party shims (Remix, Vite) finish bootstrapping when
+//     hostAppReadyModule or signalForstAppReady() defer readiness.
 const (
-	envNodeHost      = "FORST_NODE_HOST"
-	envNodeSocket    = "FORST_NODE_SOCKET"
-	envNodeHostReady = "FORST_NODE_HOST_READY"
+	envNodeHost       = "FORST_NODE_HOST"
+	envNodeHostLeader = "FORST_NODE_HOST_LEADER"
+	envNodeSocket     = "FORST_NODE_SOCKET"
+	envNodeHostReady  = "FORST_NODE_HOST_READY"
 )
 
 // mergeNodeOptions appends import flags idempotently to existing NODE_OPTIONS.
@@ -35,6 +68,65 @@ func mergeNodeOptions(existing string, additions ...string) string {
 	return result
 }
 
+func stripNodeOptionImports(existing string, substrings ...string) string {
+	existing = strings.TrimSpace(existing)
+	if existing == "" {
+		return ""
+	}
+	parts := strings.Fields(existing)
+	var kept []string
+	for i := 0; i < len(parts); i++ {
+		part := parts[i]
+		if part == "--import" && i+1 < len(parts) {
+			path := parts[i+1]
+			if nodeOptionImportMatches(path, substrings...) {
+				i++
+				continue
+			}
+			kept = append(kept, part, path)
+			i++
+			continue
+		}
+		if strings.HasPrefix(part, "--import=") {
+			path := strings.TrimPrefix(part, "--import=")
+			if nodeOptionImportMatches(path, substrings...) {
+				continue
+			}
+		}
+		kept = append(kept, part)
+	}
+	return strings.Join(kept, " ")
+}
+
+func nodeOptionImportMatches(path string, substrings ...string) bool {
+	for _, sub := range substrings {
+		if sub != "" && strings.Contains(path, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func sanitizeHostChildEnv(env []string) []string {
+	env = stripNodeOptionImportsEnv(env, "register.mjs", "register.cjs")
+	return env
+}
+
+func stripNodeOptionImportsEnv(env []string, substrings ...string) []string {
+	opts := lookupEnvValue(env, "NODE_OPTIONS")
+	if opts == "" {
+		return env
+	}
+	cleaned := stripNodeOptionImports(opts, substrings...)
+	if cleaned == opts {
+		return env
+	}
+	if cleaned == "" {
+		return filterEnv(env, "NODE_OPTIONS")
+	}
+	return setEnvVar(env, "NODE_OPTIONS", cleaned)
+}
+
 func lookupEnvValue(env []string, key string) string {
 	prefix := key + "="
 	for _, entry := range env {
@@ -43,6 +135,18 @@ func lookupEnvValue(env []string, key string) string {
 		}
 	}
 	return ""
+}
+
+func filterEnv(env []string, dropKey string) []string {
+	prefix := dropKey + "="
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 func setEnvDefault(env []string, key, value string) []string {
@@ -171,7 +275,13 @@ func ResolveHostSocketPath(boundaryRoot, configured string) (string, string, err
 }
 
 // PrepareHostSocket removes stale socket and ready marker files.
+// If the ready marker references a live process, returns an error instead of clobbering it.
 func PrepareHostSocket(socketPath, readyPath string) error {
+	if readyPath != "" {
+		if marker, ok := readHostReadyMarker(readyPath); ok && processAlive(marker.PID) {
+			return fmt.Errorf("node runtime: host already running (pid=%d, socket=%s)", marker.PID, socketPath)
+		}
+	}
 	if socketPath != "" {
 		if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("node runtime: remove stale host socket: %w", err)
@@ -187,6 +297,42 @@ func PrepareHostSocket(socketPath, readyPath string) error {
 		return fmt.Errorf("node runtime: create host socket dir: %w", err)
 	}
 	return nil
+}
+
+func stdoutIsTTY() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func applyHostSpawnColorEnv(env []string) []string {
+	if lookupEnvValue(env, "NO_COLOR") != "" {
+		return env
+	}
+	if lookupEnvValue(env, "FORCE_COLOR") != "" {
+		return env
+	}
+	if !stdoutIsTTY() {
+		return env
+	}
+	return setEnvDefault(env, "FORCE_COLOR", "1")
+}
+
+func prependNodeImportArgs(shimArgs []string, importPaths ...string) []string {
+	args := make([]string, 0, len(importPaths)*2+len(shimArgs))
+	for _, importPath := range importPaths {
+		importPath = strings.TrimSpace(importPath)
+		if importPath == "" {
+			continue
+		}
+		if strings.HasPrefix(importPath, "--import ") {
+			importPath = strings.TrimSpace(strings.TrimPrefix(importPath, "--import "))
+		}
+		args = append(args, "--import", importPath)
+	}
+	return append(args, shimArgs...)
 }
 
 // BootstrapSpawnInput configures bootstrap-mode child spawn.
@@ -302,6 +448,7 @@ func buildSpawnEnv(in spawnEnvInput) []string {
 	env = setEnvVar(env, "NODE_OPTIONS", merged)
 	if in.HostMode {
 		env = setEnvVar(env, envNodeHost, "1")
+		env = setEnvVar(env, envNodeHostLeader, "1")
 		env = setEnvDefault(env, "HOST", "127.0.0.1")
 		if in.SocketPath != "" {
 			env = setEnvVar(env, envNodeSocket, in.SocketPath)
@@ -309,6 +456,8 @@ func buildSpawnEnv(in spawnEnvInput) []string {
 		if in.ReadyPath != "" {
 			env = setEnvVar(env, envNodeHostReady, in.ReadyPath)
 		}
+		env = sanitizeHostChildEnv(env)
+		env = applyHostSpawnColorEnv(env)
 	}
 	return env
 }
@@ -336,26 +485,25 @@ func BuildHostSpawnCommand(in HostSpawnInput) (HostSpawnCommand, error) {
 	if loader == "" {
 		loader = "tsx"
 	}
-	var tsxImport string
+	var importPaths []string
 	switch loader {
 	case "tsx":
 		tsxLoader, err := ResolveTsxLoaderPath(in.BoundaryRoot, in.WorkDir)
 		if err != nil {
 			return HostSpawnCommand{}, err
 		}
-		tsxImport = "--import " + tsxLoader
+		importPaths = append(importPaths, tsxLoader)
 	default:
 		return HostSpawnCommand{}, fmt.Errorf("unsupported node loader %q", loader)
 	}
 
-	nodeOptions := []string{tsxImport}
 	childEnv := append([]string(nil), in.Env...)
 	if in.HostAutoRegister {
 		registerPath, err := ResolveHostRegisterPath(in.BoundaryRoot)
 		if err != nil {
 			return HostSpawnCommand{}, err
 		}
-		nodeOptions = append(nodeOptions, "--import "+registerPath)
+		importPaths = append(importPaths, registerPath)
 	}
 	if in.HostAppReadyModule != "" {
 		childEnv = setEnvVar(childEnv, envNodeAppReadyModule, in.HostAppReadyModule)
@@ -365,7 +513,6 @@ func BuildHostSpawnCommand(in HostSpawnInput) (HostSpawnCommand, error) {
 		BoundaryRoot: in.BoundaryRoot,
 		FilesExclude: in.FilesExclude,
 		Env:          childEnv,
-		NodeOptions:  nodeOptions,
 		HostMode:     true,
 		SocketPath:   socketPath,
 		ReadyPath:    readyPath,
@@ -373,7 +520,7 @@ func BuildHostSpawnCommand(in HostSpawnInput) (HostSpawnCommand, error) {
 
 	return HostSpawnCommand{
 		Executable: executable,
-		Args:       append([]string(nil), in.ShimArgs...),
+		Args:       prependNodeImportArgs(in.ShimArgs, importPaths...),
 		Env:        env,
 		SocketPath: socketPath,
 		ReadyPath:  readyPath,

--- a/forst/nodert/spawn.go
+++ b/forst/nodert/spawn.go
@@ -335,6 +335,43 @@ func prependNodeImportArgs(shimArgs []string, importPaths ...string) []string {
 	return append(args, shimArgs...)
 }
 
+func sameResolvedExecutable(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA != nil || errB != nil {
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+	evalA, errA := filepath.EvalSymlinks(absA)
+	evalB, errB := filepath.EvalSymlinks(absB)
+	if errA != nil {
+		evalA = absA
+	}
+	if errB != nil {
+		evalB = absB
+	}
+	return evalA == evalB
+}
+
+// hostSpawnExecutableAndArgs returns argv for host mode. --import flags are Node
+// flags; when ftconfig node.binary is a shim (e.g. remix-serve), spawn the real
+// node interpreter with the shim script as the first positional argument.
+func hostSpawnExecutableAndArgs(boundaryRoot, shimExecutable string, shimArgs, importPaths []string) (string, []string, error) {
+	nodeBin, err := ResolveNodeBinary(boundaryRoot, "node")
+	if err != nil {
+		return "", nil, err
+	}
+	args := append([]string(nil), shimArgs...)
+	executable := shimExecutable
+	if !sameResolvedExecutable(shimExecutable, nodeBin) {
+		executable = nodeBin
+		args = append([]string{shimExecutable}, args...)
+	}
+	return executable, prependNodeImportArgs(args, importPaths...), nil
+}
+
 // BootstrapSpawnInput configures bootstrap-mode child spawn.
 type BootstrapSpawnInput struct {
 	BoundaryRoot  string
@@ -467,7 +504,7 @@ func BuildHostSpawnCommand(in HostSpawnInput) (HostSpawnCommand, error) {
 	if len(in.ShimArgs) == 0 {
 		return HostSpawnCommand{}, fmt.Errorf("node runtime: hostMode requires non-empty node.args")
 	}
-	executable, err := ResolveNodeBinary(in.BoundaryRoot, in.Executable)
+	shimExecutable, err := ResolveNodeBinary(in.BoundaryRoot, in.Executable)
 	if err != nil {
 		return HostSpawnCommand{}, err
 	}
@@ -518,9 +555,14 @@ func BuildHostSpawnCommand(in HostSpawnInput) (HostSpawnCommand, error) {
 		ReadyPath:    readyPath,
 	})
 
+	executable, args, err := hostSpawnExecutableAndArgs(in.BoundaryRoot, shimExecutable, in.ShimArgs, importPaths)
+	if err != nil {
+		return HostSpawnCommand{}, err
+	}
+
 	return HostSpawnCommand{
 		Executable: executable,
-		Args:       prependNodeImportArgs(in.ShimArgs, importPaths...),
+		Args:       args,
 		Env:        env,
 		SocketPath: socketPath,
 		ReadyPath:  readyPath,

--- a/forst/nodert/spawn_test.go
+++ b/forst/nodert/spawn_test.go
@@ -164,9 +164,25 @@ func TestBuildHostSpawnCommand_autoRegisterAndAppReadyModule(t *testing.T) {
 	}
 	wantRegister := filepath.Join(root, "node_modules", "@forst", "node-runtime", "dist", "host", "register.mjs")
 	wantLoader := filepath.Join(root, "node_modules", "tsx", "dist", "loader.mjs")
-	if len(cmd.Args) != 5 || cmd.Args[0] != "--import" || cmd.Args[1] != wantLoader ||
-		cmd.Args[2] != "--import" || cmd.Args[3] != wantRegister || cmd.Args[4] != "server.js" {
-		t.Fatalf("args = %#v", cmd.Args)
+	nodeBin, err := ResolveNodeBinary(root, "node")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Executable != nodeBin {
+		t.Fatalf("executable = %q want node %q", cmd.Executable, nodeBin)
+	}
+	wantShim, err := filepath.EvalSymlinks(nodePath)
+	if err != nil {
+		wantShim = nodePath
+	}
+	wantArgs := []string{"--import", wantLoader, "--import", wantRegister, wantShim, "server.js"}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("args = %#v want %#v", cmd.Args, wantArgs)
+	}
+	for i := range wantArgs {
+		if cmd.Args[i] != wantArgs[i] {
+			t.Fatalf("args[%d] = %q want %q (full args = %#v)", i, cmd.Args[i], wantArgs[i], cmd.Args)
+		}
 	}
 	if lookupEnvValue(cmd.Env, envNodeHost) != "1" {
 		t.Fatalf("env = %#v", cmd.Env)
@@ -211,8 +227,25 @@ func TestBuildHostSpawnCommand_setsHostEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantLoader := filepath.Join(root, "node_modules", "tsx", "dist", "loader.mjs")
-	if len(cmd.Args) != 3 || cmd.Args[0] != "--import" || cmd.Args[1] != wantLoader || cmd.Args[2] != "server.js" {
-		t.Fatalf("args = %#v", cmd.Args)
+	nodeBin, err := ResolveNodeBinary(root, "node")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Executable != nodeBin {
+		t.Fatalf("executable = %q want node %q", cmd.Executable, nodeBin)
+	}
+	wantShim, err := filepath.EvalSymlinks(nodePath)
+	if err != nil {
+		wantShim = nodePath
+	}
+	wantArgs := []string{"--import", wantLoader, wantShim, "server.js"}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("args = %#v want %#v", cmd.Args, wantArgs)
+	}
+	for i := range wantArgs {
+		if cmd.Args[i] != wantArgs[i] {
+			t.Fatalf("args[%d] = %q want %q (full args = %#v)", i, cmd.Args[i], wantArgs[i], cmd.Args)
+		}
 	}
 	if lookupEnvValue(cmd.Env, envNodeHost) != "1" {
 		t.Fatalf("env = %#v", cmd.Env)
@@ -291,6 +324,97 @@ func TestPrependNodeImportArgs(t *testing.T) {
 	for i := range want {
 		if got[i] != want[i] {
 			t.Fatalf("got %#v want %#v", got, want)
+		}
+	}
+}
+
+func TestBuildHostSpawnCommand_directNodeBinary(t *testing.T) {
+	root := t.TempDir()
+	tsxDir := filepath.Join(root, "node_modules", "tsx", "dist")
+	if err := os.MkdirAll(tsxDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsxDir, "loader.mjs"), []byte("//"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nodeBin, err := ResolveNodeBinary(root, "node")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, err := BuildHostSpawnCommand(HostSpawnInput{
+		BoundaryRoot: root,
+		Executable:   "node",
+		ShimArgs:     []string{"server.js"},
+		WorkDir:      root,
+		Loader:       "tsx",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Executable != nodeBin {
+		t.Fatalf("executable = %q want %q", cmd.Executable, nodeBin)
+	}
+	wantLoader := filepath.Join(root, "node_modules", "tsx", "dist", "loader.mjs")
+	wantArgs := []string{"--import", wantLoader, "server.js"}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("args = %#v want %#v", cmd.Args, wantArgs)
+	}
+	for i := range wantArgs {
+		if cmd.Args[i] != wantArgs[i] {
+			t.Fatalf("args[%d] = %q want %q", i, cmd.Args[i], wantArgs[i])
+		}
+	}
+}
+
+func TestBuildHostSpawnCommand_nonNodeShimUsesNodeInterpreter(t *testing.T) {
+	root := t.TempDir()
+	shim := filepath.Join(root, "node_modules", ".bin", "remix-serve")
+	if err := os.MkdirAll(filepath.Dir(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shim, []byte("#!/usr/bin/env node\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tsxDir := filepath.Join(root, "node_modules", "tsx", "dist")
+	if err := os.MkdirAll(tsxDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsxDir, "loader.mjs"), []byte("//"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nodeBin, err := ResolveNodeBinary(root, "node")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, err := BuildHostSpawnCommand(HostSpawnInput{
+		BoundaryRoot: root,
+		Executable:   "node_modules/.bin/remix-serve",
+		ShimArgs:     []string{"build/server/index.js", "--port", "3000"},
+		WorkDir:      root,
+		Loader:       "tsx",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Executable != nodeBin {
+		t.Fatalf("executable = %q want node %q", cmd.Executable, nodeBin)
+	}
+	wantLoader := filepath.Join(root, "node_modules", "tsx", "dist", "loader.mjs")
+	wantShim, err := filepath.EvalSymlinks(shim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantArgs := []string{"--import", wantLoader, wantShim, "build/server/index.js", "--port", "3000"}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("args = %#v want %#v", cmd.Args, wantArgs)
+	}
+	for i := range wantArgs {
+		if cmd.Args[i] != wantArgs[i] {
+			t.Fatalf("args[%d] = %q want %q (full args = %#v)", i, cmd.Args[i], wantArgs[i], cmd.Args)
 		}
 	}
 }

--- a/forst/nodert/spawn_test.go
+++ b/forst/nodert/spawn_test.go
@@ -1,8 +1,10 @@
 package nodert
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -160,18 +162,24 @@ func TestBuildHostSpawnCommand_autoRegisterAndAppReadyModule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cmd.Args) != 1 || cmd.Args[0] != "server.js" {
+	wantRegister := filepath.Join(root, "node_modules", "@forst", "node-runtime", "dist", "host", "register.mjs")
+	wantLoader := filepath.Join(root, "node_modules", "tsx", "dist", "loader.mjs")
+	if len(cmd.Args) != 5 || cmd.Args[0] != "--import" || cmd.Args[1] != wantLoader ||
+		cmd.Args[2] != "--import" || cmd.Args[3] != wantRegister || cmd.Args[4] != "server.js" {
 		t.Fatalf("args = %#v", cmd.Args)
 	}
 	if lookupEnvValue(cmd.Env, envNodeHost) != "1" {
 		t.Fatalf("env = %#v", cmd.Env)
 	}
+	if lookupEnvValue(cmd.Env, envNodeHostLeader) != "1" {
+		t.Fatalf("missing leader env: %#v", cmd.Env)
+	}
 	if lookupEnvValue(cmd.Env, envNodeSocket) == "" {
 		t.Fatalf("missing socket env: %#v", cmd.Env)
 	}
 	nodeOpts := lookupEnvValue(cmd.Env, "NODE_OPTIONS")
-	if !strings.Contains(nodeOpts, "--import") || !strings.Contains(nodeOpts, "register.mjs") {
-		t.Fatalf("NODE_OPTIONS = %q", nodeOpts)
+	if strings.Contains(nodeOpts, "register.mjs") {
+		t.Fatalf("register.mjs must not be in NODE_OPTIONS, got %q", nodeOpts)
 	}
 	if got := lookupEnvValue(cmd.Env, envNodeAppReadyModule); got != appReadyModule {
 		t.Fatalf("FORST_NODE_APP_READY_MODULE = %q want %q", got, appReadyModule)
@@ -202,11 +210,15 @@ func TestBuildHostSpawnCommand_setsHostEnv(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cmd.Args) != 1 || cmd.Args[0] != "server.js" {
+	wantLoader := filepath.Join(root, "node_modules", "tsx", "dist", "loader.mjs")
+	if len(cmd.Args) != 3 || cmd.Args[0] != "--import" || cmd.Args[1] != wantLoader || cmd.Args[2] != "server.js" {
 		t.Fatalf("args = %#v", cmd.Args)
 	}
 	if lookupEnvValue(cmd.Env, envNodeHost) != "1" {
 		t.Fatalf("env = %#v", cmd.Env)
+	}
+	if lookupEnvValue(cmd.Env, envNodeHostLeader) != "1" {
+		t.Fatalf("missing leader env: %#v", cmd.Env)
 	}
 	if lookupEnvValue(cmd.Env, "HOST") != "127.0.0.1" {
 		t.Fatalf("HOST = %q want 127.0.0.1", lookupEnvValue(cmd.Env, "HOST"))
@@ -223,6 +235,29 @@ func TestBuildSpawnEnv_defaultsHostWhenUnset(t *testing.T) {
 	}
 }
 
+func TestStripNodeOptionImports_removesRegister(t *testing.T) {
+	existing := "--require ./a.cjs --import /path/to/register.mjs --import /tsx/loader.mjs"
+	got := stripNodeOptionImports(existing, "register.mjs")
+	want := "--require ./a.cjs --import /tsx/loader.mjs"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestSanitizeHostChildEnv_stripsRegisterFromInheritedNodeOptions(t *testing.T) {
+	env := sanitizeHostChildEnv([]string{
+		"NODE_OPTIONS=--import /app/register.mjs --max-old-space-size=4096",
+		"PATH=/usr/bin",
+	})
+	nodeOpts := lookupEnvValue(env, "NODE_OPTIONS")
+	if strings.Contains(nodeOpts, "register.mjs") {
+		t.Fatalf("NODE_OPTIONS = %q", nodeOpts)
+	}
+	if !strings.Contains(nodeOpts, "max-old-space-size=4096") {
+		t.Fatalf("NODE_OPTIONS = %q", nodeOpts)
+	}
+}
+
 func TestBuildSpawnEnv_preservesExplicitHost(t *testing.T) {
 	env := buildSpawnEnv(spawnEnvInput{
 		HostMode: true,
@@ -230,5 +265,52 @@ func TestBuildSpawnEnv_preservesExplicitHost(t *testing.T) {
 	})
 	if lookupEnvValue(env, "HOST") != "0.0.0.0" {
 		t.Fatalf("HOST = %q want 0.0.0.0", lookupEnvValue(env, "HOST"))
+	}
+}
+
+func TestApplyHostSpawnColorEnv_respectsNoColor(t *testing.T) {
+	env := applyHostSpawnColorEnv([]string{"NO_COLOR=1"})
+	if lookupEnvValue(env, "FORCE_COLOR") != "" {
+		t.Fatalf("FORCE_COLOR = %q want unset", lookupEnvValue(env, "FORCE_COLOR"))
+	}
+}
+
+func TestApplyHostSpawnColorEnv_preservesExistingForceColor(t *testing.T) {
+	env := applyHostSpawnColorEnv([]string{"FORCE_COLOR=2"})
+	if lookupEnvValue(env, "FORCE_COLOR") != "2" {
+		t.Fatalf("FORCE_COLOR = %q want 2", lookupEnvValue(env, "FORCE_COLOR"))
+	}
+}
+
+func TestPrependNodeImportArgs(t *testing.T) {
+	got := prependNodeImportArgs([]string{"server.js"}, "/tsx/loader.mjs", "/host/register.mjs")
+	want := []string{"--import", "/tsx/loader.mjs", "--import", "/host/register.mjs", "server.js"}
+	if len(got) != len(want) {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %#v want %#v", got, want)
+		}
+	}
+}
+
+func TestPrepareHostSocket_rejectsLiveHost(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket test")
+	}
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "node.sock")
+	readyPath := socketPath + ".ready"
+	marker := fmt.Sprintf(`{"pid":%d,"socket":%q,"phase":"app"}`+"\n", os.Getpid(), socketPath)
+	if err := os.WriteFile(readyPath, []byte(marker), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := PrepareHostSocket(socketPath, readyPath)
+	if err == nil {
+		t.Fatal("expected error for live host")
+	}
+	if !strings.Contains(err.Error(), "host already running") {
+		t.Fatalf("err = %v", err)
 	}
 }

--- a/packages/node-runtime/README.md
+++ b/packages/node-runtime/README.md
@@ -130,14 +130,25 @@ The compiler calls this during type checking. You rarely run it yourself.
 
 ## Environment variables
 
+### Bootstrap and logging
+
 | Variable | Purpose |
 | --- | --- |
 | `FORST_NODE_LOG_LEVEL` | Log verbosity: `debug`, `info`, `warn`, or `error` (default `info`). Per-RPC trace (`rpc_recv`, `call`, `module_cache_hit`, …) requires `debug`. |
 | `FORST_NODE_LOG_FORMAT` | Log format: `pretty` (default) or `json` for structured stderr lines. |
-| `FORST_NODE_BOOTSTRAP` | Absolute path to `bootstrap.js` |
-| `FORST_NODE_HOST` | Set by Go when host mode is active |
-| `FORST_NODE_SOCKET` | Socket path for host mode RPC |
-| `FORST_NODE_HOST_READY` | Ready file path for host mode |
+| `FORST_NODE_BOOTSTRAP` | Absolute path to `bootstrap.js` (bootstrap mode spawn planning) |
+
+### Host mode (set by Go on the direct app-shim child)
+
+| Variable | Purpose |
+| --- | --- |
+| `FORST_NODE_HOST` | When `"1"`, enables in-process host RPC (`startForstNodeHost`). Unset in bootstrap mode. |
+| `FORST_NODE_HOST_LEADER` | When `"1"`, marks the Go-spawned leader process. Required together with `register.mjs` in `process.execArgv`; workers skip binding. |
+| `FORST_NODE_SOCKET` | Absolute Unix socket path (TCP URL on Windows) for Go↔Node RPC in host mode. |
+| `FORST_NODE_HOST_READY` | Absolute path to JSON readiness file (`{socket}.ready`); Go waits for `phase: "app"`. |
+| `FORST_NODE_APP_READY_MODULE` | Optional path to a module loaded before app readiness when `node.hostAppReadyModule` is configured. |
+
+See [Call JavaScript from Forst — host mode environment variables](https://docs.forst.dev/interop/node/call-javascript#host-mode-environment-variables) for spawn layout, readiness phases, and troubleshooting.
 
 ## Development
 

--- a/packages/node-runtime/src/host.test.ts
+++ b/packages/node-runtime/src/host.test.ts
@@ -7,6 +7,7 @@ import {
   startForstNodeHost,
   signalForstAppReady,
   resetHostForTest,
+  setHostLeaderOverrideForTest,
 } from "./host.js";
 import { runTestEffect } from "../test/helpers/run-effect.js";
 
@@ -16,11 +17,14 @@ function tempDir(): string {
 
 describe("startForstNodeHost", () => {
   const prevHost = process.env.FORST_NODE_HOST;
+  const prevLeader = process.env.FORST_NODE_HOST_LEADER;
   const prevSocket = process.env.FORST_NODE_SOCKET;
   const prevReady = process.env.FORST_NODE_HOST_READY;
 
   beforeEach(() => {
     process.env.FORST_NODE_HOST = "1";
+    process.env.FORST_NODE_HOST_LEADER = "1";
+    setHostLeaderOverrideForTest(true);
   });
 
   afterEach(() => {
@@ -29,6 +33,11 @@ describe("startForstNodeHost", () => {
       delete process.env.FORST_NODE_HOST;
     } else {
       process.env.FORST_NODE_HOST = prevHost;
+    }
+    if (prevLeader === undefined) {
+      delete process.env.FORST_NODE_HOST_LEADER;
+    } else {
+      process.env.FORST_NODE_HOST_LEADER = prevLeader;
     }
     if (prevSocket === undefined) {
       delete process.env.FORST_NODE_SOCKET;
@@ -44,6 +53,14 @@ describe("startForstNodeHost", () => {
 
   test("noop when FORST_NODE_HOST unset", async () => {
     delete process.env.FORST_NODE_HOST;
+    const handle = await runTestEffect(startForstNodeHost());
+    expect(handle.socketPath).toBe("");
+    await runTestEffect(handle.close());
+  });
+
+  test("noop when FORST_NODE_HOST_LEADER unset and register not preloaded", async () => {
+    delete process.env.FORST_NODE_HOST_LEADER;
+    setHostLeaderOverrideForTest(null);
     const handle = await runTestEffect(startForstNodeHost());
     expect(handle.socketPath).toBe("");
     await runTestEffect(handle.close());

--- a/packages/node-runtime/src/host.ts
+++ b/packages/node-runtime/src/host.ts
@@ -13,6 +13,7 @@ import { startRpcServer } from "./rpc/server.js";
 import * as HostErrors from "./host/errors.js";
 
 const envHostEnabled = "FORST_NODE_HOST";
+const envHostLeader = "FORST_NODE_HOST_LEADER";
 const envSocketPath = "FORST_NODE_SOCKET";
 const envReadyPath = "FORST_NODE_HOST_READY";
 
@@ -56,6 +57,58 @@ function hostEnabled(): boolean {
   return process.env[envHostEnabled] === "1";
 }
 
+let hostLeaderOverrideForTest: boolean | null = null;
+
+function registerPreloaded(): boolean {
+  const argv = process.execArgv;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i] ?? "";
+    if (arg === "--import" && argv[i + 1]?.includes("register.mjs")) {
+      return true;
+    }
+    if (arg.includes("register.mjs")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hostLeaderEnabled(): boolean {
+  if (hostLeaderOverrideForTest != null) {
+    return hostLeaderOverrideForTest;
+  }
+  if (process.env[envHostLeader] !== "1") {
+    return false;
+  }
+  return registerPreloaded();
+}
+
+interface HostReadyMarker {
+  pid?: number;
+  socket?: string;
+  phase?: string;
+}
+
+function readReadyMarker(readyPath: string): HostReadyMarker | null {
+  try {
+    return JSON.parse(fs.readFileSync(readyPath, "utf8")) as HostReadyMarker;
+  } catch {
+    return null;
+  }
+}
+
+function processAlive(pid: number): boolean {
+  if (pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function isWindows(): boolean {
   return process.platform === "win32";
 }
@@ -94,8 +147,26 @@ function chmodSocket(socketPath: string): void {
 function listenUnix(socketPath: string): Effect.Effect<net.Server, Error, never> {
   return Effect.async<net.Server, Error>((resume) => {
     const dir = path.dirname(socketPath);
+    const readyPath = process.env[envReadyPath] ?? "";
     try {
       fs.mkdirSync(dir, { recursive: true, mode: 0o750 });
+      if (readyPath) {
+        const marker = readReadyMarker(readyPath);
+        if (
+          marker?.pid &&
+          marker.pid !== process.pid &&
+          processAlive(marker.pid)
+        ) {
+          resume(
+            Effect.fail(
+              new Error(
+                `host already running (pid=${marker.pid}, socket=${socketPath})`
+              )
+            )
+          );
+          return;
+        }
+      }
       if (fs.existsSync(socketPath)) {
         try {
           fs.unlinkSync(socketPath);
@@ -109,7 +180,20 @@ function listenUnix(socketPath: string): Effect.Effect<net.Server, Error, never>
     }
 
     const server = net.createServer();
-    server.on("error", (err) => resume(Effect.fail(err)));
+    server.on("error", (err) => {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EADDRINUSE") {
+        resume(
+          Effect.fail(
+            new Error(
+              `host socket already in use (socket=${socketPath}); another host process may be running`
+            )
+          )
+        );
+        return;
+      }
+      resume(Effect.fail(err));
+    });
     server.listen(socketPath, () => {
       chmodSocket(socketPath);
       resume(Effect.succeed(server));
@@ -197,6 +281,12 @@ export function resetHostForTest(): void {
   appReadySignaled = false;
   hostRuntimeLayer = ForstNodeRuntimeLayer;
   hostRuntime = createNodeRuntimeSetup(ForstNodeRuntimeLayer).runtime;
+  hostLeaderOverrideForTest = null;
+}
+
+/** Test-only: bypass register preload check for direct startForstNodeHost calls. */
+export function setHostLeaderOverrideForTest(value: boolean | null): void {
+  hostLeaderOverrideForTest = value;
 }
 
 const closeHostHandle = Effect.fn("Host.close")(function* (ctx: HostCloseContext) {
@@ -245,6 +335,20 @@ const closeHostHandle = Effect.fn("Host.close")(function* (ctx: HostCloseContext
     },
     catch: (cause) => causeToError(cause),
   });
+});
+
+const hostStartNonLeaderNoop = Effect.fn("Host.startNonLeaderNoop")(function* () {
+  yield* Effect.logDebug("host_skip_non_leader").pipe(
+    Effect.annotateLogs({
+      event: "host_skip_non_leader",
+      reason: "FORST_NODE_HOST_LEADER unset",
+      pid: process.pid,
+    })
+  );
+  return {
+    socketPath: "",
+    close: () => Effect.void,
+  } satisfies HostHandle;
 });
 
 const hostStartNoop = Effect.fn("Host.startNoop")(function* () {
@@ -348,6 +452,10 @@ export function startForstNodeHost(
 ): Effect.Effect<HostHandle, Error, never> {
   if (!hostEnabled()) {
     return hostStartNoop();
+  }
+
+  if (!hostLeaderEnabled()) {
+    return hostStartNonLeaderNoop();
   }
 
   if (startPromise) {

--- a/packages/node-runtime/src/host/register.test.ts
+++ b/packages/node-runtime/src/host/register.test.ts
@@ -46,6 +46,7 @@ process.exit(0);
         env: {
           ...process.env,
           FORST_NODE_HOST: "1",
+          FORST_NODE_HOST_LEADER: "1",
           FORST_NODE_SOCKET: socketPath,
           FORST_NODE_HOST_READY: readyPath,
           FORST_NODE_APP_READY_MODULE: appReadyModule,
@@ -95,6 +96,7 @@ process.exit(0);
         env: {
           ...process.env,
           FORST_NODE_HOST: "1",
+          FORST_NODE_HOST_LEADER: "1",
           FORST_NODE_SOCKET: socketPath,
           FORST_NODE_HOST_READY: readyPath,
           NODE_OPTIONS: "",


### PR DESCRIPTION
Move `register.mjs` and `tsx` preload from `NODE_OPTIONS` to direct `argv` on the Go-spawned shim so Vite and Remix worker processes no longer each try to bind `.forst/node.sock`. Add `FORST_NODE_HOST_LEADER` plus `register.mjs` `execArgv` checks so non-leader Node processes skip host startup, strip inherited register imports from `NODE_OPTIONS`, reject live hosts in `PrepareHostSocket`, and improve `EADDRINUSE` errors.

Set `FORCE_COLOR` on host spawn when the Forst parent stdout is a TTY so piped dev-server output keeps ANSI colors.

Document host-mode environment variables and update `hostAutoRegister` wording in node interop docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Node host mode to distinguish leader and worker processes, preventing workers from binding the host socket.
  - Added safer detection and clearer errors for already-running or conflicting host sockets.
  - Host imports are now applied directly to Node startup commands for more reliable behavior.
  - Added host-mode environment variable documentation, including leader, readiness, socket, and bootstrap settings.

- **Bug Fixes**
  - Prevented duplicate host startup and related `EADDRINUSE` failures.
  - Preserved ANSI-colored child-process output and terminal color behavior.

- **Documentation**
  - Expanded host-mode setup and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->