### PR TITLE
feat(cli)!: shrink host invoke connect API

### DIFF
--- a/docs/interop/node/invoke-security.mdx
+++ b/docs/interop/node/invoke-security.mdx
@@ -80,6 +80,11 @@ end. That way the host never reads a token file.
 `.forst/invoke.ready` includes `tokenDelivery` (`env` or `handoff`) so clients
 know which channel to use.
 
+In a Node host process, call `prepareInvokeConnect()` from `@forst/cli/invoke`
+at startup. It sets connect-mode env and listens on `FORST_INVOKE_AUTH_RECV_FD`.
+Use `getInvokeAuthHandoff()` with your generated client's `resolveAuth` option
+when auth arrives over the pipe.
+
 <Note>
   Use the Forst sidecar transport for authenticated invoke requests. Do not
   build a raw `curl` request to `POST /invoke`: it cannot complete the

--- a/forst/internal/devserver/host_orchestrator_test.go
+++ b/forst/internal/devserver/host_orchestrator_test.go
@@ -106,6 +106,9 @@ func TestHostOrchestrator_shutdownTerminatesSpawnedHost(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix signals")
 	}
+	// Auth relay restarts a live marker host and spawns Node (needs tsx). This test
+	// uses a sleep stand-in and asserts Shutdown terminates the marker pid.
+	t.Setenv("FORST_INVOKE_AUTH", "off")
 
 	dir := t.TempDir()
 	_, readyPath, err := nodert.ResolveHostSocketPath(dir, "")

--- a/forst/internal/transformer/ts/emit_esm_test.go
+++ b/forst/internal/transformer/ts/emit_esm_test.go
@@ -322,6 +322,8 @@ func TestEmitTransportESM_isConnectOnlyHttpWithNdjson(t *testing.T) {
 		"http://127.0.0.1:6321",
 		"Never spawns",
 		"resolveTransportMode",
+		"FORST_INVOKE_AUTH_RECV_FD",
+		"startHostInvokeAuthRecvListener",
 	})
 	assertContainsNone(t, got, []string{
 		"@forst/client",

--- a/forst/internal/transformer/ts/transport.go
+++ b/forst/internal/transformer/ts/transport.go
@@ -463,9 +463,12 @@ function parseHostInvokeAuthHandoffLine(line) {
   try {
     payload = JSON.parse(line);
   } catch {
-    throw new Error("invoke auth handoff: invalid JSON");
+    return undefined;
   }
   if (
+    payload === null ||
+    typeof payload !== "object" ||
+    Array.isArray(payload) ||
     payload.generation === undefined ||
     typeof payload.generation !== "number" ||
     !Number.isSafeInteger(payload.generation) ||
@@ -473,11 +476,11 @@ function parseHostInvokeAuthHandoffLine(line) {
     typeof payload.token !== "string" ||
     payload.token.trim() === ""
   ) {
-    throw new Error("invoke auth handoff: missing generation or token");
+    return undefined;
   }
   const token = Buffer.from(payload.token, "base64url");
   if (!token.length) {
-    throw new Error("invoke auth handoff: empty token");
+    return undefined;
   }
   return { generation: payload.generation, token };
 }
@@ -503,10 +506,9 @@ async function consumeHostInvokeAuthStream(stream) {
       if (line === "") {
         continue;
       }
-      try {
-        storeHostInvokeAuthHandoff(parseHostInvokeAuthHandoffLine(line));
-      } catch {
-        // ignore malformed handoff lines
+      const handoff = parseHostInvokeAuthHandoffLine(line);
+      if (handoff) {
+        storeHostInvokeAuthHandoff(handoff);
       }
     }
   }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -52,7 +52,7 @@
 
 * **cli:** Add `@forst/cli/invoke` with `startForstInvokeServer` for Node→Forst HTTP invoke lifecycle (attach, spawn `dev`/`embedded`, `/health` readiness, SIGTERM then SIGKILL). Orthogonal to `@forst/node-runtime`.
 * **cli:** Declare `@forst/errors` as a runtime dependency so apps with `@forst/cli` can import shared invoke failure classes without adding Effect.
-* **cli:** Host-mode invoke auth handoff via `FORST_INVOKE_AUTH_RECV_FD` (`startHostInvokeAuthRecvListener` / `resolveHostInvokeAuthHandoff` / `prepareConnectInvokeEnv`), plus shared `DEFAULT_EMBEDDED_INVOKE_PORT` and `DEFAULT_EMBEDDED_INVOKE_BASE_URL`.
+* **cli:** Host-mode invoke auth handoff via `FORST_INVOKE_AUTH_RECV_FD` (`prepareInvokeConnect` / `getInvokeAuthHandoff`), plus shared `DEFAULT_EMBEDDED_INVOKE_PORT` and `DEFAULT_EMBEDDED_INVOKE_BASE_URL`.
 
 ### Bug Fixes
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -154,6 +154,8 @@ Behaviour in short:
 - Readiness is `GET /health`, not log scraping.
 - `stop()` sends `SIGTERM`, then `SIGKILL` after 5s.
 
+For **host mode** (`node.hostMode` in `ftconfig.json`), call `prepareInvokeConnect()` at process startup so connect-mode env and the `FORST_INVOKE_AUTH_RECV_FD` listener are ready. Use `getInvokeAuthHandoff()` with a generated client's `resolveAuth` when auth arrives over the host pipe instead of `FORST_INVOKE_TOKEN`.
+
 Opt-in real spawn test (needs a local `forst` binary and Go for embedded compile):
 
 ```bash

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -9,7 +9,7 @@ export const COMPILER_RELEASES_BASE =
 export const DEFAULT_EMBEDDED_INVOKE_PORT = "6321";
 
 /** Loopback HTTP base URL for {@link DEFAULT_EMBEDDED_INVOKE_PORT}. */
-export const DEFAULT_EMBEDDED_INVOKE_BASE_URL =
+export const DEFAULT_EMBEDDED_INVOKE_BASE_URL: string =
   `http://127.0.0.1:${DEFAULT_EMBEDDED_INVOKE_PORT}`;
 
 /**

--- a/packages/cli/src/host-invoke-auth.test.ts
+++ b/packages/cli/src/host-invoke-auth.test.ts
@@ -6,17 +6,17 @@ import { PassThrough } from "node:stream";
 
 import {
   consumeHostInvokeAuthStreamForTest,
-  envInvokeAuthRecvFd,
-  prepareConnectInvokeEnv,
+  getInvokeAuthHandoff,
+  prepareInvokeConnect,
   resetHostInvokeAuthHandoffForTest,
-  resolveHostInvokeAuthHandoff,
-  startHostInvokeAuthRecvListener,
 } from "./host-invoke-auth.js";
 import { DEFAULT_EMBEDDED_INVOKE_BASE_URL } from "./constants.js";
 
+const recvFdEnv = "FORST_INVOKE_AUTH_RECV_FD";
+
 afterEach(() => {
   resetHostInvokeAuthHandoffForTest();
-  delete process.env[envInvokeAuthRecvFd];
+  delete process.env[recvFdEnv];
   delete process.env.FORST_SKIP_SPAWN;
   delete process.env.FORST_BOUNDARY_ROOT;
   delete process.env.FORST_BASE_URL;
@@ -37,29 +37,26 @@ describe("consumeHostInvokeAuthStreamForTest", () => {
     stream.end();
     await done;
 
-    const got = resolveHostInvokeAuthHandoff();
+    const got = getInvokeAuthHandoff();
     expect(got?.generation).toBe(7);
     expect(Buffer.from(got!.token)).toEqual(Buffer.from([1, 2, 3]));
   });
 });
 
-describe("startHostInvokeAuthRecvListener", () => {
-  test("is a no-op without recv fd env", () => {
-    startHostInvokeAuthRecvListener();
-    startHostInvokeAuthRecvListener();
-    expect(resolveHostInvokeAuthHandoff()).toBeUndefined();
+describe("getInvokeAuthHandoff", () => {
+  test("returns undefined without recv fd env", () => {
+    expect(getInvokeAuthHandoff()).toBeUndefined();
   });
 
-  test("is a no-op for invalid recv fd values", () => {
-    process.env[envInvokeAuthRecvFd] = "1";
-    startHostInvokeAuthRecvListener();
-    expect(resolveHostInvokeAuthHandoff()).toBeUndefined();
+  test("returns undefined for invalid recv fd values", () => {
+    process.env[recvFdEnv] = "1";
+    expect(getInvokeAuthHandoff()).toBeUndefined();
   });
 });
 
-describe("prepareConnectInvokeEnv", () => {
+describe("prepareInvokeConnect", () => {
   test("sets skip-spawn and default base url when ready file is absent", () => {
-    const root = prepareConnectInvokeEnv("/tmp/forst-boundary");
+    const root = prepareInvokeConnect("/tmp/forst-boundary");
     expect(root).toBe("/tmp/forst-boundary");
     expect(process.env.FORST_SKIP_SPAWN).toBe("1");
     expect(process.env.FORST_BOUNDARY_ROOT).toBe("/tmp/forst-boundary");
@@ -74,7 +71,7 @@ describe("prepareConnectInvokeEnv", () => {
       JSON.stringify({ url: "http://127.0.0.1:9999/" })
     );
     try {
-      prepareConnectInvokeEnv(root);
+      prepareInvokeConnect(root);
       expect(process.env.FORST_BASE_URL).toBe("http://127.0.0.1:9999");
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/packages/cli/src/host-invoke-auth.ts
+++ b/packages/cli/src/host-invoke-auth.ts
@@ -9,25 +9,24 @@ import {
   readInvokeReadyUrl,
 } from "./invoke-ready.js";
 
-export const envInvokeAuthRecvFd = "FORST_INVOKE_AUTH_RECV_FD";
+const envInvokeAuthRecvFd = "FORST_INVOKE_AUTH_RECV_FD";
 
 let hostInvokeAuth: InvokeAuthState | undefined;
 let hostInvokeAuthListenerStarted = false;
 
 /**
  * Parses one newline-delimited JSON handoff line into {@link AuthHandoff}.
- * Validates the JSON root as a non-null object before reading fields so values
- * such as `null` become handoff errors instead of TypeErrors.
+ * Returns `undefined` for invalid JSON, non-object roots, or missing fields.
  */
-function parseHandoffLine(line: string): AuthHandoff {
+function parseHandoffLine(line: string): AuthHandoff | undefined {
   let parsed: unknown;
   try {
     parsed = JSON.parse(line) as unknown;
   } catch {
-    throw new Error("invoke auth handoff: invalid JSON");
+    return undefined;
   }
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("invoke auth handoff: missing generation or token");
+    return undefined;
   }
   const record = parsed as Record<string, unknown>;
   const generation = record.generation;
@@ -39,11 +38,11 @@ function parseHandoffLine(line: string): AuthHandoff {
     typeof tokenRaw !== "string" ||
     tokenRaw.trim() === ""
   ) {
-    throw new Error("invoke auth handoff: missing generation or token");
+    return undefined;
   }
   const token = Uint8Array.from(Buffer.from(tokenRaw, "base64url"));
   if (!token.length) {
-    throw new Error("invoke auth handoff: empty token");
+    return undefined;
   }
   return { generation, token };
 }
@@ -70,20 +69,15 @@ async function consumeHostInvokeAuthStream(stream: Readable): Promise<void> {
       if (line === "") {
         continue;
       }
-      try {
-        storeHostInvokeAuth(parseHandoffLine(line));
-      } catch {
-        // ignore malformed handoff lines
+      const handoff = parseHandoffLine(line);
+      if (handoff) {
+        storeHostInvokeAuth(handoff);
       }
     }
   }
 }
 
-/**
- * Reads invoke auth handoff lines from `FORST_INVOKE_AUTH_RECV_FD` when set by
- * forst dev host mode. Safe to call multiple times; starts at most one listener.
- */
-export function startHostInvokeAuthRecvListener(): void {
+function startHostInvokeAuthRecvListener(): void {
   if (hostInvokeAuthListenerStarted) {
     return;
   }
@@ -105,10 +99,19 @@ export function startHostInvokeAuthRecvListener(): void {
   });
 }
 
-/** Returns auth delivered by {@link startHostInvokeAuthRecvListener}, if any. */
-export function resolveHostInvokeAuthHandoff():
-  | InvokeAuthState
-  | undefined {
+/**
+ * Returns invoke auth delivered over the host-mode pipe when
+ * `FORST_INVOKE_AUTH_RECV_FD` is set by `forst dev`.
+ *
+ * Use this with a generated client's `resolveAuth` option when the Node host
+ * process starts before the embedded invoke server is ready and auth arrives
+ * through the inherited recv fd rather than `FORST_INVOKE_TOKEN` or a token file.
+ *
+ * The recv listener starts automatically when this module loads and when
+ * {@link prepareInvokeConnect} runs. Safe to call before auth has arrived;
+ * returns `undefined` until a valid handoff line is received.
+ */
+export function getInvokeAuthHandoff(): InvokeAuthState | undefined {
   startHostInvokeAuthRecvListener();
   return hostInvokeAuth;
 }
@@ -128,10 +131,20 @@ export async function consumeHostInvokeAuthStreamForTest(
 }
 
 /**
- * Sets connect-mode env for embedded invoke: skip spawn, boundary root, prefer UDS.
- * Starts the host auth recv listener when `FORST_INVOKE_AUTH_RECV_FD` is set.
+ * Configures connect-mode env for embedded invoke in a Node host process.
+ *
+ * Sets `FORST_SKIP_SPAWN=1` and `FORST_BOUNDARY_ROOT` (defaults to `process.cwd()`).
+ * Resolves the invoke base URL from `.forst/invoke.ready` when present, clears URL
+ * env when only a Unix socket is advertised, or falls back to
+ * {@link DEFAULT_EMBEDDED_INVOKE_BASE_URL}.
+ *
+ * Also ensures the `FORST_INVOKE_AUTH_RECV_FD` listener is running so host-mode
+ * auth handoff works without a separate setup call.
+ *
+ * @param boundaryRoot Project root containing `.forst/invoke.ready`.
+ * @returns The resolved boundary root path.
  */
-export function prepareConnectInvokeEnv(boundaryRoot?: string): string {
+export function prepareInvokeConnect(boundaryRoot?: string): string {
   startHostInvokeAuthRecvListener();
   const root = boundaryRoot?.trim() || process.cwd();
   process.env.FORST_SKIP_SPAWN = "1";

--- a/packages/cli/src/invoke-exports.test.ts
+++ b/packages/cli/src/invoke-exports.test.ts
@@ -34,5 +34,11 @@ describe("@forst/cli/invoke package exports", () => {
     expect(typeof mod.requestOverUnixSocket).toBe("function");
     expect(typeof mod.stripReservedHeaders).toBe("function");
     expect(typeof mod.parseInvokeChallengeResult).toBe("function");
+    expect(typeof mod.prepareInvokeConnect).toBe("function");
+    expect(typeof mod.getInvokeAuthHandoff).toBe("function");
+    expect(mod.consumeHostInvokeAuthStreamForTest).toBeUndefined();
+    expect(mod.resetHostInvokeAuthHandoffForTest).toBeUndefined();
+    expect(mod.startHostInvokeAuthRecvListener).toBeUndefined();
+    expect(mod.envInvokeAuthRecvFd).toBeUndefined();
   });
 });

--- a/packages/cli/src/invoke.ts
+++ b/packages/cli/src/invoke.ts
@@ -53,10 +53,6 @@ export {
   type ForstInvokeServerErrorContext,
 } from "./errors.js";
 export {
-  consumeHostInvokeAuthStreamForTest,
-  envInvokeAuthRecvFd,
-  prepareConnectInvokeEnv,
-  resetHostInvokeAuthHandoffForTest,
-  resolveHostInvokeAuthHandoff,
-  startHostInvokeAuthRecvListener,
+  getInvokeAuthHandoff,
+  prepareInvokeConnect,
 } from "./host-invoke-auth.js";


### PR DESCRIPTION
Rename `prepareConnectInvokeEnv` to `prepareInvokeConnect` and `resolveHostInvokeAuthHandoff` to `getInvokeAuthHandoff`. Export only those two helpers from `@forst/cli/invoke`; keep test helpers and the recv listener internal. Document host-mode setup in `README` and `invoke-security`.

BREAKING CHANGE: `@forst/cli/invoke` no longer exports `prepareConnectInvokeEnv`, `resolveHostInvokeAuthHandoff`, `startHostInvokeAuthRecvListener`, or `envInvokeAuthRecvFd`. Use `prepareInvokeConnect` and `getInvokeAuthHandoff` instead.

fix(generate): skip throw in emitted invoke auth handoff parsing

Generated transport now returns undefined for malformed handoff lines instead of throw new Error, keeping connect-only ESM output free of bare throws and restoring `TestEmitTransportESM_isConnectOnlyHttpWithNdjson`.

fix(cli): add explicit type for `DEFAULT_EMBEDDED_INVOKE_BASE_URL`

Annotate the template literal export as string so JSR slow-type checks pass.