### PR TITLE
feat(fmt): cap shapes at two fields per line

### DIFF
--- a/forst/internal/printer/printer.go
+++ b/forst/internal/printer/printer.go
@@ -729,15 +729,7 @@ func (p *printer) printWith(w ast.WithNode) (string, error) {
 	var b strings.Builder
 	b.WriteString("with ")
 	if shape, ok := w.Wiring.(ast.ShapeNode); ok {
-		oneLine, err := p.printShapeOneLine(shape)
-		if err != nil {
-			return "", err
-		}
-		compactHead := "with " + oneLine + " {"
-		if len(compactHead) <= p.effectiveTypeDefLineWidth() {
-			b.WriteString(oneLine)
-			b.WriteString(" {\n")
-		} else {
+		if p.shapeShouldUseMultiline(shape) {
 			fieldIndent := p.depth + 1
 			wiring, err := p.printShapeMultiline(shape, fieldIndent)
 			if err != nil {
@@ -745,6 +737,24 @@ func (p *printer) printWith(w ast.WithNode) (string, error) {
 			}
 			b.WriteString(wiring)
 			b.WriteString(" {\n")
+		} else {
+			oneLine, err := p.printShapeOneLine(shape)
+			if err != nil {
+				return "", err
+			}
+			compactHead := "with " + oneLine + " {"
+			if len(compactHead) <= p.effectiveTypeDefLineWidth() {
+				b.WriteString(oneLine)
+				b.WriteString(" {\n")
+			} else {
+				fieldIndent := p.depth + 1
+				wiring, err := p.printShapeMultiline(shape, fieldIndent)
+				if err != nil {
+					return "", err
+				}
+				b.WriteString(wiring)
+				b.WriteString(" {\n")
+			}
 		}
 	} else {
 		wiring, err := p.printExpr(w.Wiring)
@@ -1066,11 +1076,15 @@ func (p *printer) printCall(c ast.FunctionCallNode) (string, error) {
 	return b.String(), nil
 }
 
-// shapeShouldUseMultiline picks multi-line layout when a one-line shape would exceed the line
-// width budget, or when multiple fields include nested shape literals (keeps nested structure readable).
+// shapeShouldUseMultiline picks multi-line layout when a shape has more than two fields, when a
+// one-line shape would exceed the line width budget, or when multiple fields include nested shape
+// literals (keeps nested structure readable).
 func (p *printer) shapeShouldUseMultiline(s ast.ShapeNode) bool {
 	if len(s.Fields) == 0 {
 		return false
+	}
+	if len(s.Fields) > 2 {
+		return true
 	}
 	oneLine, err := p.printShapeOneLine(s)
 	if err != nil {

--- a/forst/internal/printer/printer_shape_field_cap_test.go
+++ b/forst/internal/printer/printer_shape_field_cap_test.go
@@ -1,0 +1,119 @@
+package printer
+
+import (
+	"strings"
+	"testing"
+
+	"forst/internal/ast"
+	"github.com/sirupsen/logrus"
+)
+
+func TestShapeShouldUseMultiline_twoFieldsUnderWidthStaysOneLine(t *testing.T) {
+	t.Parallel()
+	p := printer{cfg: DefaultConfig()}
+	shape := ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"a": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+			"b": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+		},
+	}
+	if p.shapeShouldUseMultiline(shape) {
+		t.Fatal("expected two short fields to stay one-line")
+	}
+}
+
+func TestShapeShouldUseMultiline_threeFieldsForcesMultiline(t *testing.T) {
+	t.Parallel()
+	p := printer{cfg: DefaultConfig()}
+	shape := ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"cells":      {Type: &ast.TypeNode{Ident: "[]String"}},
+			"nextPlayer": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+			"status":     {Type: &ast.TypeNode{Ident: ast.TypeString}},
+		},
+	}
+	if !p.shapeShouldUseMultiline(shape) {
+		t.Fatal("expected three fields to force multiline even when under width budget")
+	}
+}
+
+func TestShapeShouldUseMultiline_nestedShapeStillForcesMultiline(t *testing.T) {
+	t.Parallel()
+	p := printer{cfg: DefaultConfig()}
+	nested := ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"n": {Type: &ast.TypeNode{Ident: ast.TypeInt}},
+		},
+	}
+	shape := ast.ShapeNode{
+		Fields: map[string]ast.ShapeFieldNode{
+			"ctx":   {Shape: &nested},
+			"input": {Type: &ast.TypeNode{Ident: ast.TypeString}},
+		},
+	}
+	if !p.shapeShouldUseMultiline(shape) {
+		t.Fatal("expected nested shape fields to force multiline")
+	}
+}
+
+func TestFormatSource_shapeTwoFieldsStaysOneLine(t *testing.T) {
+	t.Parallel()
+	const src = `package main
+
+type Pair = {a: String, b: Int}
+`
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+	out, err := FormatSource(src, "pair.ft", log)
+	if err != nil {
+		t.Fatalf("FormatSource: %v", err)
+	}
+	if !strings.Contains(out, "type Pair = {a: String, b: Int}") {
+		t.Fatalf("expected two-field typedef on one line, got:\n%s", out)
+	}
+}
+
+func TestFormatSource_shapeThreeFieldsForcesMultiline(t *testing.T) {
+	t.Parallel()
+	const src = `package main
+
+type GameState = {cells: []String, nextPlayer: String, status: String}
+`
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+	out, err := FormatSource(src, "gamestate.ft", log)
+	if err != nil {
+		t.Fatalf("FormatSource: %v", err)
+	}
+	if strings.Contains(out, "{cells: []String, nextPlayer: String, status: String}") {
+		t.Fatalf("expected three-field typedef to break across lines, got:\n%s", out)
+	}
+	for _, needle := range []string{"cells:", "nextPlayer:", "status:"} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("missing field %q in:\n%s", needle, out)
+		}
+	}
+}
+
+func TestPrint_withThreeFieldWiringForcesMultiline(t *testing.T) {
+	t.Parallel()
+	with := ast.WithNode{
+		Wiring: ast.ShapeNode{
+			Fields: map[string]ast.ShapeFieldNode{
+				"Logger": {Type: &ast.TypeNode{Ident: "NopLogger"}},
+				"Clock":  {Type: &ast.TypeNode{Ident: "FakeClock"}},
+				"Store":  {Type: &ast.TypeNode{Ident: "MemStore"}},
+			},
+		},
+		Body: []ast.Node{},
+	}
+	var p printer
+	p.cfg = DefaultConfig()
+	out, err := p.printWith(with)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "with {\n") {
+		t.Fatalf("expected multiline with wiring for three fields, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Shapes with more than two fields now always use multiline layout in forst fmt, in addition to the existing line-width and nested-shape rules. Two-field shapes that fit within the width budget still print on one line.

printWith wiring blocks reuse shapeShouldUseMultiline so the same field-count rule applies to with blocks, not only typedefs and shape literals.

Add unit and integration tests for two-field one-line, three-field multiline, nested shapes, and three-field with wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for shapes with more than two fields by consistently displaying them across multiple lines.
  * Updated nested shapes and `with` statements to use clearer multiline layouts.

* **Tests**
  * Added coverage for single-line and multiline shape formatting, including nested shapes and `with` wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->