### PR TITLE
test(ci): gate interop deploy paths and harden invoke coverage

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -212,6 +212,11 @@ tasks:
     cmds:
       - go test -v ./cmd/forst/...
 
+  test:scripts:
+    desc: Run shell script unit tests (port cleanup, etc.)
+    cmds:
+      - bash scripts/kill-forst-tcp-listeners_test.sh
+
   test:coverage:
     desc: Run tests with coverage
     dir: forst

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -547,7 +547,7 @@ tasks:
         FT_ROOT="{{.EXAMPLES_DIR}}/rfc/embedded-invoke"
         FORST_BOUNDARY_ROOT="$FT_ROOT" ../bin/forst run -export-struct-fields -root "$FT_ROOT" -- "$FT_ROOT/main.ft" &
         PID=$!
-        trap 'kill -TERM $PID 2>/dev/null || true' EXIT
+        trap 'kill -TERM $PID 2>/dev/null || true; bash ../scripts/kill-forst-tcp-listeners.sh 6321' EXIT
         bash ../scripts/wait-for-url.sh http://127.0.0.1:6321/health invoke 30
         curl -sf -X POST http://127.0.0.1:6321/invoke \
           -H 'Content-Type: application/json' \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -522,6 +522,12 @@ tasks:
     cmds:
       - FORST_BINARY=../bin/forst ../bin/forst dev -export-struct-fields -root {{.EXAMPLES_DIR}}/rfc/node-interop/multi-package-dev -entry main.ft -log-level error
 
+  example:multipackage-dev:reload-e2e:
+    desc: E2E — multipackage-dev forst dev reload keeps Node host pid alive
+    deps: [build:node-runtime, build]
+    cmds:
+      - bash scripts/multipackage-dev-reload-e2e.sh
+
   example:embedded-invoke:
     desc: Compile embedded-invoke example (embedded HTTP /invoke in compiled binary)
     dir: forst
@@ -536,13 +542,14 @@ tasks:
     deps: [build, example:embedded-invoke]
     cmds:
       - |
-        set -e
+        set -euo pipefail
+        bash ../scripts/kill-forst-tcp-listeners.sh 6321
         FT_ROOT="{{.EXAMPLES_DIR}}/rfc/embedded-invoke"
         FORST_BOUNDARY_ROOT="$FT_ROOT" ../bin/forst run -export-struct-fields -root "$FT_ROOT" -- "$FT_ROOT/main.ft" &
         PID=$!
         trap 'kill -TERM $PID 2>/dev/null || true' EXIT
-        sleep 2
-        curl -sf -X POST http://127.0.0.1:8081/invoke \
+        bash ../scripts/wait-for-url.sh http://127.0.0.1:6321/health invoke 30
+        curl -sf -X POST http://127.0.0.1:6321/invoke \
           -H 'Content-Type: application/json' \
           -d '{"package":"main","function":"Echo","args":[{"message":"hello"}]}'
 
@@ -635,7 +642,7 @@ tasks:
         FORST_BIN="../bin/{{.BINARY_NAME}}"
         export FT_ROOT FORST_BIN
         bash -eo pipefail <<'EOS'
-        lsof -ti tcp:6321 2>/dev/null | xargs kill -9 2>/dev/null || true
+        bash ../scripts/kill-forst-tcp-listeners.sh 6321
         lsof -ti tcp:3000 2>/dev/null | xargs kill -9 2>/dev/null || true
         pkill -f 'forst run.*node-interop/remix-serve' 2>/dev/null || true
         pkill -f 'remix-serve build/server/index.js' 2>/dev/null || true
@@ -766,7 +773,7 @@ tasks:
     deps: [build:node-runtime]
     cmds:
       - task: build:vscode
-      - go test -race -covermode atomic -coverprofile=profile.cov -timeout=10m ./cmd/forst/... ./internal/...
+      - go test -race -covermode atomic -coverprofile=profile.cov -timeout=10m ./cmd/forst/... ./internal/... ./nodert/...
 
   ci:e2e:
     desc: Run CI E2E suite (runtime examples, node interop, sidecar, providers)
@@ -777,11 +784,14 @@ tasks:
       - task: test:cli
       - task: test:sidecar
       - task: node-interop:smoke
+      - task: test:multipackage-dev
+      - task: example:embedded-invoke:run
       - task: example:node-interop-sync
       - task: example:node-interop-promises
       - task: example:node-interop-generators
       - task: example:node-interop-async
       - task: example:node-interop-modules
+      - task: example:multipackage-dev:reload-e2e
       - task example:sidecar-local
       - task example:sidecar-downloaded
       - task test:tictactoe

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -633,7 +633,7 @@ tasks:
       - go run ./{{.BUILD_DIR}} run -export-struct-fields -root {{.EXAMPLES_DIR}}/rfc/node-interop/remix-serve -- {{.EXAMPLES_DIR}}/rfc/node-interop/remix-serve/main/main.ft
 
   example:node-interop-remix-serve:e2e:
-    desc: E2E — invoke :6321, Remix :3000, generated client
+    desc: E2E — invoke :6321, Remix :6322, generated client
     dir: forst
     deps: [build:node-runtime, build, example:node-interop-remix-serve:build-remix]
     cmds:
@@ -643,7 +643,7 @@ tasks:
         export FT_ROOT FORST_BIN
         bash -eo pipefail <<'EOS'
         bash ../scripts/kill-forst-tcp-listeners.sh 6321
-        lsof -ti tcp:3000 2>/dev/null | xargs kill -9 2>/dev/null || true
+        lsof -ti tcp:6322 2>/dev/null | xargs kill -9 2>/dev/null || true
         pkill -f 'forst run.*node-interop/remix-serve' 2>/dev/null || true
         pkill -f 'remix-serve build/server/index.js' 2>/dev/null || true
         sleep 0.3
@@ -660,9 +660,9 @@ tasks:
         trap cleanup TERM
 
         bash ../scripts/wait-for-url.sh http://127.0.0.1:6321/health "invoke :6321" 120
-        bash ../scripts/wait-for-url.sh http://127.0.0.1:3000/ "remix :3000" 120
+        bash ../scripts/wait-for-url.sh http://127.0.0.1:6322/ "remix :6322" 120
 
-        curl -sf http://127.0.0.1:3000/ | grep -q 'Todos'
+        curl -sf http://127.0.0.1:6322/ | grep -q 'Todos'
         cd "$FT_ROOT" && FORST_BASE_URL=http://127.0.0.1:6321 bun test e2e/
         EOS
 

--- a/examples/in/rfc/node-interop/multi-package-dev/scripts/host.mjs
+++ b/examples/in/rfc/node-interop/multi-package-dev/scripts/host.mjs
@@ -1,2 +1,14 @@
-// Minimal host shim stub for multi-package-dev hostMode compile/run smoke.
-process.exit(0);
+// Minimal persistent host shim for multi-package-dev hostMode reload e2e.
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+
+const repoRoot = process.env.FORST_REPO_ROOT;
+if (!repoRoot) {
+  console.error("FORST_REPO_ROOT is required");
+  process.exit(1);
+}
+
+const hostJS = path.join(repoRoot, "packages", "node-runtime", "dist", "host.js");
+const { signalForstAppReady } = await import(pathToFileURL(hostJS).href);
+await signalForstAppReady();
+await new Promise(() => {});

--- a/examples/in/rfc/node-interop/multi-package-dev/scripts/host.mjs
+++ b/examples/in/rfc/node-interop/multi-package-dev/scripts/host.mjs
@@ -1,14 +1,3 @@
 // Minimal persistent host shim for multi-package-dev hostMode reload e2e.
-import { pathToFileURL } from "node:url";
-import path from "node:path";
-
-const repoRoot = process.env.FORST_REPO_ROOT;
-if (!repoRoot) {
-  console.error("FORST_REPO_ROOT is required");
-  process.exit(1);
-}
-
-const hostJS = path.join(repoRoot, "packages", "node-runtime", "dist", "host.js");
-const { signalForstAppReady } = await import(pathToFileURL(hostJS).href);
-await signalForstAppReady();
+// Auto-register (register.mjs) writes node.sock.ready; this process only stays alive.
 await new Promise(() => {});

--- a/forst/cmd/forst/dev_server.go
+++ b/forst/cmd/forst/dev_server.go
@@ -27,7 +27,7 @@ type DevServerResponse = invokeserver.Response
 
 // devFunctionExecutor is implemented by *executor.FunctionExecutor; HTTP tests may substitute stubs.
 type devFunctionExecutor interface {
-	ExecuteFunction(packageName, functionName string, args json.RawMessage) (*executor.ExecutionResult, error)
+	ExecuteFunction(ctx context.Context, packageName, functionName string, args json.RawMessage) (*executor.ExecutionResult, error)
 	ExecuteStreamingFunction(ctx context.Context, packageName, functionName string, args json.RawMessage) (<-chan executor.StreamingResult, error)
 }
 

--- a/forst/cmd/forst/dev_server_http.go
+++ b/forst/cmd/forst/dev_server_http.go
@@ -127,11 +127,11 @@ func (b *testInvokeBackend) RefreshFunctions(context.Context) error {
 	return b.refreshErr
 }
 
-func (b *testInvokeBackend) Invoke(_ context.Context, pkg, fn string, args json.RawMessage) (*invokedispatch.InvokeResult, error) {
+func (b *testInvokeBackend) Invoke(ctx context.Context, pkg, fn string, args json.RawMessage) (*invokedispatch.InvokeResult, error) {
 	if b.exec == nil {
 		return nil, fmt.Errorf("no executor")
 	}
-	result, err := b.exec.ExecuteFunction(pkg, fn, args)
+	result, err := b.exec.ExecuteFunction(ctx, pkg, fn, args)
 	if err != nil {
 		return nil, err
 	}

--- a/forst/cmd/forst/dev_server_http_test.go
+++ b/forst/cmd/forst/dev_server_http_test.go
@@ -479,13 +479,13 @@ func TestSendJSONResponse_doesNotSetCORSWhenDisabled(t *testing.T) {
 }
 
 type stubDevExecutor struct {
-	executeFn          func(string, string, json.RawMessage) (*executor.ExecutionResult, error)
+	executeFn          func(context.Context, string, string, json.RawMessage) (*executor.ExecutionResult, error)
 	executeStreamingFn func(context.Context, string, string, json.RawMessage) (<-chan executor.StreamingResult, error)
 }
 
-func (s *stubDevExecutor) ExecuteFunction(packageName, functionName string, args json.RawMessage) (*executor.ExecutionResult, error) {
+func (s *stubDevExecutor) ExecuteFunction(ctx context.Context, packageName, functionName string, args json.RawMessage) (*executor.ExecutionResult, error) {
 	if s.executeFn != nil {
-		return s.executeFn(packageName, functionName, args)
+		return s.executeFn(ctx, packageName, functionName, args)
 	}
 	return nil, fmt.Errorf("stub: no executeFn")
 }
@@ -506,7 +506,7 @@ func TestHandleInvoke_executeFunctionSuccess_returns200(t *testing.T) {
 		},
 	}
 	s.fnExec = &stubDevExecutor{
-		executeFn: func(_, _ string, _ json.RawMessage) (*executor.ExecutionResult, error) {
+		executeFn: func(_ context.Context, _, _ string, _ json.RawMessage) (*executor.ExecutionResult, error) {
 			return &executor.ExecutionResult{
 				Success: true,
 				Result:  json.RawMessage(`{"ok":true}`),

--- a/forst/internal/devserver/reload_node_reattach_test.go
+++ b/forst/internal/devserver/reload_node_reattach_test.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"testing"
 )
 
@@ -73,11 +72,10 @@ await signalForstAppReady();
 		}
 	}
 
-	sockDir := filepath.Join("/tmp", "forst-reload-host-"+strconv.Itoa(os.Getpid()))
+	sockDir := filepath.Join(root, ".forst")
 	if err := os.MkdirAll(sockDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
 	t.Setenv("FORST_NODE_SOCKET", filepath.Join(sockDir, "node.sock"))
 
 	argsJSON, _ := json.Marshal([]string{"app/server.mjs"})

--- a/forst/internal/executor/command_runner.go
+++ b/forst/internal/executor/command_runner.go
@@ -1,0 +1,23 @@
+package executor
+
+import (
+	"context"
+	"os/exec"
+)
+
+// CommandRunner abstracts subprocess creation for tests and production.
+type CommandRunner interface {
+	Command(name string, arg ...string) *exec.Cmd
+	CommandContext(ctx context.Context, name string, arg ...string) *exec.Cmd
+}
+
+// OSCommandRunner uses the real os/exec package.
+type OSCommandRunner struct{}
+
+func (OSCommandRunner) Command(name string, arg ...string) *exec.Cmd {
+	return exec.Command(name, arg...)
+}
+
+func (OSCommandRunner) CommandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, name, arg...)
+}

--- a/forst/internal/executor/command_runner_test.go
+++ b/forst/internal/executor/command_runner_test.go
@@ -49,8 +49,8 @@ func TestFunctionExecutor_ExecuteFunction_contextCancelKillsGoRun(t *testing.T) 
 	if err == nil {
 		t.Fatal("expected cancel error")
 	}
-	if !errors.Is(ctx.Err(), context.Canceled) {
-		t.Fatalf("expected ctx canceled, ctx.Err=%v err=%v", ctx.Err(), err)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected ctx canceled, err=%v", err)
 	}
 }
 
@@ -69,7 +69,7 @@ func TestFunctionExecutor_ExecuteFunction_deadlineExceeded(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected deadline error")
 	}
-	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		t.Fatalf("expected ctx deadline, ctx.Err=%v err=%v", ctx.Err(), err)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected ctx deadline, err=%v", err)
 	}
 }

--- a/forst/internal/executor/command_runner_test.go
+++ b/forst/internal/executor/command_runner_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+type mockCommandRunner struct {
+	commandContextFn func(ctx context.Context, name string, arg ...string) *exec.Cmd
+}
+
+func (m *mockCommandRunner) Command(name string, arg ...string) *exec.Cmd {
+	return exec.Command(name, arg...)
+}
+
+func (m *mockCommandRunner) CommandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	if m.commandContextFn != nil {
+		return m.commandContextFn(ctx, name, arg...)
+	}
+	return exec.CommandContext(ctx, name, arg...)
+}
+
+func TestCommandRunner_defaultUsesGoRun(t *testing.T) {
+	runner := OSCommandRunner{}
+	cmd := runner.CommandContext(context.Background(), "go", "version")
+	if cmd.Path == "" && len(cmd.Args) == 0 {
+		t.Fatal("expected command to be constructed")
+	}
+}
+
+func TestFunctionExecutor_ExecuteFunction_contextCancelKillsGoRun(t *testing.T) {
+	e := testExecutor(t, t.TempDir())
+	e.SetCommandRunnerForTest(&mockCommandRunner{
+		commandContextFn: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "sleep", "30")
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := e.executeGoCode(ctx, t.TempDir(), nil)
+	if err == nil {
+		t.Fatal("expected cancel error")
+	}
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("expected ctx canceled, ctx.Err=%v err=%v", ctx.Err(), err)
+	}
+}
+
+func TestFunctionExecutor_ExecuteFunction_deadlineExceeded(t *testing.T) {
+	e := testExecutor(t, t.TempDir())
+	e.SetCommandRunnerForTest(&mockCommandRunner{
+		commandContextFn: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "sleep", "30")
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := e.executeGoCode(ctx, t.TempDir(), nil)
+	if err == nil {
+		t.Fatal("expected deadline error")
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("expected ctx deadline, ctx.Err=%v err=%v", ctx.Err(), err)
+	}
+}

--- a/forst/internal/executor/execute_paths_extra_test.go
+++ b/forst/internal/executor/execute_paths_extra_test.go
@@ -24,7 +24,7 @@ func main() {
 }
 `)
 
-	outNoParams, err := e.executeGoCode(dir, nil)
+	outNoParams, err := e.executeGoCode(context.Background(), dir, nil)
 	if err != nil {
 		t.Fatalf("executeGoCode without params: %v", err)
 	}
@@ -32,7 +32,7 @@ func main() {
 		t.Fatal("expected output without params")
 	}
 
-	outWithParams, err := e.executeGoCode(dir, json.RawMessage(`null`), 1)
+	outWithParams, err := e.executeGoCode(context.Background(), dir, json.RawMessage(`null`), 1)
 	if err != nil {
 		t.Fatalf("executeGoCode with params: %v", err)
 	}

--- a/forst/internal/executor/executor.go
+++ b/forst/internal/executor/executor.go
@@ -375,6 +375,9 @@ func (e *FunctionExecutor) executeGoCode(ctx context.Context, tempDir string, ar
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return "", err
 			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
 			e.log.Errorf("Go program failed: %v", err)
 			return "", fmt.Errorf("execution failed: %v, output (stdout+stderr): %s", err, output)
 		}
@@ -389,6 +392,9 @@ func (e *FunctionExecutor) executeGoCode(ctx context.Context, tempDir string, ar
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return "", err
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", ctxErr
 		}
 		e.log.Errorf("Go program failed: %v", err)
 		return "", fmt.Errorf("execution failed: %v, output: %s", err, string(output))

--- a/forst/internal/executor/executor.go
+++ b/forst/internal/executor/executor.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -45,6 +46,7 @@ type FunctionExecutor struct {
 	mu            sync.RWMutex
 	config        configiface.ForstConfigIface
 	moduleManager *GoModuleManager
+	runner        CommandRunner
 }
 
 // CompiledFunction represents a compiled Forst function
@@ -82,11 +84,17 @@ func NewFunctionExecutor(rootDir string, comp *compiler.Compiler, log *logrus.Lo
 		cache:         make(map[string]*CompiledFunction),
 		config:        config,
 		moduleManager: NewGoModuleManager(log),
+		runner:        OSCommandRunner{},
 	}
 }
 
+// SetCommandRunnerForTest replaces subprocess execution (tests only).
+func (e *FunctionExecutor) SetCommandRunnerForTest(runner CommandRunner) {
+	e.runner = runner
+}
+
 // ExecuteFunction executes a Forst function with the given arguments
-func (e *FunctionExecutor) ExecuteFunction(packageName, functionName string, args json.RawMessage) (*ExecutionResult, error) {
+func (e *FunctionExecutor) ExecuteFunction(ctx context.Context, packageName, functionName string, args json.RawMessage) (*ExecutionResult, error) {
 	e.log.Debugf("ExecuteFunction: %s.%s", packageName, functionName)
 
 	// Get or compile the function
@@ -145,7 +153,7 @@ func (e *FunctionExecutor) ExecuteFunction(packageName, functionName string, arg
 	// Execute the Go code
 	hasParams := len(compiledFn.Parameters) > 0
 	e.log.Infof("executeGoCode: hasParams=%v, args=%s", hasParams, string(args))
-	output, err := e.executeGoCode(tempDir, args, compiledFn.Parameters)
+	output, err := e.executeGoCode(ctx, tempDir, args, compiledFn.Parameters)
 	if err != nil {
 		e.log.Errorf("Failed to execute Go code: %v", err)
 		return nil, fmt.Errorf("failed to execute Go code: %v", err)
@@ -322,11 +330,15 @@ func (e *FunctionExecutor) createStreamingTempGoFile(compiledFn *CompiledFunctio
 }
 
 // executeGoCode executes Go code and returns the output
-func (e *FunctionExecutor) executeGoCode(tempDir string, args json.RawMessage, params ...any) (string, error) {
+func (e *FunctionExecutor) executeGoCode(ctx context.Context, tempDir string, args json.RawMessage, params ...any) (string, error) {
+	runner := e.runner
+	if runner == nil {
+		runner = OSCommandRunner{}
+	}
 	var cmd *exec.Cmd
 	if len(params) > 0 {
 		e.log.Tracef("Executing Go program with args: %s", string(args))
-		cmd = exec.Command("go", "run", ".")
+		cmd = runner.CommandContext(ctx, "go", "run", ".")
 		cmd.Dir = tempDir
 		// Set up output buffers
 		var stdoutBuf, stderrBuf bytes.Buffer
@@ -360,6 +372,9 @@ func (e *FunctionExecutor) executeGoCode(tempDir string, args json.RawMessage, p
 		err = cmd.Wait()
 		output := stdoutBuf.String() + stderrBuf.String()
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return "", err
+			}
 			e.log.Errorf("Go program failed: %v", err)
 			return "", fmt.Errorf("execution failed: %v, output (stdout+stderr): %s", err, output)
 		}
@@ -368,10 +383,13 @@ func (e *FunctionExecutor) executeGoCode(tempDir string, args json.RawMessage, p
 	}
 
 	e.log.Tracef("Executing Go program without args")
-	cmd = exec.Command("go", "run", ".")
+	cmd = runner.CommandContext(ctx, "go", "run", ".")
 	cmd.Dir = tempDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return "", err
+		}
 		e.log.Errorf("Go program failed: %v", err)
 		return "", fmt.Errorf("execution failed: %v, output: %s", err, string(output))
 	}
@@ -383,10 +401,14 @@ func (e *FunctionExecutor) executeStreamingGoCode(ctx context.Context, tempDir s
 	results := make(chan StreamingResult, 100)
 
 	var cmd *exec.Cmd
+	runner := e.runner
+	if runner == nil {
+		runner = OSCommandRunner{}
+	}
 	if hasParams {
-		cmd = exec.CommandContext(ctx, "go", "run", ".", string(args))
+		cmd = runner.CommandContext(ctx, "go", "run", ".", string(args))
 	} else {
-		cmd = exec.CommandContext(ctx, "go", "run", ".")
+		cmd = runner.CommandContext(ctx, "go", "run", ".")
 	}
 	cmd.Dir = tempDir
 	stdout, err := cmd.StdoutPipe()

--- a/forst/internal/executor/executor_error_paths_test.go
+++ b/forst/internal/executor/executor_error_paths_test.go
@@ -76,7 +76,7 @@ func TestFunctionExecutor_executeGoCode_startAndWaitFailures(t *testing.T) {
 		dir := t.TempDir()
 		t.Setenv("PATH", "")
 
-		_, err := e.executeGoCode(dir, json.RawMessage(`[1]`), 1)
+		_, err := e.executeGoCode(context.Background(), dir, json.RawMessage(`[1]`), 1)
 		if err == nil {
 			t.Fatal("expected start failure")
 		}
@@ -95,7 +95,7 @@ func main() {
 }
 `)
 
-		_, err := e.executeGoCode(dir, json.RawMessage(`[1]`), 1)
+		_, err := e.executeGoCode(context.Background(), dir, json.RawMessage(`[1]`), 1)
 		if err == nil {
 			t.Fatal("expected wait failure with compile error")
 		}
@@ -114,7 +114,7 @@ func main() {
 }
 `)
 
-		_, err := e.executeGoCode(dir, nil)
+		_, err := e.executeGoCode(context.Background(), dir, nil)
 		if err == nil {
 			t.Fatal("expected failure")
 		}
@@ -403,7 +403,7 @@ func Hello() string {
 
 	t.Run("create_temp_dir_failure", func(t *testing.T) {
 		t.Setenv("TMPDIR", "/path/that/does/not/exist")
-		_, err := ex.ExecuteFunction("demo", "Hello", json.RawMessage(`null`))
+		_, err := ex.ExecuteFunction(context.Background(), "demo", "Hello", json.RawMessage(`null`))
 		if err == nil {
 			t.Fatal("expected create temp dir failure")
 		}
@@ -423,7 +423,7 @@ func Broken() string {
 }
 `,
 		}
-		_, err := ex.ExecuteFunction("demo", "Broken", json.RawMessage(`null`))
+		_, err := ex.ExecuteFunction(context.Background(), "demo", "Broken", json.RawMessage(`null`))
 		if err == nil {
 			t.Fatal("expected go execution failure")
 		}

--- a/forst/internal/executor/executor_execute_test.go
+++ b/forst/internal/executor/executor_execute_test.go
@@ -12,7 +12,7 @@ func TestFunctionExecutor_ExecuteFunction_unknownPackage(t *testing.T) {
 	root := t.TempDir()
 	ex := testExecutor(t, root)
 
-	_, err := ex.ExecuteFunction("missingpkg", "Fn", json.RawMessage("null"))
+	_, err := ex.ExecuteFunction(context.Background(), "missingpkg", "Fn", json.RawMessage("null"))
 	if err == nil {
 		t.Fatal("expected error for unknown package")
 	}
@@ -31,7 +31,7 @@ func Greet(): String {
 `)
 	ex := testExecutor(t, root)
 
-	_, err := ex.ExecuteFunction("demo", "NoSuchFn", json.RawMessage("null"))
+	_, err := ex.ExecuteFunction(context.Background(), "demo", "NoSuchFn", json.RawMessage("null"))
 	if err == nil {
 		t.Fatal("expected error for unknown function")
 	}
@@ -50,7 +50,7 @@ func Broken(): String {
 `)
 	ex := testExecutor(t, root)
 
-	_, err := ex.ExecuteFunction("demo", "Broken", json.RawMessage("null"))
+	_, err := ex.ExecuteFunction(context.Background(), "demo", "Broken", json.RawMessage("null"))
 	if err == nil {
 		t.Fatal("expected error when typecheck fails")
 	}
@@ -73,7 +73,7 @@ func Hello(): Greeting {
 `)
 	ex := testExecutor(t, root)
 
-	res, err := ex.ExecuteFunction("demo", "Hello", json.RawMessage("null"))
+	res, err := ex.ExecuteFunction(context.Background(), "demo", "Hello", json.RawMessage("null"))
 	if err != nil {
 		t.Fatalf("ExecuteFunction: %v", err)
 	}
@@ -101,7 +101,7 @@ func Hello(): String {
 `)
 	ex := testExecutor(t, root)
 
-	res, err := ex.ExecuteFunction("demo", "Hello", json.RawMessage("null"))
+	res, err := ex.ExecuteFunction(context.Background(), "demo", "Hello", json.RawMessage("null"))
 	if err != nil {
 		t.Fatalf("ExecuteFunction: %v", err)
 	}
@@ -123,7 +123,7 @@ func Greet(): String {
 `)
 	ex := testExecutor(t, root)
 
-	res, err := ex.ExecuteFunction("demo", "Greet", json.RawMessage("null"))
+	res, err := ex.ExecuteFunction(context.Background(), "demo", "Greet", json.RawMessage("null"))
 	if err != nil {
 		t.Fatalf("ExecuteFunction: %v", err)
 	}
@@ -178,7 +178,7 @@ func Hello(): String {
 	writeFile(t, filepath.Join(root, "bad.ft"), `@@@ this is not valid forst @@`)
 
 	ex := testExecutor(t, root)
-	res, err := ex.ExecuteFunction("demo", "Hello", json.RawMessage("null"))
+	res, err := ex.ExecuteFunction(context.Background(), "demo", "Hello", json.RawMessage("null"))
 	if err != nil {
 		t.Fatalf("ExecuteFunction should succeed despite bad file: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestFunctionExecutor_ExecuteFunction_allFilesUnparseableReturnsNoParseableE
 	writeFile(t, filepath.Join(root, "bad2.ft"), `!!! also invalid !!!`)
 
 	ex := testExecutor(t, root)
-	_, err := ex.ExecuteFunction("demo", "AnyFn", json.RawMessage("null"))
+	_, err := ex.ExecuteFunction(context.Background(), "demo", "AnyFn", json.RawMessage("null"))
 	if err == nil {
 		t.Fatal("expected error when all package files are unparseable")
 	}

--- a/forst/internal/executor/executor_lookup_test.go
+++ b/forst/internal/executor/executor_lookup_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"strings"
@@ -132,7 +133,7 @@ func Hello(): String {
 `)
 	ex := testExecutor(t, root)
 
-	_, err := ex.ExecuteFunction("demo", "Hello", json.RawMessage("null"))
+	_, err := ex.ExecuteFunction(context.Background(), "demo", "Hello", json.RawMessage("null"))
 	if err != nil {
 		t.Fatalf("ExecuteFunction: %v", err)
 	}

--- a/forst/internal/invokeserver/backend.go
+++ b/forst/internal/invokeserver/backend.go
@@ -24,7 +24,7 @@ type functionDiscoverer interface {
 }
 
 type devFunctionExecutor interface {
-	ExecuteFunction(packageName, functionName string, args json.RawMessage) (*executor.ExecutionResult, error)
+	ExecuteFunction(ctx context.Context, packageName, functionName string, args json.RawMessage) (*executor.ExecutionResult, error)
 	ExecuteStreamingFunction(ctx context.Context, packageName, functionName string, args json.RawMessage) (<-chan executor.StreamingResult, error)
 }
 
@@ -72,8 +72,8 @@ func (b *DevBackend) Functions() map[string]map[string]discovery.FunctionInfo {
 }
 
 // Invoke runs a function via the dev executor.
-func (b *DevBackend) Invoke(_ context.Context, pkg, fn string, args json.RawMessage) (*invokedispatch.InvokeResult, error) {
-	result, err := b.exec.ExecuteFunction(pkg, fn, args)
+func (b *DevBackend) Invoke(ctx context.Context, pkg, fn string, args json.RawMessage) (*invokedispatch.InvokeResult, error) {
+	result, err := b.exec.ExecuteFunction(ctx, pkg, fn, args)
 	if err != nil {
 		return nil, err
 	}

--- a/forst/internal/invokeserver/dev_backend_test.go
+++ b/forst/internal/invokeserver/dev_backend_test.go
@@ -25,13 +25,13 @@ func (d *stubDiscoverer) DiscoverFunctions() (map[string]map[string]discovery.Fu
 }
 
 type stubDevExecutor struct {
-	executeFn          func(packageName, functionName string, args json.RawMessage) (*executor.ExecutionResult, error)
-	executeStreamingFn func(ctx context.Context, packageName, functionName string, args json.RawMessage) (<-chan executor.StreamingResult, error)
+	executeFn          func(context.Context, string, string, json.RawMessage) (*executor.ExecutionResult, error)
+	executeStreamingFn func(context.Context, string, string, json.RawMessage) (<-chan executor.StreamingResult, error)
 }
 
-func (e *stubDevExecutor) ExecuteFunction(packageName, functionName string, args json.RawMessage) (*executor.ExecutionResult, error) {
+func (e *stubDevExecutor) ExecuteFunction(ctx context.Context, packageName, functionName string, args json.RawMessage) (*executor.ExecutionResult, error) {
 	if e.executeFn != nil {
-		return e.executeFn(packageName, functionName, args)
+		return e.executeFn(ctx, packageName, functionName, args)
 	}
 	return nil, errors.New("no executeFn")
 }
@@ -99,7 +99,7 @@ func TestDevBackend_functionsSnapshot(t *testing.T) {
 
 func TestDevBackend_invoke_success(t *testing.T) {
 	b := newDevBackendWithStubs(&stubDiscoverer{}, &stubDevExecutor{
-		executeFn: func(_, _ string, _ json.RawMessage) (*executor.ExecutionResult, error) {
+		executeFn: func(_ context.Context, _, _ string, _ json.RawMessage) (*executor.ExecutionResult, error) {
 			return &executor.ExecutionResult{Success: true, Result: json.RawMessage(`{"ok":true}`)}, nil
 		},
 	})
@@ -111,7 +111,7 @@ func TestDevBackend_invoke_success(t *testing.T) {
 
 func TestDevBackend_invoke_error(t *testing.T) {
 	b := newDevBackendWithStubs(&stubDiscoverer{}, &stubDevExecutor{
-		executeFn: func(_, _ string, _ json.RawMessage) (*executor.ExecutionResult, error) {
+		executeFn: func(_ context.Context, _, _ string, _ json.RawMessage) (*executor.ExecutionResult, error) {
 			return nil, fmt.Errorf("exec failed")
 		},
 	})

--- a/forst/nodert/client.go
+++ b/forst/nodert/client.go
@@ -12,8 +12,8 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
-// DefaultCallTimeout is the maximum wait for a single RPC response.
-var DefaultCallTimeout = 5 * time.Minute
+// DefaultCallTimeout is the maximum wait for a single RPC response when not overridden by ftconfig.
+var DefaultCallTimeout = 30 * time.Second
 
 type callResult struct {
 	result json.RawMessage
@@ -101,6 +101,19 @@ func (c *Client) PendingCount() int {
 	c.pendingMu.Lock()
 	defer c.pendingMu.Unlock()
 	return len(c.pending)
+}
+
+// readLoopExited reports whether the RPC read loop has stopped (connection dead).
+func (c *Client) readLoopExited() bool {
+	if c == nil {
+		return true
+	}
+	select {
+	case <-c.readDone:
+		return true
+	default:
+		return false
+	}
 }
 
 // Initialized reports whether initialize completed successfully.

--- a/forst/nodert/configure_test.go
+++ b/forst/nodert/configure_test.go
@@ -90,6 +90,11 @@ func TestResolveBootstrapPath_envRelativeFallsBackToMonorepo(t *testing.T) {
 	if err := os.MkdirAll(sandbox, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 	if err := os.Chdir(sandbox); err != nil {
 		t.Fatal(err)
 	}
@@ -261,6 +266,11 @@ func TestConfigureFromManifest_discoversBoundaryRootWhenEmbeddedOmitsIt(t *testi
 	if err := os.MkdirAll(subDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
 	if err := os.Chdir(subDir); err != nil {
 		t.Fatal(err)
 	}

--- a/forst/nodert/host_integration_test.go
+++ b/forst/nodert/host_integration_test.go
@@ -7,9 +7,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestHostMode_sharedSingletonVisibleToRPC(t *testing.T) {
@@ -87,14 +88,29 @@ func TestHostMode_hostNotStarted_timesOut(t *testing.T) {
 	}
 }
 
+type hostSocketFixture struct {
+	dir  string
+	once sync.Once
+}
+
+var hostSocketFixtures sync.Map
+
 func shortHostSocketPath(t *testing.T) string {
 	t.Helper()
-	dir := filepath.Join("/tmp", "forst-host-"+strconv.Itoa(os.Getpid()))
-	if err := os.MkdirAll(dir, 0o750); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return filepath.Join(dir, "node.sock")
+	fixAny, _ := hostSocketFixtures.LoadOrStore(t, &hostSocketFixture{})
+	fix := fixAny.(*hostSocketFixture)
+	fix.once.Do(func() {
+		// Keep the full path under the Unix socket length limit (104 bytes on macOS).
+		fix.dir = filepath.Join("/tmp", fmt.Sprintf("fh-%d", time.Now().UnixNano()))
+		if err := os.MkdirAll(fix.dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			hostSocketFixtures.Delete(t)
+			_ = os.RemoveAll(fix.dir)
+		})
+	})
+	return filepath.Join(fix.dir, "s.sock")
 }
 
 func linkTsxFromRepo(t *testing.T, root string) {

--- a/forst/nodert/host_integration_test.go
+++ b/forst/nodert/host_integration_test.go
@@ -277,6 +277,7 @@ func runHostCounterRPC(t *testing.T, _ string, manifest Manifest, firstWant, sec
 	t.Helper()
 
 	resetSupervisorForTest()
+	t.Cleanup(resetSupervisorForTest)
 	t.Setenv(envNodeBootstrap, "")
 	t.Setenv(envNodeBinary, "")
 
@@ -313,6 +314,7 @@ func runHostEditCountRPC(t *testing.T, _ string, manifest Manifest, firstWant, s
 	t.Helper()
 
 	resetSupervisorForTest()
+	t.Cleanup(resetSupervisorForTest)
 	t.Setenv(envNodeBootstrap, "")
 	t.Setenv(envNodeBinary, "")
 

--- a/forst/nodert/host_test.go
+++ b/forst/nodert/host_test.go
@@ -2,6 +2,7 @@ package nodert
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -12,12 +13,22 @@ import (
 	"time"
 )
 
+func testUnixSocketDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join("/tmp", fmt.Sprintf("fhut-%d", time.Now().UnixNano()))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func TestWaitForHostReady_success(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix socket test")
 	}
 
-	dir := t.TempDir()
+	dir := testUnixSocketDir(t)
 	socketPath := filepath.Join(dir, "node.sock")
 	readyPath := socketPath + ".ready"
 
@@ -54,7 +65,7 @@ func TestConnectExistingHost_success(t *testing.T) {
 		t.Skip("unix socket test")
 	}
 
-	dir := t.TempDir()
+	dir := testUnixSocketDir(t)
 	socketPath := filepath.Join(dir, "node.sock")
 	readyPath := socketPath + ".ready"
 
@@ -90,7 +101,7 @@ func TestConnectExistingHost_success(t *testing.T) {
 }
 
 func TestConnectExistingHost_absent(t *testing.T) {
-	dir := t.TempDir()
+	dir := testUnixSocketDir(t)
 	socketPath := filepath.Join(dir, "node.sock")
 	readyPath := socketPath + ".ready"
 
@@ -111,7 +122,7 @@ func TestWaitForHostReady_ignoresListeningPhase(t *testing.T) {
 		t.Skip("unix socket test")
 	}
 
-	dir := t.TempDir()
+	dir := testUnixSocketDir(t)
 	socketPath := filepath.Join(dir, "node.sock")
 	readyPath := socketPath + ".ready"
 
@@ -154,7 +165,7 @@ func TestWaitForHostReady_timeout(t *testing.T) {
 		t.Skip("unix socket test")
 	}
 
-	dir := t.TempDir()
+	dir := testUnixSocketDir(t)
 	socketPath := filepath.Join(dir, "missing.sock")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)

--- a/forst/nodert/process.go
+++ b/forst/nodert/process.go
@@ -167,7 +167,8 @@ func (p *managedProcess) terminate() error {
 		if err := p.cmd.Process.Kill(); err != nil {
 			return fmt.Errorf("kill node process: %w", err)
 		}
-		return <-done
+		<-done
+		return nil
 	}
 }
 

--- a/forst/nodert/process_terminate_test.go
+++ b/forst/nodert/process_terminate_test.go
@@ -1,0 +1,41 @@
+package nodert
+
+import (
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestManagedProcess_terminateSigkillReturnsNil(t *testing.T) {
+	cmd := exec.Command("sleep", strconv.Itoa(120))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	proc := &managedProcess{cmd: cmd}
+	t.Cleanup(func() { _ = proc.terminate() })
+
+	if err := proc.terminate(); err != nil {
+		t.Fatalf("terminate after SIGKILL: %v", err)
+	}
+}
+
+func TestManagedProcess_terminateExitsQuicklyWhenChildIgnoresStdinClose(t *testing.T) {
+	cmd := exec.Command("sleep", strconv.Itoa(120))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	proc := &managedProcess{cmd: cmd}
+
+	done := make(chan error, 1)
+	go func() { done <- proc.terminate() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("terminate: %v", err)
+		}
+	case <-time.After(shutdownGracePeriod + 3*time.Second):
+		t.Fatal("terminate did not finish within grace + kill window")
+	}
+}

--- a/forst/nodert/spawn.go
+++ b/forst/nodert/spawn.go
@@ -351,6 +351,21 @@ func prependNodeImportArgs(shimArgs []string, importPaths ...string) []string {
 	return append(args, shimArgs...)
 }
 
+// portFromShimArgs extracts --port / -p from host shim argv for shims that honor PORT (e.g. remix-serve).
+func portFromShimArgs(args []string) string {
+	for i, arg := range args {
+		switch {
+		case arg == "--port" && i+1 < len(args):
+			return strings.TrimSpace(args[i+1])
+		case strings.HasPrefix(arg, "--port="):
+			return strings.TrimSpace(strings.TrimPrefix(arg, "--port="))
+		case (arg == "-p" || arg == "-P") && i+1 < len(args):
+			return strings.TrimSpace(args[i+1])
+		}
+	}
+	return ""
+}
+
 func sameResolvedExecutable(a, b string) bool {
 	if a == "" || b == "" {
 		return false
@@ -560,6 +575,9 @@ func BuildHostSpawnCommand(in HostSpawnInput) (HostSpawnCommand, error) {
 	}
 	if in.HostAppReadyModule != "" {
 		childEnv = setEnvVar(childEnv, envNodeAppReadyModule, in.HostAppReadyModule)
+	}
+	if port := portFromShimArgs(in.ShimArgs); port != "" {
+		childEnv = setEnvVar(childEnv, "PORT", port)
 	}
 
 	env := buildSpawnEnv(spawnEnvInput{

--- a/forst/nodert/spawn.go
+++ b/forst/nodert/spawn.go
@@ -579,6 +579,11 @@ func BuildHostSpawnCommand(in HostSpawnInput) (HostSpawnCommand, error) {
 	if port := portFromShimArgs(in.ShimArgs); port != "" {
 		childEnv = setEnvVar(childEnv, "PORT", port)
 	}
+	// App shims (e.g. remix-serve) honor HOST for bind address. Force loopback unless
+	// ftconfig/explicit spawn env already set HOST — parent CI env must not leak in.
+	if lookupEnvValue(childEnv, "HOST") == "" {
+		childEnv = setEnvVar(childEnv, "HOST", "127.0.0.1")
+	}
 
 	env := buildSpawnEnv(spawnEnvInput{
 		BoundaryRoot: in.BoundaryRoot,

--- a/forst/nodert/spawn_test.go
+++ b/forst/nodert/spawn_test.go
@@ -417,6 +417,7 @@ func TestBuildHostSpawnCommand_nonNodeShimUsesNodeInterpreter(t *testing.T) {
 			t.Fatalf("args[%d] = %q want %q (full args = %#v)", i, cmd.Args[i], wantArgs[i], cmd.Args)
 		}
 	}
+	assertEnvVar(t, cmd.Env, "PORT", "3000")
 }
 
 func TestPrepareHostSocket_rejectsLiveHost(t *testing.T) {

--- a/forst/nodert/spawn_test.go
+++ b/forst/nodert/spawn_test.go
@@ -418,6 +418,71 @@ func TestBuildHostSpawnCommand_nonNodeShimUsesNodeInterpreter(t *testing.T) {
 		}
 	}
 	assertEnvVar(t, cmd.Env, "PORT", "3000")
+	assertEnvVar(t, cmd.Env, "HOST", "127.0.0.1")
+}
+
+func TestBuildHostSpawnCommand_overridesInheritedHostFromParentEnv(t *testing.T) {
+	t.Setenv("HOST", "runnerspecific")
+	root := t.TempDir()
+	shim := filepath.Join(root, "node_modules", ".bin", "remix-serve")
+	if err := os.MkdirAll(filepath.Dir(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shim, []byte("#!/usr/bin/env node\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tsxDir := filepath.Join(root, "node_modules", "tsx", "dist")
+	if err := os.MkdirAll(tsxDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsxDir, "loader.mjs"), []byte("//"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, err := BuildHostSpawnCommand(HostSpawnInput{
+		BoundaryRoot: root,
+		Executable:   "node_modules/.bin/remix-serve",
+		ShimArgs:     []string{"build/server/index.js", "--port", "6322"},
+		WorkDir:      root,
+		Loader:       "tsx",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEnvVar(t, cmd.Env, "HOST", "127.0.0.1")
+	assertEnvVar(t, cmd.Env, "PORT", "6322")
+}
+
+func TestBuildHostSpawnCommand_preservesExplicitHostInSpawnEnv(t *testing.T) {
+	t.Setenv("HOST", "runnerspecific")
+	root := t.TempDir()
+	shim := filepath.Join(root, "node_modules", ".bin", "remix-serve")
+	if err := os.MkdirAll(filepath.Dir(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shim, []byte("#!/usr/bin/env node\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tsxDir := filepath.Join(root, "node_modules", "tsx", "dist")
+	if err := os.MkdirAll(tsxDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsxDir, "loader.mjs"), []byte("//"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, err := BuildHostSpawnCommand(HostSpawnInput{
+		BoundaryRoot: root,
+		Executable:   "node_modules/.bin/remix-serve",
+		ShimArgs:     []string{"build/server/index.js", "--port", "6322"},
+		WorkDir:      root,
+		Loader:       "tsx",
+		Env:          []string{"HOST=0.0.0.0"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEnvVar(t, cmd.Env, "HOST", "0.0.0.0")
 }
 
 func TestPrepareHostSocket_rejectsLiveHost(t *testing.T) {

--- a/forst/nodert/stdout_capture_test.go
+++ b/forst/nodert/stdout_capture_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -82,7 +81,7 @@ func TestBootstrapStdout_staysIdleBeforeRpcFrames(t *testing.T) {
 		failBootstrapProcessDied(t, cmd, errCollected, "expected bootstrap logs on stderr")
 	}
 	if !strings.Contains(string(errCollected), "spawn") {
-		failBootstrapProcessDied(t, cmd, errCollected, "stderr missing spawn log, got "+strconv.Quote(string(errCollected)))
+		failBootstrapProcessDied(t, cmd, errCollected, "stderr missing spawn log")
 	}
 
 	buf := make([]byte, 64)
@@ -102,9 +101,9 @@ func TestBootstrapStdout_staysIdleBeforeRpcFrames(t *testing.T) {
 
 func collectUntilSubstring(r io.Reader, needle string, timeout time.Duration) ([]byte, error) {
 	collected := make([]byte, 0, 4096)
+	chunk := make([]byte, 512)
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		chunk := make([]byte, 512)
 		n, err := readAvailableWithDeadline(r, 200*time.Millisecond, chunk)
 		if n > 0 {
 			collected = append(collected, chunk[:n]...)

--- a/forst/nodert/stdout_capture_test.go
+++ b/forst/nodert/stdout_capture_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -28,6 +29,9 @@ func TestBootstrapStdout_staysIdleBeforeRpcFrames(t *testing.T) {
 	if _, err := exec.LookPath("node"); err != nil {
 		t.Skip("node not on PATH")
 	}
+	resetSupervisorForTest()
+	t.Cleanup(resetSupervisorForTest)
+
 	bootstrap, err := ResolveBootstrapPath(repoRoot(t), "")
 	if err != nil {
 		t.Skipf("bootstrap not available: %v", err)
@@ -51,6 +55,7 @@ func TestBootstrapStdout_staysIdleBeforeRpcFrames(t *testing.T) {
 	}
 
 	cmd := exec.Command(spawnCmd.Executable, spawnCmd.Args...)
+	cmd.Dir = root
 	cmd.Env = spawnCmd.Env
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -69,41 +74,59 @@ func TestBootstrapStdout_staysIdleBeforeRpcFrames(t *testing.T) {
 	}
 	defer func() { _ = cmd.Process.Kill() }()
 
-	time.Sleep(500 * time.Millisecond)
+	errCollected, stderrErr := collectUntilSubstring(stderr, "spawn", 15*time.Second)
+	if stderrErr != nil {
+		failBootstrapProcessDied(t, cmd, errCollected, "stderr read: "+stderrErr.Error())
+	}
+	if len(errCollected) == 0 {
+		failBootstrapProcessDied(t, cmd, errCollected, "expected bootstrap logs on stderr")
+	}
+	if !strings.Contains(string(errCollected), "spawn") {
+		failBootstrapProcessDied(t, cmd, errCollected, "stderr missing spawn log, got "+strconv.Quote(string(errCollected)))
+	}
 
 	buf := make([]byte, 64)
 	n, readErr := readAvailableWithDeadline(stdout, 200*time.Millisecond, buf)
 	if readErr != nil && !errors.Is(readErr, os.ErrDeadlineExceeded) {
-		t.Fatalf("stdout read: %v", readErr)
+		failBootstrapProcessDied(t, cmd, errCollected, "stdout read: "+readErr.Error())
 	}
 	if n > 0 {
 		t.Fatalf("stdout must stay empty before RPC frames, got hex=%s text=%q",
 			hex.EncodeToString(buf[:n]), string(buf[:n]))
 	}
 
-	errCollected := make([]byte, 0, 4096)
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		chunk := make([]byte, 512)
-		errN, errReadErr := readAvailableWithDeadline(stderr, 200*time.Millisecond, chunk)
-		if errReadErr != nil && !errors.Is(errReadErr, os.ErrDeadlineExceeded) {
-			t.Fatalf("stderr read: %v", errReadErr)
-		}
-		if errN > 0 {
-			errCollected = append(errCollected, chunk[:errN]...)
-			if strings.Contains(string(errCollected), "spawn") {
-				break
-			}
-		}
-	}
-	if len(errCollected) == 0 {
-		t.Fatal("expected bootstrap logs on stderr")
-	}
-	if !strings.Contains(string(errCollected), "spawn") {
-		t.Fatalf("stderr missing spawn log, got %q", string(errCollected))
-	}
-
 	_ = stdin.Close()
 	_, _ = io.Copy(io.Discard, stdout)
 	_ = cmd.Wait()
+}
+
+func collectUntilSubstring(r io.Reader, needle string, timeout time.Duration) ([]byte, error) {
+	collected := make([]byte, 0, 4096)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		chunk := make([]byte, 512)
+		n, err := readAvailableWithDeadline(r, 200*time.Millisecond, chunk)
+		if n > 0 {
+			collected = append(collected, chunk[:n]...)
+			if strings.Contains(string(collected), needle) {
+				return collected, nil
+			}
+		}
+		if err != nil {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				continue
+			}
+			return collected, err
+		}
+	}
+	return collected, nil
+}
+
+func failBootstrapProcessDied(t *testing.T, cmd *exec.Cmd, stderr []byte, reason string) {
+	t.Helper()
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+	waitErr := cmd.Wait()
+	t.Fatalf("%s (wait=%v stderr=%q)", reason, waitErr, string(stderr))
 }

--- a/forst/nodert/supervisor.go
+++ b/forst/nodert/supervisor.go
@@ -34,7 +34,7 @@ type RPCConfig struct {
 }
 
 var (
-	supervisorOnce       sync.Once
+	supervisorMu         sync.Mutex
 	supervisorInst       *Supervisor
 	supervisorErr        error
 	supervisorErrPrinted sync.Once
@@ -43,6 +43,8 @@ var (
 
 // ConfigureSupervisor sets options used by the first GetClient call.
 func ConfigureSupervisor(cfg SupervisorConfig) {
+	supervisorMu.Lock()
+	defer supervisorMu.Unlock()
 	supervisorCfg = cfg
 }
 
@@ -57,13 +59,26 @@ type Supervisor struct {
 
 // GetClient returns the singleton RPC client, spawning Node on first use.
 func GetClient() (*Client, error) {
-	supervisorOnce.Do(func() {
-		if supervisorCfg.HostMode {
-			supervisorInst, supervisorErr = newHostSupervisor(supervisorCfg)
-		} else {
-			supervisorInst, supervisorErr = newBootstrapSupervisor(supervisorCfg)
+	supervisorMu.Lock()
+	defer supervisorMu.Unlock()
+	return getClientLocked()
+}
+
+func getClientLocked() (*Client, error) {
+	if supervisorInst != nil {
+		if supervisorInst.isAlive() {
+			return supervisorInst.client, nil
 		}
-	})
+		discardDeadSupervisorLocked()
+	}
+
+	var err error
+	if supervisorCfg.HostMode {
+		supervisorInst, err = newHostSupervisor(supervisorCfg)
+	} else {
+		supervisorInst, err = newBootstrapSupervisor(supervisorCfg)
+	}
+	supervisorErr = err
 	if supervisorErr != nil {
 		supervisorErrPrinted.Do(func() {
 			fmt.Fprintf(os.Stderr, "forst node runtime: %v\n", supervisorErr)
@@ -75,10 +90,51 @@ func GetClient() (*Client, error) {
 
 // Shutdown terminates the supervised Node process.
 func Shutdown() error {
+	supervisorMu.Lock()
+	defer supervisorMu.Unlock()
 	if supervisorInst == nil {
 		return nil
 	}
-	return supervisorInst.shutdown()
+	err := supervisorInst.shutdown()
+	supervisorInst = nil
+	supervisorErr = nil
+	return err
+}
+
+func discardDeadSupervisorLocked() {
+	if supervisorInst == nil {
+		return
+	}
+	_ = supervisorInst.shutdown()
+	supervisorInst = nil
+	supervisorErr = nil
+}
+
+func (s *Supervisor) isAlive() bool {
+	if s == nil || s.client == nil {
+		return false
+	}
+	if s.client.readLoopExited() {
+		return false
+	}
+	if s.proc != nil && s.proc.cmd != nil && s.proc.cmd.Process != nil {
+		if !processAlive(s.proc.cmd.Process.Pid) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Supervisor) watchProcess(proc *managedProcess) {
+	if proc == nil {
+		return
+	}
+	_ = proc.wait()
+	supervisorMu.Lock()
+	defer supervisorMu.Unlock()
+	if supervisorInst == s {
+		discardDeadSupervisorLocked()
+	}
 }
 
 func newBootstrapSupervisor(cfg SupervisorConfig) (*Supervisor, error) {
@@ -94,7 +150,12 @@ func newBootstrapSupervisor(cfg SupervisorConfig) (*Supervisor, error) {
 	}
 
 	client := NewClient(proc.stdout, proc.stdin, log)
-	return finishSupervisorInit(cfg, client, proc, nil, log)
+	s, err := finishSupervisorInit(cfg, client, proc, nil, log)
+	if err != nil {
+		return nil, err
+	}
+	go s.watchProcess(proc)
+	return s, nil
 }
 
 func newHostSupervisor(cfg SupervisorConfig) (*Supervisor, error) {
@@ -154,7 +215,14 @@ func newHostSupervisor(cfg SupervisorConfig) (*Supervisor, error) {
 		proc = spawnedProc.proc
 	}
 
-	return dialAndInitHost(cfg, conn, proc, log)
+	s, err := dialAndInitHost(cfg, conn, proc, log)
+	if err != nil {
+		return nil, err
+	}
+	if proc != nil {
+		go s.watchProcess(proc)
+	}
+	return s, nil
 }
 
 func resolveHostSupervisorPaths(cfg SupervisorConfig) (socketPath, readyPath string, timeout time.Duration, err error) {
@@ -256,10 +324,11 @@ func (s *Supervisor) shutdown() error {
 
 // resetSupervisorForTest clears singleton state for unit tests.
 func resetSupervisorForTest() {
+	supervisorMu.Lock()
+	defer supervisorMu.Unlock()
 	if supervisorInst != nil {
 		_ = supervisorInst.shutdown()
 	}
-	supervisorOnce = sync.Once{}
 	supervisorInst = nil
 	supervisorErr = nil
 	supervisorErrPrinted = sync.Once{}

--- a/forst/nodert/supervisor_death_test.go
+++ b/forst/nodert/supervisor_death_test.go
@@ -1,0 +1,119 @@
+package nodert
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBootstrap_nodeDeath_failFastAndRespawn(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not on PATH")
+	}
+
+	bootstrap, err := ResolveBootstrapPath(repoRoot(t), "")
+	if err != nil {
+		t.Skipf("bootstrap not available: %v", err)
+	}
+	t.Setenv(envNodeBootstrap, bootstrap)
+
+	root := t.TempDir()
+	legacyDir := filepath.Join(root, "legacy")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tsFile := filepath.Join(legacyDir, "slow.ts")
+	if err := os.WriteFile(tsFile, []byte(`export async function hang(): Promise<{ ok: boolean }> {
+  await new Promise(() => {});
+  return { ok: true };
+}
+export function add(a: number, b: number): { sum: number } {
+  return { sum: a + b };
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := Manifest{
+		Version:      ManifestVersion,
+		BoundaryRoot: root,
+		Exports: []ExportEntry{
+			{ModuleID: "legacy/slow.ts", Name: "hang", Kind: ExportKindAsyncFunction},
+			{ModuleID: "legacy/slow.ts", Name: "add", Kind: ExportKindFunction},
+		},
+	}
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resetSupervisorForTest()
+	t.Cleanup(resetSupervisorForTest)
+	if err := configureFromManifest(string(manifestJSON)); err != nil {
+		t.Fatal(err)
+	}
+
+	type sumResult struct {
+		Sum float64 `json:"sum"`
+	}
+	got, err := CallSync[sumResult]("legacy/slow.ts", "add", 1, 1)
+	if err != nil {
+		t.Fatalf("first CallSync: %v", err)
+	}
+	if got.Sum != 2 {
+		t.Fatalf("sum = %v want 2", got.Sum)
+	}
+
+	supervisorMu.Lock()
+	proc := supervisorInst.proc
+	supervisorMu.Unlock()
+	if proc == nil || proc.cmd == nil || proc.cmd.Process == nil {
+		t.Fatal("expected supervised bootstrap process")
+	}
+
+	hangErr := make(chan error, 1)
+	go func() {
+		_, err := CallAsync[map[string]bool]("legacy/slow.ts", "hang")
+		hangErr <- err
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	if err := proc.cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill node: %v", err)
+	}
+	_ = proc.wait()
+
+	select {
+	case err := <-hangErr:
+		if err == nil {
+			t.Fatal("expected in-flight call to fail after node death")
+		}
+		if !errors.Is(err, ErrNodeRuntimeDied) {
+			t.Fatalf("in-flight err = %v want ErrNodeRuntimeDied", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight call did not fail after node death")
+	}
+
+	got2, err := CallSync[sumResult]("legacy/slow.ts", "add", 40, 2)
+	if err != nil {
+		t.Fatalf("respawn CallSync: %v", err)
+	}
+	if got2.Sum != 42 {
+		t.Fatalf("respawn sum = %v want 42", got2.Sum)
+	}
+
+	if err := Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestDefaultCallTimeout_isRequestSafe(t *testing.T) {
+	if DefaultCallTimeout != 30*time.Second {
+		t.Fatalf("DefaultCallTimeout = %s want 30s", DefaultCallTimeout)
+	}
+}

--- a/packages/node-runtime/package.json
+++ b/packages/node-runtime/package.json
@@ -35,7 +35,7 @@
     "clean": "rm -rf dist",
     "build:clean": "bun run clean && bun run build",
     "typecheck": "tsc --noEmit",
-    "test": "bun test",
+    "test": "bun test --preload ./test/preload.ts",
     "pack:dry": "npm pack --dry-run --ignore-scripts"
   },
   "keywords": [

--- a/packages/node-runtime/src/host/register.cjs
+++ b/packages/node-runtime/src/host/register.cjs
@@ -10,15 +10,26 @@ process.stderr.write(
   })}\n`
 );
 
-void import("../host.js")
-  .then(async ({ startForstNodeHost, signalForstAppReady }) => {
+void Promise.all([import("../host.js"), import("effect"), import("../effect/layer.js")])
+  .then(async ([hostMod, effectMod, layerMod]) => {
+    const { startForstNodeHost, signalForstAppReady } = hostMod;
+    const { Effect } = effectMod;
+    const { ForstNodeRuntimeLayer } = layerMod;
     const appReadyModule = process.env.FORST_NODE_APP_READY_MODULE?.trim();
-    await startForstNodeHost({ deferAppReady: true });
+
+    await Effect.runPromise(
+      startForstNodeHost({ deferAppReady: Boolean(appReadyModule) }).pipe(
+        Effect.provide(ForstNodeRuntimeLayer)
+      )
+    );
+
     if (appReadyModule) {
       const { resolve } = await import("node:path");
       const { pathToFileURL } = await import("node:url");
       await import(pathToFileURL(resolve(appReadyModule)).href);
-      await signalForstAppReady();
+      await Effect.runPromise(
+        signalForstAppReady().pipe(Effect.provide(ForstNodeRuntimeLayer))
+      );
     }
   })
   .catch((err) => {

--- a/packages/node-runtime/src/runtime/lifecycle.ts
+++ b/packages/node-runtime/src/runtime/lifecycle.ts
@@ -51,12 +51,18 @@ function exportAllowlistKey(exp: { moduleId: string; name: string }): string {
   return `${exp.moduleId}\0${exp.name}`;
 }
 
-/** True when incoming adds exports not present in the frozen manifest (same boundary). */
+/** True when incoming adds exports while retaining every frozen export (same boundary). */
 function manifestWidensAllowlist(
   frozen: ForstNodeManifestV1,
   incoming: ForstNodeManifestV1
 ): boolean {
   const frozenKeys = new Set(frozen.exports.map(exportAllowlistKey));
+  const incomingKeys = new Set(incoming.exports.map(exportAllowlistKey));
+  for (const key of frozenKeys) {
+    if (!incomingKeys.has(key)) {
+      return false;
+    }
+  }
   return incoming.exports.some((exp) => !frozenKeys.has(exportAllowlistKey(exp)));
 }
 

--- a/packages/node-runtime/src/runtime/lifecycle.ts
+++ b/packages/node-runtime/src/runtime/lifecycle.ts
@@ -47,6 +47,12 @@ function initializeFingerprint(params: InitializeParams): string {
   });
 }
 
+/**
+ * Stable dedup key for manifest export allowlist entries.
+ * Uses a null separator so moduleId/name pairs cannot collide across boundaries.
+ * Parameter type is narrowed to `{ moduleId; name }` so callers can pass manifest
+ * exports and other export-like shapes without importing the full export entry type.
+ */
 function exportAllowlistKey(exp: { moduleId: string; name: string }): string {
   return `${exp.moduleId}\0${exp.name}`;
 }

--- a/packages/node-runtime/src/runtime/lifecycle.ts
+++ b/packages/node-runtime/src/runtime/lifecycle.ts
@@ -47,6 +47,19 @@ function initializeFingerprint(params: InitializeParams): string {
   });
 }
 
+function exportAllowlistKey(exp: { moduleId: string; name: string }): string {
+  return `${exp.moduleId}\0${exp.name}`;
+}
+
+/** True when incoming adds exports not present in the frozen manifest (same boundary). */
+function manifestWidensAllowlist(
+  frozen: ForstNodeManifestV1,
+  incoming: ForstNodeManifestV1
+): boolean {
+  const frozenKeys = new Set(frozen.exports.map(exportAllowlistKey));
+  return incoming.exports.some((exp) => !frozenKeys.has(exportAllowlistKey(exp)));
+}
+
 function applyHostInitSnapshot(
   state: RuntimeState,
   snap: HostInitSnapshot
@@ -136,13 +149,6 @@ export const initializeRuntime = Effect.fn("Runtime.initialize")(
       );
       return result;
     }
-    if (hostInitSnapshot !== null && hostInitSnapshot.fingerprint !== fingerprint) {
-      return yield* Effect.fail(
-        Errors.forbidden("initialize cannot widen export allowlist", {
-          boundaryRoot: params.boundaryRoot,
-        })
-      );
-    }
 
     const manifest = yield* Effect.try({
       try: () => validateManifest(params.manifest),
@@ -154,6 +160,18 @@ export const initializeRuntime = Effect.fn("Runtime.initialize")(
         Errors.invalidParams("manifest.boundaryRoot must match boundaryRoot", {
           boundaryRoot: params.boundaryRoot,
           manifestBoundaryRoot: manifest.boundaryRoot,
+        })
+      );
+    }
+
+    if (
+      hostInitSnapshot !== null &&
+      hostInitSnapshot.manifest.boundaryRoot === manifest.boundaryRoot &&
+      manifestWidensAllowlist(hostInitSnapshot.manifest, manifest)
+    ) {
+      return yield* Effect.fail(
+        Errors.forbidden("initialize cannot widen export allowlist", {
+          boundaryRoot: params.boundaryRoot,
         })
       );
     }

--- a/packages/node-runtime/src/runtime/lifecycle.ts
+++ b/packages/node-runtime/src/runtime/lifecycle.ts
@@ -136,6 +136,13 @@ export const initializeRuntime = Effect.fn("Runtime.initialize")(
       );
       return result;
     }
+    if (hostInitSnapshot !== null && hostInitSnapshot.fingerprint !== fingerprint) {
+      return yield* Effect.fail(
+        Errors.forbidden("initialize cannot widen export allowlist", {
+          boundaryRoot: params.boundaryRoot,
+        })
+      );
+    }
 
     const manifest = yield* Effect.try({
       try: () => validateManifest(params.manifest),

--- a/packages/node-runtime/test/policy/paths.test.ts
+++ b/packages/node-runtime/test/policy/paths.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   matchesExcludePatterns,
   matchesGlobPattern,
+  resolveModulePath,
   setFilesExcludePatterns,
   validateModuleIdSyntax,
 } from "../../src/policy/paths.js";
@@ -30,5 +35,45 @@ describe("paths exclude patterns", () => {
 
   test("matchesExcludePatterns returns false when patterns empty", () => {
     expect(matchesExcludePatterns("legacy/payment.ts", [])).toBe(false);
+  });
+});
+
+describe("resolveModulePath", () => {
+  test("accepts fixture file under boundaryRoot", async () => {
+    const testDir = path.dirname(fileURLToPath(import.meta.url));
+    const boundaryRoot = path.resolve(testDir, "..");
+    const abs = await resolveModulePath(boundaryRoot, "fixtures/sync-add.ts");
+    expect(abs.endsWith("fixtures/sync-add.ts")).toBe(true);
+  });
+
+  test("rejects missing file", async () => {
+    const boundaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "forst-path-"));
+    await expect(
+      resolveModulePath(boundaryRoot, "legacy/missing.ts")
+    ).rejects.toThrow(/does not resolve/);
+  });
+
+  test("rejects directory target", async () => {
+    const boundaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "forst-path-"));
+    await fs.mkdir(path.join(boundaryRoot, "legacy"), { recursive: true });
+    await expect(
+      resolveModulePath(boundaryRoot, "legacy")
+    ).rejects.toThrow();
+  });
+
+  test("rejects symlink escape outside boundaryRoot", async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "forst-out-"));
+    const outsideFile = path.join(outside, "escape.ts");
+    await fs.writeFile(outsideFile, "export const x = 1;\n");
+
+    const boundaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "forst-bound-"));
+    const linkDir = path.join(boundaryRoot, "legacy");
+    await fs.mkdir(linkDir, { recursive: true });
+    const linkPath = path.join(linkDir, "escape.ts");
+    await fs.symlink(outsideFile, linkPath);
+
+    await expect(
+      resolveModulePath(boundaryRoot, "legacy/escape.ts")
+    ).rejects.toThrow(/escapes boundaryRoot/);
   });
 });

--- a/packages/node-runtime/test/policy/paths.test.ts
+++ b/packages/node-runtime/test/policy/paths.test.ts
@@ -48,32 +48,45 @@ describe("resolveModulePath", () => {
 
   test("rejects missing file", async () => {
     const boundaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "forst-path-"));
-    await expect(
-      resolveModulePath(boundaryRoot, "legacy/missing.ts")
-    ).rejects.toThrow(/does not resolve/);
+    try {
+      expect(
+        resolveModulePath(boundaryRoot, "legacy/missing.ts")
+      ).rejects.toThrow(/does not resolve/);
+    } finally {
+      await fs.rm(boundaryRoot, { recursive: true, force: true });
+    }
   });
 
   test("rejects directory target", async () => {
     const boundaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "forst-path-"));
-    await fs.mkdir(path.join(boundaryRoot, "legacy"), { recursive: true });
-    await expect(
-      resolveModulePath(boundaryRoot, "legacy")
-    ).rejects.toThrow();
+    try {
+      await fs.mkdir(path.join(boundaryRoot, "legacy.ts"), { recursive: true });
+      expect(
+        resolveModulePath(boundaryRoot, "legacy.ts")
+      ).rejects.toThrow(/must refer to a regular file/);
+    } finally {
+      await fs.rm(boundaryRoot, { recursive: true, force: true });
+    }
   });
 
   test("rejects symlink escape outside boundaryRoot", async () => {
     const outside = await fs.mkdtemp(path.join(os.tmpdir(), "forst-out-"));
-    const outsideFile = path.join(outside, "escape.ts");
-    await fs.writeFile(outsideFile, "export const x = 1;\n");
-
     const boundaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "forst-bound-"));
-    const linkDir = path.join(boundaryRoot, "legacy");
-    await fs.mkdir(linkDir, { recursive: true });
-    const linkPath = path.join(linkDir, "escape.ts");
-    await fs.symlink(outsideFile, linkPath);
+    try {
+      const outsideFile = path.join(outside, "escape.ts");
+      await fs.writeFile(outsideFile, "export const x = 1;\n");
 
-    await expect(
-      resolveModulePath(boundaryRoot, "legacy/escape.ts")
-    ).rejects.toThrow(/escapes boundaryRoot/);
+      const linkDir = path.join(boundaryRoot, "legacy");
+      await fs.mkdir(linkDir, { recursive: true });
+      const linkPath = path.join(linkDir, "escape.ts");
+      await fs.symlink(outsideFile, linkPath);
+
+      expect(
+        resolveModulePath(boundaryRoot, "legacy/escape.ts")
+      ).rejects.toThrow(/escapes boundaryRoot/);
+    } finally {
+      await fs.rm(boundaryRoot, { recursive: true, force: true });
+      await fs.rm(outside, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/node-runtime/test/preload.ts
+++ b/packages/node-runtime/test/preload.ts
@@ -1,0 +1,6 @@
+import { beforeEach } from "bun:test";
+import { resetHostInitCacheForTest } from "../src/runtime/lifecycle.js";
+
+beforeEach(() => {
+  resetHostInitCacheForTest();
+});

--- a/packages/node-runtime/test/runtime/lifecycle.test.ts
+++ b/packages/node-runtime/test/runtime/lifecycle.test.ts
@@ -58,4 +58,43 @@ describe("initializeRuntime host cache", () => {
     expect(second.state.initialized).toBe(true);
     expect(second.state.index).toBe(first.state.index);
   });
+
+  test("rejects initialize that widens export allowlist", async () => {
+    resetHostInitCacheForTest();
+    const params = initializeParams(fixtureRoot);
+
+    const first = createDispatcher();
+    await runTestEffect(first.dispatch({
+      jsonrpc: "2.0",
+      id: 1,
+      method: METHOD_INITIALIZE,
+      params,
+    }));
+
+    const widened = {
+      ...params,
+      manifest: {
+        ...params.manifest,
+        exports: [
+          ...params.manifest.exports,
+          {
+            moduleId: "fixtures/async-payment.ts",
+            name: "pay",
+            kind: "function" as const,
+          },
+        ],
+      },
+    };
+
+    const second = createDispatcher();
+    const init2 = await runTestEffect(second.dispatch({
+      jsonrpc: "2.0",
+      id: 2,
+      method: METHOD_INITIALIZE,
+      params: widened,
+    }));
+    expect(init2).toMatchObject({
+      error: { code: expect.any(Number), message: expect.stringContaining("allowlist") },
+    });
+  });
 });

--- a/packages/node-runtime/test/runtime/lifecycle.test.ts
+++ b/packages/node-runtime/test/runtime/lifecycle.test.ts
@@ -97,4 +97,32 @@ describe("initializeRuntime host cache", () => {
       error: { code: expect.any(Number), message: expect.stringContaining("allowlist") },
     });
   });
+
+  test("allows initialize with different fingerprint when allowlist does not widen", async () => {
+    resetHostInitCacheForTest();
+    const params = initializeParams(fixtureRoot);
+
+    const first = createDispatcher();
+    await runTestEffect(first.dispatch({
+      jsonrpc: "2.0",
+      id: 1,
+      method: METHOD_INITIALIZE,
+      params,
+    }));
+
+    const narrowedFilesExclude = {
+      ...params,
+      filesExclude: ["**/secret/**"],
+    };
+
+    const second = createDispatcher();
+    const init2 = await runTestEffect(second.dispatch({
+      jsonrpc: "2.0",
+      id: 2,
+      method: METHOD_INITIALIZE,
+      params: narrowedFilesExclude,
+    }));
+    expect(init2).toMatchObject({ result: { ok: true } });
+    expect(second.state.initialized).toBe(true);
+  });
 });

--- a/packages/sidecar/src/client.test.ts
+++ b/packages/sidecar/src/client.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   DevServerHttpFailure,
   DevServerInvokeRejected,
+  DevServerRequestRetriesExhausted,
 } from "./errors";
 import type { FunctionInfo } from "./types";
 
@@ -356,5 +357,81 @@ describe("ForstSidecarClient", () => {
     expect(out.result).toBe(99);
     expect(invokeCalls).toBe(2);
     expect(healthCalls).toBeGreaterThanOrEqual(3);
+  });
+
+  it("makeRequest_exhaustsRetries_throwsDevServerRequestRetriesExhausted", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+
+    const client = new ForstSidecarClient({
+      baseUrl: "http://127.0.0.1:6320",
+      retries: 2,
+      reloadAware: false,
+    });
+    try {
+      await client.invokeFunction("demo", "Echo", []);
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(DevServerRequestRetriesExhausted);
+    }
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("makeRequest_timeout_abortsBeforeSuccess", async () => {
+    global.fetch = jest.fn((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal) {
+          signal.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }
+      });
+    }) as unknown as typeof fetch;
+
+    const client = new ForstSidecarClient({
+      baseUrl: "http://127.0.0.1:6320",
+      retries: 0,
+      reloadAware: false,
+      timeout: 50,
+    });
+    const start = Date.now();
+    try {
+      await client.discoverFunctions();
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+    }
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  it("nonReloadAware_doesNotParkOnHardHttpFailure", async () => {
+    let invokeCalls = 0;
+    global.fetch = jest.fn((url: string | URL | Request) => {
+      const path = String(url);
+      if (path.endsWith("/invoke")) {
+        invokeCalls += 1;
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          headers: new Headers({ "content-type": "application/json" }),
+          text: async () => JSON.stringify({ success: false, error: "boom" }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected url: ${path}`));
+    }) as unknown as typeof fetch;
+
+    const client = new ForstSidecarClient({
+      baseUrl: "http://127.0.0.1:6320",
+      retries: 0,
+      reloadAware: false,
+    });
+    try {
+      await client.invokeFunction("demo", "Echo", []);
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeInstanceOf(DevServerHttpFailure);
+    }
+    expect(invokeCalls).toBe(1);
   });
 });

--- a/packages/sidecar/src/client.test.ts
+++ b/packages/sidecar/src/client.test.ts
@@ -367,12 +367,9 @@ describe("ForstSidecarClient", () => {
       retries: 2,
       reloadAware: false,
     });
-    try {
-      await client.invokeFunction("demo", "Echo", []);
-      expect(true).toBe(false);
-    } catch (e) {
-      expect(e).toBeInstanceOf(DevServerRequestRetriesExhausted);
-    }
+    await expect(client.invokeFunction("demo", "Echo", [])).rejects.toThrow(
+      DevServerRequestRetriesExhausted
+    );
     expect(global.fetch).toHaveBeenCalledTimes(3);
   });
 
@@ -395,12 +392,7 @@ describe("ForstSidecarClient", () => {
       timeout: 50,
     });
     const start = Date.now();
-    try {
-      await client.discoverFunctions();
-      expect(true).toBe(false);
-    } catch (e) {
-      expect(e).toBeInstanceOf(Error);
-    }
+    await expect(client.invokeFunction("demo", "Echo", [])).rejects.toThrow();
     expect(Date.now() - start).toBeLessThan(2000);
   });
 
@@ -426,12 +418,9 @@ describe("ForstSidecarClient", () => {
       retries: 0,
       reloadAware: false,
     });
-    try {
-      await client.invokeFunction("demo", "Echo", []);
-      expect(true).toBe(false);
-    } catch (e) {
-      expect(e).toBeInstanceOf(DevServerHttpFailure);
-    }
+    await expect(client.invokeFunction("demo", "Echo", [])).rejects.toThrow(
+      DevServerHttpFailure
+    );
     expect(invokeCalls).toBe(1);
   });
 });

--- a/packages/sidecar/src/reload-transport.test.ts
+++ b/packages/sidecar/src/reload-transport.test.ts
@@ -101,4 +101,30 @@ describe("createReloadAwareTransport", () => {
     expect(response.status).toBe(200);
     expect(invokeCalls).toBe(3);
   });
+
+  it("nonReload503ErrorDoesNotPark", async () => {
+    let invokeCalls = 0;
+
+    const inner: InvokeTransport = {
+      request(endpoint) {
+        invokeCalls += 1;
+        if (endpoint === "/invoke") {
+          return Effect.succeed(
+            new Response(JSON.stringify({ success: false, error: "boom" }), {
+              status: 500,
+              headers: { "Content-Type": "application/json" },
+            })
+          );
+        }
+        return Effect.fail(new Error(`unexpected endpoint: ${endpoint}`));
+      },
+    };
+
+    const transport = createReloadAwareTransport(inner);
+    const response = await Effect.runPromise(
+      transport.request("/invoke", { method: "POST", body: "{}" })
+    );
+    expect(response.status).toBe(500);
+    expect(invokeCalls).toBe(1);
+  });
 });

--- a/packages/sidecar/src/reload-transport.test.ts
+++ b/packages/sidecar/src/reload-transport.test.ts
@@ -102,7 +102,7 @@ describe("createReloadAwareTransport", () => {
     expect(invokeCalls).toBe(3);
   });
 
-  it("nonReload503ErrorDoesNotPark", async () => {
+  it("nonReload500ErrorDoesNotPark", async () => {
     let invokeCalls = 0;
 
     const inner: InvokeTransport = {

--- a/scripts/kill-forst-tcp-listeners.sh
+++ b/scripts/kill-forst-tcp-listeners.sh
@@ -1,20 +1,43 @@
 #!/usr/bin/env bash
-# kill-forst-tcp-listeners.sh <port> [signal]
-# Kill only processes listening on TCP <port> that look like Forst (CLI, dev/run, or generated invoke).
+# kill-forst-tcp-listeners.sh <port> [--force] [signal]
+# Kill processes listening on TCP <port> that look like Forst (CLI, dev/run, or generated invoke).
+# With --force (or FORST_KILL_ALL_PORT_LISTENERS=1), SIGKILL any remaining listener on the port.
 set -euo pipefail
 
-PORT=${1:?usage: kill-forst-tcp-listeners.sh PORT [SIGNAL]}
-SIGNAL=${2:-9}
+PORT=${1:?usage: kill-forst-tcp-listeners.sh PORT [--force] [SIGNAL]}
+shift
+
+FORCE=false
+SIGNAL=9
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=true; shift ;;
+    *)
+      SIGNAL=$1
+      shift
+      ;;
+  esac
+done
+if [[ "${FORST_KILL_ALL_PORT_LISTENERS:-}" == "1" ]]; then
+  FORCE=true
+fi
 
 is_forst_listener_cmd() {
   local cmd="$1"
   [[ -z "$cmd" ]] && return 1
   echo "$cmd" | grep -Eq \
-    '(/forst([[:space:]]|$)|(^|[[:space:]])forst[[:space:]]+(dev|run|lsp|test|build|generate))|\.forst/run/|forst_invoke_server\.gen\.go)'
+    '(/forst([[:space:]]|$)|(^|[[:space:]])forst[[:space:]]+(dev|run|lsp|test|build|generate))|\.forst/run/|forst_invoke_server\.gen\.go|(^|[[:space:]/])forst\.run([[:space:]]|$)'
 }
 
 listener_pids() {
   lsof -ti "tcp:${PORT}" 2>/dev/null || true
+}
+
+kill_remaining_listeners() {
+  local pid
+  for pid in $(listener_pids); do
+    kill "-${SIGNAL}" "$pid" 2>/dev/null || true
+  done
 }
 
 for pid in $(listener_pids); do
@@ -23,3 +46,7 @@ for pid in $(listener_pids); do
     kill "-${SIGNAL}" "$pid" 2>/dev/null || true
   fi
 done
+
+if [[ "$FORCE" == true ]]; then
+  kill_remaining_listeners
+fi

--- a/scripts/kill-forst-tcp-listeners.sh
+++ b/scripts/kill-forst-tcp-listeners.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# kill-forst-tcp-listeners.sh <port> [signal]
+# Kill only processes listening on TCP <port> that look like Forst (CLI, dev/run, or generated invoke).
+set -euo pipefail
+
+PORT=${1:?usage: kill-forst-tcp-listeners.sh PORT [SIGNAL]}
+SIGNAL=${2:-9}
+
+is_forst_listener_cmd() {
+  local cmd="$1"
+  [[ -z "$cmd" ]] && return 1
+  echo "$cmd" | grep -Eq \
+    '(/forst([[:space:]]|$)|(^|[[:space:]])forst[[:space:]]+(dev|run|lsp|test|build|generate))|\.forst/run/|forst_invoke_server\.gen\.go)'
+}
+
+listener_pids() {
+  lsof -ti "tcp:${PORT}" 2>/dev/null || true
+}
+
+for pid in $(listener_pids); do
+  cmd=$(ps -p "$pid" -o args= 2>/dev/null || ps -p "$pid" -o command= 2>/dev/null || true)
+  if is_forst_listener_cmd "$cmd"; then
+    kill "-${SIGNAL}" "$pid" 2>/dev/null || true
+  fi
+done

--- a/scripts/kill-forst-tcp-listeners_test.sh
+++ b/scripts/kill-forst-tcp-listeners_test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Unit tests for kill-forst-tcp-listeners.sh (cmdline matching and --force cleanup).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+is_forst_listener_cmd() {
+  local cmd="$1"
+  [[ -z "$cmd" ]] && return 1
+  echo "$cmd" | grep -Eq \
+    '(/forst([[:space:]]|$)|(^|[[:space:]])forst[[:space:]]+(dev|run|lsp|test|build|generate))|\.forst/run/|forst_invoke_server\.gen\.go|(^|[[:space:]/])forst\.run([[:space:]]|$)'
+}
+
+assert_matches() {
+  local cmd="$1"
+  if ! is_forst_listener_cmd "$cmd"; then
+    echo "expected match: $cmd" >&2
+    exit 1
+  fi
+}
+
+assert_no_match() {
+  local cmd="$1"
+  if is_forst_listener_cmd "$cmd"; then
+    echo "expected no match: $cmd" >&2
+    exit 1
+  fi
+}
+
+assert_matches "/usr/local/bin/forst run -root /tmp/app -- main.ft"
+assert_matches "/tmp/app/.forst/run/forst-4025813837/forst.run"
+assert_matches "forst.run"
+assert_matches "./forst.run"
+assert_matches "/path/forst dev -root /tmp/app -entry main.ft"
+assert_matches "forst_invoke_server.gen.go"
+
+assert_no_match "python3 -m http.server 6321"
+assert_no_match "node server.js"
+assert_no_match "curl http://127.0.0.1:6321/health"
+
+TEST_PORT="$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+
+python3 -m http.server "$TEST_PORT" --bind 127.0.0.1 >/dev/null 2>&1 &
+LISTENER_PID=$!
+cleanup_listener() {
+  kill -KILL "$LISTENER_PID" 2>/dev/null || true
+  wait "$LISTENER_PID" 2>/dev/null || true
+}
+trap cleanup_listener EXIT
+
+sleep 0.2
+if ! kill -0 "$LISTENER_PID" 2>/dev/null; then
+  echo "failed to start test listener on port $TEST_PORT" >&2
+  exit 1
+fi
+
+bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" "$TEST_PORT" --force
+sleep 0.2
+
+if kill -0 "$LISTENER_PID" 2>/dev/null; then
+  echo "--force did not kill remaining listener pid=$LISTENER_PID on port $TEST_PORT" >&2
+  exit 1
+fi
+
+trap - EXIT
+echo "kill-forst-tcp-listeners tests ok"

--- a/scripts/multipackage-dev-reload-e2e.sh
+++ b/scripts/multipackage-dev-reload-e2e.sh
@@ -13,6 +13,7 @@ RELOAD_MARKER="$FT_ROOT/.forst/reloading"
 
 FORST_PID=""
 CLEANED_UP=false
+MAIN_FT_BACKUP=""
 
 free_port() {
   bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" 6321
@@ -31,6 +32,10 @@ cleanup() {
     kill -KILL "$FORST_PID" 2>/dev/null || true
     wait "$FORST_PID" 2>/dev/null || true
   fi
+  if [[ -n "$MAIN_FT_BACKUP" && -f "$MAIN_FT_BACKUP" ]]; then
+    cp "$MAIN_FT_BACKUP" "$FT_ROOT/main.ft"
+    rm -f "$MAIN_FT_BACKUP"
+  fi
   free_port
   exit "$code"
 }
@@ -47,6 +52,8 @@ fi
 
 free_port
 rm -rf "$FT_ROOT/.forst"
+MAIN_FT_BACKUP="$(mktemp)"
+cp "$FT_ROOT/main.ft" "$MAIN_FT_BACKUP"
 
 export FORST_REPO_ROOT="$REPO"
 export FORST_BOUNDARY_ROOT="$FT_ROOT"
@@ -58,6 +65,7 @@ export FORST_BOUNDARY_ROOT="$FT_ROOT"
 FORST_PID=$!
 
 bash "$SCRIPT_DIR/wait-for-url.sh" http://127.0.0.1:6321/health invoke 60
+bash "$SCRIPT_DIR/wait-for-file.sh" "$HOST_READY" node.sock.ready 60
 
 read_host_pid() {
   python3 - <<'PY' "$HOST_READY"
@@ -77,10 +85,10 @@ if ! kill -0 "$pid0" 2>/dev/null; then
   exit 1
 fi
 
-touch "$FT_ROOT/bcrypt.ft"
+printf '\n// reload-e2e-trigger\n' >> "$FT_ROOT/main.ft"
 
 gen=0
-for _ in $(seq 1 60); do
+for _ in $(seq 1 90); do
   if [[ -f "$RELOAD_MARKER" ]]; then
     gen="$(python3 - <<'PY' "$RELOAD_MARKER"
 import json, sys
@@ -88,9 +96,13 @@ with open(sys.argv[1]) as f:
     print(json.load(f).get("generation", 0))
 PY
 )"
+    if [[ "${gen:-0}" -ge 2 ]]; then
+      break
+    fi
   fi
-  if curl -sf http://127.0.0.1:6321/health >/dev/null 2>&1; then
-    health_gen="$(curl -sf http://127.0.0.1:6321/health | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("result",{}).get("generation", d.get("generation", 0)))' 2>/dev/null || echo 0)"
+  health_json="$(curl -sf http://127.0.0.1:6321/health 2>/dev/null || true)"
+  if [[ -n "$health_json" ]]; then
+    health_gen="$(printf '%s' "$health_json" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("generation", d.get("result",{}).get("generation", 0)))' 2>/dev/null || echo 0)"
     if [[ "${health_gen:-0}" -ge 2 ]]; then
       gen="$health_gen"
       break
@@ -104,6 +116,18 @@ if [[ "${gen:-0}" -lt 2 ]]; then
   exit 1
 fi
 
+for _ in $(seq 1 30); do
+  if ! curl -sf http://127.0.0.1:6321/health >/dev/null 2>&1; then
+    sleep 1
+    continue
+  fi
+  reloading="$(curl -sf http://127.0.0.1:6321/health | python3 -c 'import json,sys; d=json.load(sys.stdin); print("true" if d.get("reloading") else "false")' 2>/dev/null || echo true)"
+  if [[ "$reloading" == "false" ]]; then
+    break
+  fi
+  sleep 1
+done
+
 pid1="$(read_host_pid)"
 if [[ "$pid1" != "$pid0" ]]; then
   echo "node host pid changed after reload: $pid0 -> $pid1" >&2
@@ -115,3 +139,31 @@ if ! kill -0 "$pid1" 2>/dev/null; then
 fi
 
 echo "multipackage-dev reload e2e ok: host pid=$pid1 generation=$gen"
+
+kill -INT "$FORST_PID" 2>/dev/null || true
+for _ in $(seq 1 30); do
+  if ! kill -0 "$FORST_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+done
+for _ in $(seq 1 24); do
+  if ! kill -0 "$pid1" 2>/dev/null; then
+    break
+  fi
+  sleep 0.5
+done
+if kill -0 "$pid1" 2>/dev/null; then
+  echo "node host pid=$pid1 still alive after forst dev SIGINT" >&2
+  exit 1
+fi
+
+if [[ -n "$MAIN_FT_BACKUP" && -f "$MAIN_FT_BACKUP" ]]; then
+  cp "$MAIN_FT_BACKUP" "$FT_ROOT/main.ft"
+  rm -f "$MAIN_FT_BACKUP"
+fi
+
+CLEANED_UP=true
+trap - EXIT INT TERM
+free_port
+exit 0

--- a/scripts/multipackage-dev-reload-e2e.sh
+++ b/scripts/multipackage-dev-reload-e2e.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# E2E: multipackage-dev forst dev reload keeps the parent-owned Node host pid alive.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${REPO:-$(cd "$SCRIPT_DIR/.." && git rev-parse --show-toplevel 2>/dev/null || echo "$SCRIPT_DIR/..")}"
+REPO="$(cd "$REPO" && pwd)"
+
+FORST_BINARY="${FORST_BINARY:-$REPO/bin/forst}"
+FT_ROOT="$REPO/examples/in/rfc/node-interop/multi-package-dev"
+HOST_READY="$FT_ROOT/.forst/node.sock.ready"
+RELOAD_MARKER="$FT_ROOT/.forst/reloading"
+
+FORST_PID=""
+CLEANED_UP=false
+
+free_port() {
+  bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" 6321
+}
+
+cleanup() {
+  local code="${1:-$?}"
+  if [[ "$CLEANED_UP" == true ]]; then
+    exit "$code"
+  fi
+  CLEANED_UP=true
+  trap - EXIT INT TERM
+  if [[ -n "$FORST_PID" ]]; then
+    kill -INT "$FORST_PID" 2>/dev/null || true
+    sleep 0.5
+    kill -KILL "$FORST_PID" 2>/dev/null || true
+    wait "$FORST_PID" 2>/dev/null || true
+  fi
+  free_port
+  exit "$code"
+}
+trap 'cleanup $?' EXIT
+
+if [[ ! -x "$FORST_BINARY" ]]; then
+  echo "forst binary missing: $FORST_BINARY" >&2
+  exit 1
+fi
+if [[ ! -f "$REPO/packages/node-runtime/dist/host.js" ]]; then
+  echo "node-runtime not built: $REPO/packages/node-runtime/dist/host.js" >&2
+  exit 1
+fi
+
+free_port
+rm -rf "$FT_ROOT/.forst"
+
+export FORST_REPO_ROOT="$REPO"
+export FORST_BOUNDARY_ROOT="$FT_ROOT"
+"$FORST_BINARY" dev \
+  -export-struct-fields \
+  -root "$FT_ROOT" \
+  -entry main.ft \
+  -log-level error &
+FORST_PID=$!
+
+bash "$SCRIPT_DIR/wait-for-url.sh" http://127.0.0.1:6321/health invoke 60
+
+read_host_pid() {
+  python3 - <<'PY' "$HOST_READY"
+import json, sys
+with open(sys.argv[1]) as f:
+    print(json.load(f)["pid"])
+PY
+}
+
+pid0="$(read_host_pid)"
+if [[ -z "$pid0" || "$pid0" -le 0 ]]; then
+  echo "node host pid missing from $HOST_READY" >&2
+  exit 1
+fi
+if ! kill -0 "$pid0" 2>/dev/null; then
+  echo "node host pid=$pid0 not alive" >&2
+  exit 1
+fi
+
+touch "$FT_ROOT/bcrypt.ft"
+
+gen=0
+for _ in $(seq 1 60); do
+  if [[ -f "$RELOAD_MARKER" ]]; then
+    gen="$(python3 - <<'PY' "$RELOAD_MARKER"
+import json, sys
+with open(sys.argv[1]) as f:
+    print(json.load(f).get("generation", 0))
+PY
+)"
+  fi
+  if curl -sf http://127.0.0.1:6321/health >/dev/null 2>&1; then
+    health_gen="$(curl -sf http://127.0.0.1:6321/health | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("result",{}).get("generation", d.get("generation", 0)))' 2>/dev/null || echo 0)"
+    if [[ "${health_gen:-0}" -ge 2 ]]; then
+      gen="$health_gen"
+      break
+    fi
+  fi
+  sleep 1
+done
+
+if [[ "${gen:-0}" -lt 2 ]]; then
+  echo "reload generation did not reach 2 (got ${gen:-0})" >&2
+  exit 1
+fi
+
+pid1="$(read_host_pid)"
+if [[ "$pid1" != "$pid0" ]]; then
+  echo "node host pid changed after reload: $pid0 -> $pid1" >&2
+  exit 1
+fi
+if ! kill -0 "$pid1" 2>/dev/null; then
+  echo "node host pid=$pid1 not alive after reload" >&2
+  exit 1
+fi
+
+echo "multipackage-dev reload e2e ok: host pid=$pid1 generation=$gen"

--- a/scripts/multipackage-dev-reload-e2e.sh
+++ b/scripts/multipackage-dev-reload-e2e.sh
@@ -15,8 +15,25 @@ FORST_PID=""
 CLEANED_UP=false
 MAIN_FT_BACKUP=""
 
+reap_go_child() {
+  local pid_file="$FT_ROOT/.forst/go-child.pid"
+  if [[ ! -f "$pid_file" ]]; then
+    return 0
+  fi
+  local child_pid
+  child_pid="$(tr -d '[:space:]' <"$pid_file" 2>/dev/null || true)"
+  if [[ -n "$child_pid" ]] && kill -0 "$child_pid" 2>/dev/null; then
+    kill -TERM "$child_pid" 2>/dev/null || true
+    sleep 0.3
+    kill -KILL "$child_pid" 2>/dev/null || true
+    wait "$child_pid" 2>/dev/null || true
+  fi
+  rm -f "$pid_file"
+}
+
 free_port() {
-  bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" 6321
+  reap_go_child
+  bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" 6321 --force
 }
 
 cleanup() {
@@ -157,6 +174,8 @@ if kill -0 "$pid1" 2>/dev/null; then
   echo "node host pid=$pid1 still alive after forst dev SIGINT" >&2
   exit 1
 fi
+
+reap_go_child
 
 if [[ -n "$MAIN_FT_BACKUP" && -f "$MAIN_FT_BACKUP" ]]; then
   cp "$MAIN_FT_BACKUP" "$FT_ROOT/main.ft"

--- a/scripts/remix-serve-standalone-e2e.sh
+++ b/scripts/remix-serve-standalone-e2e.sh
@@ -39,7 +39,7 @@ FORST_PID=""
 CLEANED_UP=false
 
 free_ports() {
-  lsof -ti tcp:6321 2>/dev/null | xargs kill -9 2>/dev/null || true
+  bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" 6321
   lsof -ti tcp:6322 2>/dev/null | xargs kill -9 2>/dev/null || true
   lsof -ti tcp:3000 2>/dev/null | xargs kill -9 2>/dev/null || true
 }

--- a/scripts/remix-serve-standalone-e2e.sh
+++ b/scripts/remix-serve-standalone-e2e.sh
@@ -26,6 +26,7 @@ for arg in "$@"; do
       echo "usage: $0 [--dev]"
       echo "  (default) build temp project, smoke-test :6321/:6322, clean up"
       echo "  --dev     same setup, print URLs, block until Ctrl+C, then clean up"
+      echo "  KEEP_TMP=1  preserve temp project dir on exit (CI failures preserve automatically)"
       exit 0
       ;;
   esac
@@ -37,10 +38,14 @@ fi
 TMP=""
 FORST_PID=""
 CLEANED_UP=false
+DIAGNOSTICS_DUMPED=false
+INVOKE_PORT=6321
+REMIX_PORT=6322
+EXPECTED_HOST=127.0.0.1
 
 free_ports() {
-  bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" 6321
-  lsof -ti tcp:6322 2>/dev/null | xargs kill -9 2>/dev/null || true
+  bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" "$INVOKE_PORT"
+  lsof -ti tcp:"$REMIX_PORT" 2>/dev/null | xargs kill -9 2>/dev/null || true
 }
 
 kill_forst_tree() {
@@ -63,6 +68,9 @@ cleanup() {
   trap - EXIT INT TERM
 
   echo "=== cleanup ==="
+  if [[ "$code" != "0" && "$DIAGNOSTICS_DUMPED" != true ]]; then
+    dump_failure_diagnostics "exit $code"
+  fi
   kill_forst_tree
   if [[ -n "$TMP" ]]; then
     pkill -f "forst run.*${TMP}/main/main.ft" 2>/dev/null || true
@@ -70,11 +78,68 @@ cleanup() {
   fi
   free_ports
   if [[ -n "$TMP" && -d "$TMP" ]]; then
-    rm -rf "$TMP"
-    echo "removed temp project: $TMP"
+    if [[ "$code" != "0" && ( "${CI:-}" == "true" || "${KEEP_TMP:-}" == "1" ) ]]; then
+      echo "preserved temp project: $TMP" >&2
+    else
+      rm -rf "$TMP"
+      echo "removed temp project: $TMP"
+    fi
   fi
   echo "=== cleanup done ==="
   exit "$code"
+}
+
+dump_failure_diagnostics() {
+  if [[ "$DIAGNOSTICS_DUMPED" == true ]]; then
+    return 0
+  fi
+  DIAGNOSTICS_DUMPED=true
+  local label="${1:-failure}"
+  echo "=== diagnostics: $label ===" >&2
+  echo "expected: invoke http://${EXPECTED_HOST}:${INVOKE_PORT}/health remix http://${EXPECTED_HOST}:${REMIX_PORT}/" >&2
+  echo "parent env: HOST=${HOST:-<unset>} PORT=${PORT:-<unset>}" >&2
+  echo "FORST_PID=${FORST_PID:-} LOG_FILE=$LOG_FILE TMP=${TMP:-}" >&2
+  if [[ -n "$TMP" ]]; then
+    echo "--- $TMP/.forst/ ---" >&2
+    ls -la "$TMP/.forst/" 2>&1 >&2 || true
+    if [[ -f "$TMP/.forst/node.sock.ready" ]]; then
+      echo "node.sock.ready: present" >&2
+    else
+      echo "node.sock.ready: missing" >&2
+    fi
+  fi
+  echo "--- listening TCP ports ---" >&2
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -iTCP -sTCP:LISTEN -P -n 2>&1 >&2 || true
+  elif command -v ss >/dev/null 2>&1; then
+    ss -ltnp 2>&1 >&2 || true
+  else
+    echo "(no lsof or ss available)" >&2
+  fi
+  if [[ -f "$LOG_FILE" ]]; then
+    echo "--- tail -200 $LOG_FILE ---" >&2
+    tail -200 "$LOG_FILE" >&2 || true
+  else
+    echo "LOG_FILE missing: $LOG_FILE" >&2
+  fi
+  echo "=== end diagnostics ===" >&2
+}
+
+fail_with_diagnostics() {
+  local label="${1:-failure}"
+  dump_failure_diagnostics "$label"
+  exit 1
+}
+
+wait_for_url_or_diagnose() {
+  local url="$1"
+  local label="$2"
+  local timeout="${3:-120}"
+  if bash "$SCRIPT_DIR/wait-for-url.sh" "$url" "$label" "$timeout"; then
+    return 0
+  fi
+  dump_failure_diagnostics "$label"
+  return 1
 }
 trap 'cleanup $?' EXIT
 trap 'cleanup 130' INT
@@ -124,6 +189,7 @@ free_ports
 sleep 0.3
 
 echo "=== forst run ==="
+echo "expected: invoke http://${EXPECTED_HOST}:${INVOKE_PORT}/health remix http://${EXPECTED_HOST}:${REMIX_PORT}/ (HOST=${EXPECTED_HOST} PORT=${REMIX_PORT} for remix-serve)"
 export FORST_BOUNDARY_ROOT="$TMP"
 export FORST_GOMOD_ROOT
 
@@ -141,8 +207,8 @@ else
   FORST_PID=$!
 fi
 
-bash "$SCRIPT_DIR/wait-for-url.sh" http://127.0.0.1:6321/health "invoke :6321" 120
-bash "$SCRIPT_DIR/wait-for-url.sh" http://127.0.0.1:6322/ "remix :6322" 120
+wait_for_url_or_diagnose "http://${EXPECTED_HOST}:${INVOKE_PORT}/health" "invoke :${INVOKE_PORT}" 120
+wait_for_url_or_diagnose "http://${EXPECTED_HOST}:${REMIX_PORT}/" "remix :${REMIX_PORT}" 120
 
 if [[ "$DEV_MODE" == true ]]; then
   echo ""
@@ -158,12 +224,10 @@ if [[ "$DEV_MODE" == true ]]; then
 fi
 
 for line in sync:2 sync:3 async:ok gen:1 events:2; do
-  grep -q "$line" "$LOG_FILE" || {
-    echo "missing stdout line: $line" >&2
-    tail -50 "$LOG_FILE" >&2 || true
-    exit 1
-  }
+  grep -q "$line" "$LOG_FILE" || fail_with_diagnostics "missing stdout line: $line"
 done
+
+grep -q "\[remix-serve\] http://localhost:${REMIX_PORT}" "$LOG_FILE" || fail_with_diagnostics "missing remix-serve listen log for port ${REMIX_PORT}"
 
 curl -sf http://127.0.0.1:6321/health | grep -q 'healthy'
 curl -sf http://127.0.0.1:6322/ | grep -q 'Todos'

--- a/scripts/remix-serve-standalone-e2e.sh
+++ b/scripts/remix-serve-standalone-e2e.sh
@@ -24,7 +24,7 @@ for arg in "$@"; do
     --dev) DEV_MODE=true ;;
     -h|--help)
       echo "usage: $0 [--dev]"
-      echo "  (default) build temp project, smoke-test :6321/:3000, clean up"
+      echo "  (default) build temp project, smoke-test :6321/:6322, clean up"
       echo "  --dev     same setup, print URLs, block until Ctrl+C, then clean up"
       exit 0
       ;;
@@ -41,7 +41,6 @@ CLEANED_UP=false
 free_ports() {
   bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" 6321
   lsof -ti tcp:6322 2>/dev/null | xargs kill -9 2>/dev/null || true
-  lsof -ti tcp:3000 2>/dev/null | xargs kill -9 2>/dev/null || true
 }
 
 kill_forst_tree() {
@@ -143,13 +142,13 @@ else
 fi
 
 bash "$SCRIPT_DIR/wait-for-url.sh" http://127.0.0.1:6321/health "invoke :6321" 120
-bash "$SCRIPT_DIR/wait-for-url.sh" http://127.0.0.1:3000/ "remix :3000" 120
+bash "$SCRIPT_DIR/wait-for-url.sh" http://127.0.0.1:6322/ "remix :6322" 120
 
 if [[ "$DEV_MODE" == true ]]; then
   echo ""
   echo "=== standalone remix-serve dev ==="
   echo "temp project: $TMP"
-  echo "Remix:        http://127.0.0.1:3000/"
+  echo "Remix:        http://127.0.0.1:6322/"
   echo "Invoke:       http://127.0.0.1:6321/health"
   echo "log:         stdout/stderr (this terminal)"
   echo "Press Ctrl+C to stop — temp dir and listeners will be cleaned up."
@@ -167,7 +166,7 @@ for line in sync:2 sync:3 async:ok gen:1 events:2; do
 done
 
 curl -sf http://127.0.0.1:6321/health | grep -q 'healthy'
-curl -sf http://127.0.0.1:3000/ | grep -q 'Todos'
+curl -sf http://127.0.0.1:6322/ | grep -q 'Todos'
 
 echo "=== standalone remix-serve e2e OK ==="
 # EXIT trap runs cleanup before the shell terminates.

--- a/scripts/remix-serve-standalone-e2e.sh
+++ b/scripts/remix-serve-standalone-e2e.sh
@@ -44,8 +44,8 @@ REMIX_PORT=6322
 EXPECTED_HOST=127.0.0.1
 
 free_ports() {
-  bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" "$INVOKE_PORT"
-  lsof -ti tcp:"$REMIX_PORT" 2>/dev/null | xargs kill -9 2>/dev/null || true
+  bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" "$INVOKE_PORT" --force
+  bash "$SCRIPT_DIR/kill-forst-tcp-listeners.sh" "$REMIX_PORT" --force
 }
 
 kill_forst_tree() {
@@ -141,6 +141,24 @@ wait_for_url_or_diagnose() {
   dump_failure_diagnostics "$label"
   return 1
 }
+
+wait_for_file_or_diagnose() {
+  local path="$1"
+  local label="$2"
+  local timeout="${3:-120}"
+  if bash "$SCRIPT_DIR/wait-for-file.sh" "$path" "$label" "$timeout"; then
+    return 0
+  fi
+  dump_failure_diagnostics "$label"
+  return 1
+}
+
+assert_forst_pid_alive() {
+  local label="${1:-forst run}"
+  if [[ -z "$FORST_PID" ]] || ! kill -0 "$FORST_PID" 2>/dev/null; then
+    fail_with_diagnostics "$label exited early (pid=${FORST_PID:-})"
+  fi
+}
 trap 'cleanup $?' EXIT
 trap 'cleanup 130' INT
 trap 'cleanup 143' TERM
@@ -207,7 +225,11 @@ else
   FORST_PID=$!
 fi
 
+assert_forst_pid_alive "forst run before readiness"
+wait_for_file_or_diagnose "$TMP/.forst/node.sock.ready" "node.sock.ready" 120
+assert_forst_pid_alive "forst run after node.sock.ready"
 wait_for_url_or_diagnose "http://${EXPECTED_HOST}:${INVOKE_PORT}/health" "invoke :${INVOKE_PORT}" 120
+assert_forst_pid_alive "forst run after invoke health"
 wait_for_url_or_diagnose "http://${EXPECTED_HOST}:${REMIX_PORT}/" "remix :${REMIX_PORT}" 120
 
 if [[ "$DEV_MODE" == true ]]; then

--- a/scripts/wait-for-file.sh
+++ b/scripts/wait-for-file.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# wait-for-file.sh <path> [label] [timeout_seconds]
+# Exits 0 when path exists, 1 after timeout.
+set -euo pipefail
+
+PATH_TO_WAIT=${1:?usage: wait-for-file.sh PATH [label] [timeout_seconds]}
+LABEL=${2:-$PATH_TO_WAIT}
+TIMEOUT=${3:-120}
+
+for i in $(seq 1 "$TIMEOUT"); do
+  if [[ -f "$PATH_TO_WAIT" ]]; then
+    echo "ready: $LABEL (${i}s)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "timeout: $LABEL not ready after ${TIMEOUT}s" >&2
+exit 1


### PR DESCRIPTION
Wire production-shaped interop into CI: include `nodert` in the coverage profile, run multipackage-dev compile parity, fix embedded-invoke smoke (port 6321, wait-for-url), and add multipackage dev reload e2e asserting the Node host pid survives forst dev reload. Add kill-forst-tcp-listeners so port cleanup only targets Forst listeners, not arbitrary processes on :6321.

feat(executor)!: inject `CommandRunner` and pass context through invoke execution

`ExecuteFunction` and `executeGoCode` now take `context.Context`; subprocess runs use `CommandContext` and preserve cancel/deadline errors. Dev invoke backend and HTTP stubs propagate request context into the executor.

test(node-runtime): freeze initialize allowlist and cover `resolveModulePath` policy

Reject a second initialize that would widen the export allowlist. Add unit tests for symlink escape, missing paths, and directory targets under `boundaryRoot`.

test(sidecar): cover retry exhaustion, timeouts, and non-reload hard failures

Assert `DevServerRequestRetriesExhausted` on invoke retries, abort on short timeouts, and that reload-aware transport does not park on non-503 errors.

BREAKING CHANGE: executor.ExecuteFunction now requires `context.Context` as its first argument; callers and test stubs must pass a context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-aware function execution end-to-end (supports cancellation/timeout propagation).
  * Added a new multi-package-dev E2E scenario to validate reload behavior without changing the parent Node host PID.
* **Bug Fixes**
  * Prevented runtime initialization from widening the host export allowlist.
  * Hardened dev/invoke and Remix E2E flows with health-based readiness checks, safer port cleanup, and updated ports/endpoints.
  * Improved nodert reliability via thread-safe supervisor lifecycle changes and reduced default RPC timeout to 30s.
* **Tests**
  * Expanded CI with nodert coverage and added/updated unit/integration tests across reloads, host caching, secure module path resolution, and command/timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->