### PR TITLE
fix(typechecker): pop if-scope before collecting else/else-if

### DIFF
--- a/examples/in/rfc/node-interop/multi-package-dev/main.ft
+++ b/examples/in/rfc/node-interop/multi-package-dev/main.ft
@@ -1,9 +1,14 @@
 package main
 
+import "os"
 import node host "./host"
 
 func main() {
-	ready := host.hostPing()
-	ensure ready is Ok()
-	println("multipackage-dev ready: " + ready)
+	if os.Getenv("FORST_INVOKE_ONLY") == "1" {
+		println("multipackage-dev invoke-only")
+	} else {
+		ready := host.hostPing()
+		ensure ready is Ok()
+		println("multipackage-dev ready: " + ready)
+	}
 }

--- a/examples/out/rfc/node-interop/multi-package-dev/main.go
+++ b/examples/out/rfc/node-interop/multi-package-dev/main.go
@@ -1,16 +1,20 @@
 package main
 
+import "os"
 import fmt "fmt"
-import os "os"
 
 func main() {
-	ready, readyErr := forst_node_callsync_host_ts_hostPing()
-	if !(readyErr == nil) {
-		{
-			fmt.Fprintf(os.Stderr, "ensure failed: %v\n", readyErr)
-			os.Exit(1)
+	if os.Getenv("FORST_INVOKE_ONLY") == "1" {
+		println("multipackage-dev invoke-only")
+	} else {
+		ready, readyErr := forst_node_callsync_host_ts_hostPing()
+		if !(readyErr == nil) {
+			{
+				fmt.Fprintf(os.Stderr, "ensure failed: %v\n", readyErr)
+				os.Exit(1)
+			}
 		}
+		println("multipackage-dev ready: " + ready)
 	}
-	println("multipackage-dev ready: " + ready)
 	ForstInvokeWaitForShutdown()
 }

--- a/forst/internal/transformer/go/scope_else_ensure_test.go
+++ b/forst/internal/transformer/go/scope_else_ensure_test.go
@@ -1,0 +1,65 @@
+package transformergo
+
+import (
+	"testing"
+
+	"forst/internal/testutil"
+)
+
+func TestTransformIfNode_elseBranchVariableVisibleToBareEnsure(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+func main(): Void {
+	flag := true
+	if flag {
+		println("a")
+	} else {
+		x := 5
+		ensure x is GreaterThan(0)
+		println("b")
+	}
+}
+`
+	MustCompileGo(t, src, testutil.CompileOpts{})
+}
+
+func TestTransformIfNode_elseIfBranchVariableVisibleToBareEnsure(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+func main(): Void {
+	flag := 1
+	if flag == 0 {
+		println("a")
+	} else if flag == 1 {
+		x := 5
+		ensure x is GreaterThan(0)
+		println("b")
+	}
+}
+`
+	MustCompileGo(t, src, testutil.CompileOpts{})
+}
+
+func TestTransformIfNode_elseBranchResultVariableVisibleToEnsureOk(t *testing.T) {
+	t.Parallel()
+	src := `package demo
+
+func okInt(): Result(Int, Error) {
+	return 5
+}
+
+func main(): Void {
+	flag := true
+	if flag {
+		println("a")
+	} else {
+		x := okInt()
+		ensure x is Ok()
+		println("b")
+	}
+}
+`
+	MustCompileGo(t, src, testutil.CompileOpts{})
+}

--- a/forst/internal/typechecker/collect.go
+++ b/forst/internal/typechecker/collect.go
@@ -179,6 +179,7 @@ func (tc *TypeChecker) collectIfNode(n *ast.IfNode) error {
 			return err
 		}
 	}
+	tc.popScope()
 
 	for i := range n.ElseIfs {
 		if err := tc.collectExplicitTypes(&n.ElseIfs[i]); err != nil {
@@ -192,7 +193,6 @@ func (tc *TypeChecker) collectIfNode(n *ast.IfNode) error {
 		}
 	}
 
-	tc.popScope()
 	return nil
 }
 

--- a/forst/internal/typechecker/scope_if_restore_test.go
+++ b/forst/internal/typechecker/scope_if_restore_test.go
@@ -63,6 +63,53 @@ func main(): Void {
 	}
 }
 
+func TestRestoreScope_elseBranchBareEnsure_resolvesBranchLocalVariable(t *testing.T) {
+	t.Parallel()
+	src := []byte(`package demo
+
+func main(): Void {
+	n := 2
+	if n > 10 {
+		z := 1
+		println(string(z))
+	} else {
+		x := 5
+		ensure x is GreaterThan(0)
+		println(string(x))
+	}
+}
+`)
+	nodes := parseNodesForTest(t, src)
+	tc := testTypeChecker(t)
+	if err := tc.CheckTypes(nodes); err != nil {
+		t.Fatalf("CheckTypes: %v", err)
+	}
+	fn := findFunctionNode(t, nodes, "main")
+	ifn, ok := fn.Body[1].(*ast.IfNode)
+	if !ok {
+		t.Fatalf("body[1] want *IfNode, got %T", fn.Body[1])
+	}
+	if ifn.Else == nil || len(ifn.Else.Body) < 2 {
+		t.Fatalf("expected else body with assignment and ensure, got %d stmts", len(ifn.Else.Body))
+	}
+	ensureAST := ifn.Else.Body[1]
+	if _, ok := ensureAST.(ast.EnsureNode); !ok {
+		t.Fatalf("else body[1] want EnsureNode, got %T", ensureAST)
+	}
+
+	if err := tc.RestoreScope(ensureAST); err != nil {
+		t.Fatalf("RestoreScope(ensure): %v", err)
+	}
+	ensureNode := ensureAST.(ast.EnsureNode)
+	typ, err := tc.LookupVariableType(&ensureNode.Variable, tc.CurrentScope())
+	if err != nil {
+		t.Fatalf("LookupVariableType(x): %v", err)
+	}
+	if typ.Ident != ast.TypeInt {
+		t.Fatalf("LookupVariableType(x) = %q, want Int", typ.Ident)
+	}
+}
+
 func findFunctionNode(t *testing.T, nodes []ast.Node, name string) ast.FunctionNode {
 	t.Helper()
 	for _, n := range nodes {


### PR DESCRIPTION
## Summary

Fixes a transform-time crash where a variable declared in an `else` or `else if` branch and checked with a bare `ensure x is ...()` was reported as an undefined symbol, even though typechecking succeeded.

## Problem

Code like this failed during Go code generation:

```forst
if flag {
	println("a")
} else {
	x := 5
	ensure x is GreaterThan(0)
	println("b")
}
```

Error:

```text
failed to lookup variable type: undefined symbol: x
[scope: Scope(Ensure(Variable(x), GreaterThan(0)))]
```

The same bug appeared with `else if`, and with the original report shape (`ready := host.hostPing()` then `ensure ready is Ok()` inside `else`). Node interop and `Ok()` were not required to reproduce it. The `then` branch worked fine.

## Cause

Collect and infer disagreed on the parent of `else` / `else if` scopes:

1. **Collect** (`collectIfNode`) kept the if-node scope open while walking `ElseIfs` and `Else`, so those branch scopes were children of the if-scope.
2. **Infer** (`inferIfStatement`) popped the if-scope right after the `then` body, so the same branches became children of the outer (pre-if) scope.

`pushScope` only reuses an existing scope when the structural hash matches and `existing.Parent == ss.current`. Because of the parent mismatch, infer created a replacement branch scope and registered locals there. Collect had already registered a bare `ensure` scope under the old, empty branch. Transform restored that orphaned ensure scope, walked its stale parent chain, and never found the variable.

`else if` and `else` still get their own push/pop scopes via the `ElseIfNode` / `ElseBlockNode` cases in `collectExplicitTypes`. The bug was only which scope was current (the parent) when those cases ran.

## Fix

In `collectIfNode`, pop the if-scope immediately after collecting the `then` body and before collecting `ElseIfs` / `Else`, matching `inferIfStatement`. Branch scopes then share the same parent in both passes, so ensure scopes stay attached to the scope that receives the locals.

## Tests and example

- Transformer pipeline tests for bare `ensure` in `else` and `else if`, plus `ensure x is Ok()` in `else`
- Typechecker restore test: `RestoreScope` on a bare ensure inside `else` resolves the branch-local variable
- `multi-package-dev` example wraps `host.hostPing()` / `ensure ready is Ok()` in an `if` / `else` on `FORST_INVOKE_ONLY`, with updated goldens

## Test plan

- [x] `go test ./internal/typechecker/... ./internal/transformer/go/...`
- [x] `go test ./cmd/forst/... -run TestExampleNodeInteropPackagesCompileGolden/multi-package-dev`
- [x] `task example:multipackage-dev`