### PR TITLE
fix(reload): restore coordinator state on drain cancel

### DIFF
--- a/forst/internal/compileplan/plan.go
+++ b/forst/internal/compileplan/plan.go
@@ -55,5 +55,13 @@ func EmitGo(log *logrus.Logger, plan Plan, mode EmitMode) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if tr.EmbedInvokeServer {
+		tr.AppendInvokeShutdownIfNeeded()
+		var regenErr error
+		goAST, regenErr = tr.Output.GenerateFile()
+		if regenErr != nil {
+			return "", regenErr
+		}
+	}
 	return generateFn(goAST)
 }

--- a/forst/internal/compileplan/plan_test.go
+++ b/forst/internal/compileplan/plan_test.go
@@ -1,0 +1,82 @@
+package compileplan
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/testutil"
+	"forst/internal/typechecker"
+)
+
+func TestEmitGo_nilChecker_returnsEmpty(t *testing.T) {
+	t.Parallel()
+	code, err := EmitGo(nil, Plan{}, EmitExecutor)
+	if err != nil {
+		t.Fatalf("EmitGo: %v", err)
+	}
+	if code != "" {
+		t.Fatalf("code = %q, want empty", code)
+	}
+}
+
+func TestEmitGo_EmitLibShim_emitsPackageTypeDefs(t *testing.T) {
+	t.Parallel()
+	src := `package main
+
+type Widget = { n: Int }
+
+func main() {}
+`
+	tc, nodes := typechecker.MustTypecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
+	code, err := EmitGo(nil, Plan{Checker: tc, Nodes: nodes}, EmitLibShim)
+	if err != nil {
+		t.Fatalf("EmitGo: %v", err)
+	}
+	if !strings.Contains(code, "type Widget") {
+		t.Fatalf("EmitLibShim should emit package type defs:\n%s", code)
+	}
+}
+
+func TestEmitGo_EmitTest_omitsPackageTypeDefs(t *testing.T) {
+	t.Parallel()
+	src := `package main
+
+type Widget = { n: Int }
+
+func main() {}
+`
+	tc, nodes := typechecker.MustTypecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
+	code, err := EmitGo(nil, Plan{Checker: tc, Nodes: nodes}, EmitTest)
+	if err != nil {
+		t.Fatalf("EmitGo: %v", err)
+	}
+	if strings.Contains(code, "type Widget") {
+		t.Fatalf("EmitTest should omit package type defs:\n%s", code)
+	}
+}
+
+func TestEmitGo_EmbedInvoke_onlyWithCompanions(t *testing.T) {
+	t.Parallel()
+	src := `package main
+
+func main() {}
+`
+	tc, nodes := typechecker.MustTypecheck(t, src, testutil.TypecheckOpts{UseModuleRoot: true})
+	plan := Plan{Checker: tc, Nodes: nodes, EmbedInvoke: true}
+
+	executorCode, err := EmitGo(nil, plan, EmitExecutor)
+	if err != nil {
+		t.Fatalf("EmitGo executor: %v", err)
+	}
+	if strings.Contains(executorCode, "ForstInvokeWaitForShutdown") {
+		t.Fatalf("EmitExecutor should not embed invoke shutdown:\n%s", executorCode)
+	}
+
+	companionCode, err := EmitGo(nil, plan, EmitWithCompanions)
+	if err != nil {
+		t.Fatalf("EmitGo companions: %v", err)
+	}
+	if !strings.Contains(companionCode, "ForstInvokeWaitForShutdown") {
+		t.Fatalf("EmitWithCompanions+EmbedInvoke should append shutdown hook:\n%s", companionCode)
+	}
+}

--- a/forst/internal/devcompile/session_test.go
+++ b/forst/internal/devcompile/session_test.go
@@ -116,3 +116,64 @@ func TestModuleFingerprint_changesOnEdit(t *testing.T) {
 		t.Fatal("fingerprint should change when file content changes")
 	}
 }
+
+func TestParsedFilesForModule_skipsEditedFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.ft")
+	if err := os.WriteFile(path, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := NewSession(dir)
+	if _, err := s.ParseFile(nil, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("package main\n// edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := s.ParsedFilesForModule(dir)
+	if ok {
+		t.Fatalf("expected stale cache miss, got %d files", len(got))
+	}
+}
+
+func TestParsedFilesForModuleCheck_parsesAllForstFiles(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.ft")
+	apiPath := filepath.Join(dir, "api.ft")
+	if err := os.WriteFile(mainPath, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(apiPath, []byte("package api\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := NewSession(dir)
+	got, err := s.ParsedFilesForModuleCheck(nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("parsed %d files, want 2: %v", len(got), got)
+	}
+	if _, ok := got[mainPath]; !ok {
+		t.Fatalf("missing main.ft in %v", got)
+	}
+	if _, ok := got[apiPath]; !ok {
+		t.Fatalf("missing api.ft in %v", got)
+	}
+}
+
+func TestNilSession_ParseFile_delegates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.ft")
+	if err := os.WriteFile(path, []byte("package main\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var s *Session
+	nodes, err := s.ParseFile(nil, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) == 0 {
+		t.Fatal("expected parsed nodes from nil session fallback")
+	}
+}

--- a/forst/internal/invokeserver/middleware_test.go
+++ b/forst/internal/invokeserver/middleware_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 type stubInvokeBackend struct {
-	invokeFn func(ctx context.Context, pkg, fn string, args json.RawMessage) (*invokedispatch.InvokeResult, error)
+	invokeFn       func(ctx context.Context, pkg, fn string, args json.RawMessage) (*invokedispatch.InvokeResult, error)
+	invokeStreamFn func(ctx context.Context, pkg, fn string, args json.RawMessage) (<-chan invokedispatch.StreamChunk, error)
 }
 
 func (b *stubInvokeBackend) Functions() map[string]map[string]discovery.FunctionInfo {
@@ -30,7 +31,10 @@ func (b *stubInvokeBackend) Invoke(ctx context.Context, pkg, fn string, args jso
 	return &invokedispatch.InvokeResult{Success: true}, nil
 }
 
-func (b *stubInvokeBackend) InvokeStream(context.Context, string, string, json.RawMessage) (<-chan invokedispatch.StreamChunk, error) {
+func (b *stubInvokeBackend) InvokeStream(ctx context.Context, pkg, fn string, args json.RawMessage) (<-chan invokedispatch.StreamChunk, error) {
+	if b.invokeStreamFn != nil {
+		return b.invokeStreamFn(ctx, pkg, fn, args)
+	}
 	return nil, errors.New("not implemented")
 }
 
@@ -67,5 +71,49 @@ func TestReloadGate_allowsInvokeWhenReady(t *testing.T) {
 	}
 	if !result.Success {
 		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestReloadGate_blocksInvokeStreamWhenNotReady(t *testing.T) {
+	t.Parallel()
+	coord := reload.NewCoordinator()
+	coord.SetState(reload.StateRegenerating, nil)
+
+	backend := WrapBackend(&stubInvokeBackend{}, WithReloadGate(coord))
+	_, err := backend.InvokeStream(context.Background(), "pkg", "Fn", nil)
+	if !errors.Is(err, ErrReloading) {
+		t.Fatalf("InvokeStream() err = %v, want ErrReloading", err)
+	}
+}
+
+func TestReloadGate_propagatesDegradedError(t *testing.T) {
+	t.Parallel()
+	coord := reload.NewCoordinator()
+	degradedErr := errors.New("compile failed")
+	coord.SetState(reload.StateDegraded, degradedErr)
+
+	backend := WrapBackend(&stubInvokeBackend{}, WithReloadGate(coord))
+	_, err := backend.Invoke(context.Background(), "pkg", "Fn", nil)
+	if errors.Is(err, ErrReloading) {
+		t.Fatalf("Invoke() err = %v, want degraded error not ErrReloading", err)
+	}
+	if !errors.Is(err, degradedErr) {
+		t.Fatalf("Invoke() err = %v, want %v", err, degradedErr)
+	}
+}
+
+func TestReloadGate_propagatesDegradedError_onStream(t *testing.T) {
+	t.Parallel()
+	coord := reload.NewCoordinator()
+	degradedErr := errors.New("compile failed")
+	coord.SetState(reload.StateDegraded, degradedErr)
+
+	backend := WrapBackend(&stubInvokeBackend{}, WithReloadGate(coord))
+	_, err := backend.InvokeStream(context.Background(), "pkg", "Fn", nil)
+	if errors.Is(err, ErrReloading) {
+		t.Fatalf("InvokeStream() err = %v, want degraded error not ErrReloading", err)
+	}
+	if !errors.Is(err, degradedErr) {
+		t.Fatalf("InvokeStream() err = %v, want %v", err, degradedErr)
 	}
 }

--- a/forst/internal/project/project_test.go
+++ b/forst/internal/project/project_test.go
@@ -1,0 +1,116 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"forst/internal/modulecheck"
+)
+
+func writeMinimalProject(t *testing.T, dir string, extraFiles map[string]string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module projecttest\n\ngo 1.26.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.ft"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range extraFiles {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestProject_Package_returnsMergedNodes(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalProject(t, dir, map[string]string{
+		"api.ft": "package api\n\nfunc Ping() { return {ok: true} }\n",
+	})
+
+	proj, err := Open(nil, OpenOpts{BoundaryRoot: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit, err := proj.Package("api")
+	if err != nil {
+		t.Fatalf("Package: %v", err)
+	}
+	if unit.Name != "api" {
+		t.Fatalf("name = %q", unit.Name)
+	}
+	if len(unit.Nodes) == 0 {
+		t.Fatal("expected merged nodes")
+	}
+	if len(unit.FilePaths) != 1 {
+		t.Fatalf("file paths = %v", unit.FilePaths)
+	}
+}
+
+func TestProject_Package_unknownName(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalProject(t, dir, nil)
+
+	proj, err := Open(nil, OpenOpts{BoundaryRoot: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = proj.Package("missing")
+	if err == nil || !strings.Contains(err.Error(), `package "missing" not found`) {
+		t.Fatalf("Package unknown: got %v", err)
+	}
+}
+
+func TestFilterPackagesUnderBoundary_excludesOutsideFiles(t *testing.T) {
+	dir := t.TempDir()
+	boundary := filepath.Join(dir, "boundary")
+	if err := os.MkdirAll(boundary, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	insideFile := filepath.Join(boundary, "main.ft")
+	outsideFile := filepath.Join(dir, "outside", "remote.ft")
+	if err := os.MkdirAll(filepath.Dir(outsideFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(insideFile, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outsideFile, []byte("package remote\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	proj := &Project{
+		BoundaryRoot: boundary,
+		Module: &modulecheck.ModuleResult{
+			ForstPkgToFiles: map[string][]string{
+				"main":   {insideFile},
+				"remote": {outsideFile},
+			},
+		},
+	}
+	filtered := proj.FilterPackagesUnderBoundary()
+	if _, ok := filtered["remote"]; ok {
+		t.Fatalf("remote package should be excluded: %v", filtered)
+	}
+	if paths, ok := filtered["main"]; !ok || len(paths) != 1 || paths[0] != insideFile {
+		t.Fatalf("main package should remain: %v", filtered)
+	}
+}
+
+func TestOpen_resolvesDevProfileFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalProject(t, dir, nil)
+	if err := os.WriteFile(filepath.Join(dir, "ftconfig.json"), []byte(`{"dev":{"profile":"runtime"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	proj, err := Open(nil, OpenOpts{BoundaryRoot: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proj.DevProfile() != DevProfileRuntime {
+		t.Fatalf("DevProfile = %q, want runtime", proj.DevProfile())
+	}
+}

--- a/forst/internal/reload/coordinator.go
+++ b/forst/internal/reload/coordinator.go
@@ -51,6 +51,7 @@ func (c *ReloadCoordinator) State() State {
 }
 
 // BeginDrain enters Draining, waits for in-flight work, then moves to Regenerating.
+// On context cancel the prior phase (Ready or Degraded) is restored.
 func (c *ReloadCoordinator) BeginDrain(ctx context.Context) error {
 	c.mu.Lock()
 	if c.state != StateReady && c.state != StateDegraded {
@@ -58,6 +59,7 @@ func (c *ReloadCoordinator) BeginDrain(ctx context.Context) error {
 		c.mu.Unlock()
 		return errors.New("cannot drain: state " + state.String())
 	}
+	prior := c.state
 	c.state = StateDraining
 	c.mu.Unlock()
 
@@ -69,6 +71,10 @@ func (c *ReloadCoordinator) BeginDrain(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
+		c.mu.Lock()
+		c.state = prior
+		c.cond.Broadcast()
+		c.mu.Unlock()
 		return ctx.Err()
 	case <-done:
 	}
@@ -80,24 +86,24 @@ func (c *ReloadCoordinator) BeginDrain(ctx context.Context) error {
 	return nil
 }
 
-// WaitReady blocks until the coordinator is Ready or Degraded, or ctx is canceled.
-// Returns ErrNotReady immediately while Draining or Regenerating.
+// WaitReady is a non-blocking reload gate: returns nil when Ready, the degraded
+// error when Degraded, or ErrNotReady immediately while Draining or Regenerating.
 func (c *ReloadCoordinator) WaitReady(_ context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for {
-		switch c.state {
-		case StateReady:
-			return nil
-		case StateDegraded:
-			if c.degraded != nil {
-				return c.degraded
-			}
-			return nil
-		case StateDraining, StateRegenerating:
-			return ErrNotReady
+	switch c.state {
+	case StateReady:
+		return nil
+	case StateDegraded:
+		if c.degraded != nil {
+			return c.degraded
 		}
+		return nil
+	case StateDraining, StateRegenerating:
+		return ErrNotReady
+	default:
+		return ErrNotReady
 	}
 }
 

--- a/forst/internal/reload/coordinator_test.go
+++ b/forst/internal/reload/coordinator_test.go
@@ -2,9 +2,164 @@ package reload
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestWaitReady_readyAndDegraded(t *testing.T) {
+	t.Parallel()
+	c := NewCoordinator()
+	if err := c.WaitReady(context.Background()); err != nil {
+		t.Fatalf("ready: %v", err)
+	}
+
+	degradedErr := errors.New("compile failed")
+	c.SetState(StateDegraded, degradedErr)
+	if err := c.WaitReady(context.Background()); !errors.Is(err, degradedErr) {
+		t.Fatalf("degraded with err: got %v", err)
+	}
+
+	c.SetState(StateDegraded, nil)
+	if err := c.WaitReady(context.Background()); err != nil {
+		t.Fatalf("degraded without err: %v", err)
+	}
+}
+
+func TestWaitReady_drainingAndRegenerating_returnsErrNotReady(t *testing.T) {
+	t.Parallel()
+	c := NewCoordinator()
+	for _, state := range []State{StateDraining, StateRegenerating} {
+		c.SetState(state, nil)
+		err := c.WaitReady(context.Background())
+		if !errors.Is(err, ErrNotReady) {
+			t.Fatalf("state %v: got %v, want ErrNotReady", state, err)
+		}
+	}
+}
+
+func TestSetState_readyIncrementsGenerationAndClearsDegraded(t *testing.T) {
+	t.Parallel()
+	c := NewCoordinator()
+	if gen := c.Generation(); gen != 0 {
+		t.Fatalf("initial generation = %d, want 0", gen)
+	}
+
+	degradedErr := errors.New("compile failed")
+	c.SetState(StateDegraded, degradedErr)
+	c.SetState(StateReady, nil)
+	if gen := c.Generation(); gen != 1 {
+		t.Fatalf("generation after first ready = %d, want 1", gen)
+	}
+	if err := c.WaitReady(context.Background()); err != nil {
+		t.Fatalf("degraded cleared: %v", err)
+	}
+
+	c.SetState(StateReady, nil)
+	if gen := c.Generation(); gen != 2 {
+		t.Fatalf("generation after second ready = %d, want 2", gen)
+	}
+}
+
+func TestBeginDrain_fromDegraded_entersRegenerating(t *testing.T) {
+	t.Parallel()
+	c := NewCoordinator()
+	c.SetState(StateDegraded, errors.New("last compile failed"))
+	if err := c.BeginDrain(context.Background()); err != nil {
+		t.Fatalf("BeginDrain: %v", err)
+	}
+	if c.State() != StateRegenerating {
+		t.Fatalf("state = %v, want regenerating", c.State())
+	}
+}
+
+func TestBeginDrain_contextCancel_restoresPriorState(t *testing.T) {
+	t.Parallel()
+	t.Run("fromReady", func(t *testing.T) {
+		t.Parallel()
+		c := NewCoordinator()
+		release := make(chan struct{})
+		go c.TrackInFlight(func() { <-release })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := c.BeginDrain(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("BeginDrain: %v", err)
+		}
+		if c.State() != StateReady {
+			t.Fatalf("state = %v, want ready after cancel", c.State())
+		}
+		close(release)
+	})
+
+	t.Run("fromDegraded", func(t *testing.T) {
+		t.Parallel()
+		c := NewCoordinator()
+		degradedErr := errors.New("compile failed")
+		c.SetState(StateDegraded, degradedErr)
+		release := make(chan struct{})
+		go c.TrackInFlight(func() { <-release })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := c.BeginDrain(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("BeginDrain: %v", err)
+		}
+		if c.State() != StateDegraded {
+			t.Fatalf("state = %v, want degraded after cancel", c.State())
+		}
+		if err := c.WaitReady(context.Background()); !errors.Is(err, degradedErr) {
+			t.Fatalf("degraded err: got %v", err)
+		}
+		close(release)
+	})
+}
+
+func TestBeginDrain_rejectsWhileAlreadyDraining(t *testing.T) {
+	t.Parallel()
+	c := NewCoordinator()
+	c.SetState(StateDraining, nil)
+	err := c.BeginDrain(context.Background())
+	if err == nil {
+		t.Fatal("expected error when already draining")
+	}
+	if !strings.Contains(err.Error(), "draining") {
+		t.Fatalf("error = %q, want state draining in message", err.Error())
+	}
+}
+
+func TestBeginDrain_rejectsWhileRegenerating(t *testing.T) {
+	t.Parallel()
+	c := NewCoordinator()
+	c.SetState(StateRegenerating, nil)
+	err := c.BeginDrain(context.Background())
+	if err == nil {
+		t.Fatal("expected error when regenerating")
+	}
+	if !strings.Contains(err.Error(), "regenerating") {
+		t.Fatalf("error = %q, want state regenerating in message", err.Error())
+	}
+}
+
+func TestState_String_coversAllPhases(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		state State
+		want  string
+	}{
+		{StateReady, "ready"},
+		{StateDraining, "draining"},
+		{StateRegenerating, "regenerating"},
+		{StateDegraded, "degraded"},
+		{State(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.state.String(); got != tc.want {
+			t.Fatalf("State(%d).String() = %q, want %q", tc.state, got, tc.want)
+		}
+	}
+}
 
 func TestReloadCoordinator_drainWaitsForInFlight(t *testing.T) {
 	t.Parallel()

--- a/forst/internal/transformer/go/node_bridge_test.go
+++ b/forst/internal/transformer/go/node_bridge_test.go
@@ -230,6 +230,75 @@ func main() {
 	}
 }
 
+func TestCodegen_nodeIteratorFor_bindsIndexAndValue(t *testing.T) {
+	root := t.TempDir()
+	writeNodeBridgeGeneratorFixture(t, root)
+
+	src := `package main
+import node "./legacy/generators"
+
+func main() {
+	seq := generators.syncNumbers(2.0)
+	ensure seq is Ok()
+	for i, n := range seq {
+		println(i)
+		println(n)
+	}
+}
+`
+	tc, nodes := typechecker.MustTypecheck(t, src, testutil.TypecheckOpts{
+		NodeBoundaryRoot: root,
+		ForstFileDir:     root,
+	})
+	tr := New(tc, nil)
+	file, err := tr.TransformForstFileToGo(nodes)
+	if err != nil {
+		t.Fatalf("TransformForstFileToGo: %v", err)
+	}
+	mainCode, _ := formatTransformerGoFiles(t, tr, file)
+	for _, want := range []string{
+		"_nodeIdx",
+		"_nodeStep",
+		"_nodeStep.Value",
+	} {
+		if !strings.Contains(mainCode, want) {
+			t.Fatalf("missing %q in main:\n%s", want, mainCode)
+		}
+	}
+}
+
+func TestCodegen_nodeIteratorFor_emitsErrorKindPanic(t *testing.T) {
+	root := t.TempDir()
+	writeNodeBridgeGeneratorFixture(t, root)
+
+	src := `package main
+import node "./legacy/generators"
+
+func main() {
+	seq := generators.syncNumbers(2.0)
+	ensure seq is Ok()
+	for range seq {
+	}
+}
+`
+	tc, nodes := typechecker.MustTypecheck(t, src, testutil.TypecheckOpts{
+		NodeBoundaryRoot: root,
+		ForstFileDir:     root,
+	})
+	tr := New(tc, nil)
+	file, err := tr.TransformForstFileToGo(nodes)
+	if err != nil {
+		t.Fatalf("TransformForstFileToGo: %v", err)
+	}
+	mainCode, _ := formatTransformerGoFiles(t, tr, file)
+	if !strings.Contains(mainCode, forstNodeGenStepErrorIdent) {
+		t.Fatalf("missing error-kind branch in main:\n%s", mainCode)
+	}
+	if !strings.Contains(mainCode, "panic") {
+		t.Fatalf("missing panic on generator error step in main:\n%s", mainCode)
+	}
+}
+
 func writeNodeBridgeAsyncGenFixture(t *testing.T, root string) {
 	t.Helper()
 	legacyDir := filepath.Join(root, "legacy")

--- a/forst/nodert/call_sync_test.go
+++ b/forst/nodert/call_sync_test.go
@@ -1,0 +1,99 @@
+package nodert
+
+import (
+	"encoding/json"
+	"testing"
+
+	logrus "github.com/sirupsen/logrus"
+)
+
+func setTestSupervisorClient(t *testing.T, client *Client) {
+	t.Helper()
+	resetSupervisorForTest()
+	t.Cleanup(func() {
+		supervisorMu.Lock()
+		supervisorInst = nil
+		supervisorMu.Unlock()
+	})
+	supervisorMu.Lock()
+	supervisorInst = &Supervisor{
+		client: client,
+		log:    logrus.New(),
+	}
+	supervisorMu.Unlock()
+}
+
+func TestCallSync_nullResultReturnsZeroValue(t *testing.T) {
+	t.Parallel()
+	client, server := pairedClientServer(t, func(req Request) Response {
+		switch req.Method {
+		case MethodInitialize:
+			return Response{
+				JSONRPC: JSONRPCVersion,
+				ID:      req.ID,
+				Result:  json.RawMessage(`{"ok":true,"protocol":"` + WireProtocolProtoV1 + `"}`),
+			}
+		case MethodCall:
+			return Response{JSONRPC: JSONRPCVersion, ID: req.ID, Result: json.RawMessage(`null`)}
+		default:
+			return okResponse(req)
+		}
+	})
+	defer func() { _ = server.Close() }()
+	if err := client.Initialize(sampleManifest(), nil); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	setTestSupervisorClient(t, client)
+
+	got, err := CallSync[int]("legacy/payment.ts", "create")
+	if err != nil {
+		t.Fatalf("CallSync: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("got = %d, want zero value", got)
+	}
+}
+
+func TestCallSync_emptyResultReturnsZeroValue(t *testing.T) {
+	t.Parallel()
+	client, server := pairedClientServer(t, func(req Request) Response {
+		switch req.Method {
+		case MethodInitialize:
+			return Response{
+				JSONRPC: JSONRPCVersion,
+				ID:      req.ID,
+				Result:  json.RawMessage(`{"ok":true,"protocol":"` + WireProtocolProtoV1 + `"}`),
+			}
+		case MethodCall:
+			return Response{JSONRPC: JSONRPCVersion, ID: req.ID, Result: json.RawMessage(`""`)}
+		default:
+			return okResponse(req)
+		}
+	})
+	defer func() { _ = server.Close() }()
+	if err := client.Initialize(sampleManifest(), nil); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	setTestSupervisorClient(t, client)
+
+	got, err := CallSync[string]("legacy/payment.ts", "create")
+	if err != nil {
+		t.Fatalf("CallSync: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("got = %q, want empty string", got)
+	}
+}
+
+func TestMustCallSync_panicsOnError(t *testing.T) {
+	t.Parallel()
+	resetSupervisorForTest()
+	t.Cleanup(resetSupervisorForTest)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	MustCallSync[int]("legacy/payment.ts", "create")
+}

--- a/forst/nodert/codec_test.go
+++ b/forst/nodert/codec_test.go
@@ -1,0 +1,58 @@
+package nodert
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalNodeCallArgsJSON_encodesPositionalArray(t *testing.T) {
+	t.Parallel()
+	raw, err := MarshalNodeCallArgsJSON(42, "usd")
+	if err != nil {
+		t.Fatalf("MarshalNodeCallArgsJSON: %v", err)
+	}
+	var got []any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0] != float64(42) {
+		t.Fatalf("args[0] = %v", got[0])
+	}
+	if got[1] != "usd" {
+		t.Fatalf("args[1] = %v", got[1])
+	}
+}
+
+func TestCallSyncArgs_nullResultReturnsZeroValue(t *testing.T) {
+	t.Parallel()
+	client, server := pairedClientServer(t, func(req Request) Response {
+		switch req.Method {
+		case MethodInitialize:
+			return Response{
+				JSONRPC: JSONRPCVersion,
+				ID:      req.ID,
+				Result:  json.RawMessage(`{"ok":true,"protocol":"` + WireProtocolProtoV1 + `"}`),
+			}
+		case MethodCall:
+			return Response{JSONRPC: JSONRPCVersion, ID: req.ID, Result: json.RawMessage(`null`)}
+		default:
+			return okResponse(req)
+		}
+	})
+	defer func() { _ = server.Close() }()
+	if err := client.Initialize(sampleManifest(), nil); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	setTestSupervisorClient(t, client)
+
+	got, err := CallSyncArgs[string]("legacy/payment.ts", "create", json.RawMessage(`[1]`))
+	if err != nil {
+		t.Fatalf("CallSyncArgs: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("got = %q, want zero value", got)
+	}
+}

--- a/forst/nodert/errors_test.go
+++ b/forst/nodert/errors_test.go
@@ -1,0 +1,54 @@
+package nodert
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestRPCErrorFromWire_buildsNodeCallError(t *testing.T) {
+	t.Parallel()
+	data, err := json.Marshal(map[string]string{
+		"name":       "TypeError",
+		"stack":      "at create (payment.ts:1:1)",
+		"moduleId":   "legacy/payment.ts",
+		"exportName": "create",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wireErr := rpcErrorFromWire(ErrCodeServerError, "boom", data)
+	var nodeErr *NodeCallError
+	if !AsNodeCallError(wireErr, &nodeErr) {
+		t.Fatalf("expected NodeCallError, got %T: %v", wireErr, wireErr)
+	}
+	if nodeErr.Message != "boom" {
+		t.Fatalf("message = %q", nodeErr.Message)
+	}
+	if nodeErr.Name != "TypeError" {
+		t.Fatalf("name = %q", nodeErr.Name)
+	}
+	if nodeErr.Stack == "" || nodeErr.ModuleID != "legacy/payment.ts" || nodeErr.ExportName != "create" {
+		t.Fatalf("nodeErr = %+v", nodeErr)
+	}
+}
+
+func TestIsForbidden_matchesBareRPCError(t *testing.T) {
+	t.Parallel()
+	err := &RPCError{Code: ErrCodeForbidden, Message: "forbidden"}
+	if !IsForbidden(err) {
+		t.Fatal("expected IsForbidden for bare RPCError")
+	}
+	if IsForbidden(errors.New("other")) {
+		t.Fatal("unexpected IsForbidden match")
+	}
+}
+
+func TestIsMethodNotFound_matchesBareRPCError(t *testing.T) {
+	t.Parallel()
+	err := &RPCError{Code: ErrCodeMethodNotFound, Message: "method not found"}
+	if !IsMethodNotFound(err) {
+		t.Fatal("expected IsMethodNotFound for bare RPCError")
+	}
+}

--- a/forst/nodert/manifest_test.go
+++ b/forst/nodert/manifest_test.go
@@ -1,0 +1,116 @@
+package nodert
+
+import (
+	"strings"
+	"testing"
+)
+
+func validEmbeddedManifest() Manifest {
+	return Manifest{
+		Version: ManifestVersion,
+		Exports: []ExportEntry{
+			{ModuleID: "legacy/payment.ts", Name: "create", Kind: ExportKindFunction},
+		},
+	}
+}
+
+func TestValidateEmbedded_rejectsEmptyExportsAndUnknownKind(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		m    Manifest
+		want string
+	}{
+		{
+			name: "unsupportedVersion",
+			m: Manifest{
+				Version: 99,
+				Exports: validEmbeddedManifest().Exports,
+			},
+			want: "unsupported manifest version",
+		},
+		{
+			name: "emptyExports",
+			m: Manifest{
+				Version: ManifestVersion,
+				Exports: nil,
+			},
+			want: "exports must not be empty",
+		},
+		{
+			name: "unknownKind",
+			m: Manifest{
+				Version: ManifestVersion,
+				Exports: []ExportEntry{
+					{ModuleID: "legacy/payment.ts", Name: "create", Kind: ExportKind("class")},
+				},
+			},
+			want: "unknown export kind",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.m.ValidateEmbedded()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestValidate_requiresBoundaryRoot(t *testing.T) {
+	t.Parallel()
+	m := validEmbeddedManifest()
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected error when boundaryRoot missing")
+	}
+	if !strings.Contains(err.Error(), "boundaryRoot") {
+		t.Fatalf("error = %q", err.Error())
+	}
+
+	m.BoundaryRoot = "/tmp/project"
+	if err := m.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestAllowCall_rejectsKindMismatch(t *testing.T) {
+	t.Parallel()
+	manifest := Manifest{
+		Version:      ManifestVersion,
+		BoundaryRoot: "/tmp/project",
+		Exports: []ExportEntry{
+			{ModuleID: "legacy/payment.ts", Name: "create", Kind: ExportKindAsyncFunction},
+		},
+	}
+	err := manifest.AllowCall("legacy/payment.ts", "create", ExportKindFunction)
+	if err == nil {
+		t.Fatal("expected kind mismatch error")
+	}
+	if !strings.Contains(err.Error(), "expected") || !strings.Contains(err.Error(), string(ExportKindFunction)) {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestAllowCall_rejectsKindMismatch_syncExportAsyncCall(t *testing.T) {
+	t.Parallel()
+	manifest := Manifest{
+		Version:      ManifestVersion,
+		BoundaryRoot: "/tmp/project",
+		Exports: []ExportEntry{
+			{ModuleID: "legacy/payment.ts", Name: "create", Kind: ExportKindFunction},
+		},
+	}
+	err := manifest.AllowCall("legacy/payment.ts", "create", ExportKindAsyncFunction)
+	if err == nil {
+		t.Fatal("expected kind mismatch error")
+	}
+	if !strings.Contains(err.Error(), string(ExportKindAsyncFunction)) {
+		t.Fatalf("error = %q", err.Error())
+	}
+}


### PR DESCRIPTION
When `BeginDrain` is canceled, restore the prior `Ready` or `Degraded` phase instead of leaving the coordinator stuck in `Draining`. Document `WaitReady` as a non-blocking gate that returns `ErrNotReady` while draining or regenerating.

fix(compileplan): append invoke shutdown in companions emit mode

`EmitGo` with `EmbedInvoke` and `EmitWithCompanions` regenerates main output after `AppendInvokeShutdownIfNeeded` so embedded invoke binaries include `ForstInvokeWaitForShutdown`.

test: cover reload, compileplan, nodert, project, and devcompile gaps

Add unit tests for coordinator state transitions, reload gate middleware (including stream and degraded paths), `EmitGo` emit modes, `nodert` manifest validation and `CallSync` edge cases, project Package and boundary filtering, devcompile parse cache helpers, and node iterator for-range codegen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved reload handling so canceled reloads restore the previous operational state.
  - Added clearer readiness behavior and error reporting while regeneration is in progress or degraded.

- **Code Generation**
  - Improved generated integrations that embed invocation services, including graceful shutdown coordination.
  - Enhanced support for asynchronous iteration and generator error handling.

- **Validation**
  - Strengthened manifest, package, and invocation validation to provide safer runtime behavior.

- **Tests**
  - Expanded coverage across reloads, streaming calls, project configuration, generated code, and runtime error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->