### PR TITLE
perf(generate): skip excluded directories during discovery

### DIFF
--- a/forst/cmd/forst/generate.go
+++ b/forst/cmd/forst/generate.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -108,6 +109,7 @@ type generateOptions struct {
 	allowStemMismatch bool
 	watch             bool
 	listJSON          bool
+	logLevel          string
 	target            string
 }
 
@@ -119,6 +121,7 @@ func parseGenerateArgs(args []string) (generateOptions, error) {
 	watch := fs.Bool("watch", false, "Regenerate when .ft files change")
 	listJSON := fs.Bool("json", false, "With --list, emit a JSON manifest of packages and functions")
 	list := fs.Bool("list", false, "Print a manifest of packages and functions instead of writing output")
+	logLevel := fs.String("log-level", "", "Log level (trace, debug, info, warn, error)")
 	if err := fs.Parse(args); err != nil {
 		return generateOptions{}, err
 	}
@@ -131,8 +134,36 @@ func parseGenerateArgs(args []string) (generateOptions, error) {
 		allowStemMismatch: *allowStemMismatch,
 		watch:             *watch,
 		listJSON:          *list || *listJSON,
+		logLevel:          *logLevel,
 		target:            tail[0],
 	}, nil
+}
+
+func configureGenerateLogger(log *logrus.Logger, opts generateOptions, cfg *ForstConfig) {
+	logLevel := opts.logLevel
+	if logLevel == "" {
+		logLevel = cfg.Dev.LogLevel
+	}
+	setLogLevel(log, logLevel)
+}
+
+func generateTSOptions(cfg *ForstConfig) *transformerts.GenerateTSOptions {
+	return &transformerts.GenerateTSOptions{
+		GenerateStreamingClients: cfg.Compiler.GenerateStreamingClients,
+		ReportPhases:             cfg.Compiler.ReportPhases,
+	}
+}
+
+func logGeneratePhase(log *logrus.Logger, reportPhases bool, phase string, start time.Time) {
+	fields := logrus.Fields{
+		"phase":      phase,
+		"durationMs": time.Since(start).Milliseconds(),
+	}
+	if reportPhases {
+		log.WithFields(fields).Info("generate phase")
+	} else {
+		log.WithFields(fields).Debug("generate phase")
+	}
 }
 
 // generateCommand handles the "forst generate" command
@@ -153,6 +184,7 @@ func generateCommand(args []string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+	configureGenerateLogger(log, opts, cfg)
 
 	if opts.watch {
 		return watchGenerate(opts, cfg, fileInfo.IsDir(), log)
@@ -166,7 +198,11 @@ func generateCommand(args []string) error {
 
 // runGenerateList discovers exports and prints a JSON manifest without writing client output.
 func runGenerateList(opts generateOptions, cfg *ForstConfig, isDir bool, log *logrus.Logger) error {
+	reportPhases := cfg.Compiler.ReportPhases
+
+	discoverStart := time.Now()
 	forstFiles, outputDir, err := discoverForstFilesForGenerate(cfg, opts.target, isDir)
+	logGeneratePhase(log, reportPhases, "discover", discoverStart)
 	if err != nil {
 		return err
 	}
@@ -185,9 +221,9 @@ func runGenerateList(opts generateOptions, cfg *ForstConfig, isDir bool, log *lo
 	if err := validateDiscoveredFileStemsHook(forstFiles, opts.allowStemMismatch, log); err != nil {
 		return err
 	}
-	outputs, err := generateTSOutputsByPackageHook(forstFiles, log, &transformerts.GenerateTSOptions{
-		GenerateStreamingClients: cfg.Compiler.GenerateStreamingClients,
-	})
+	typecheckStart := time.Now()
+	outputs, err := generateTSOutputsByPackageHook(forstFiles, log, generateTSOptions(cfg))
+	logGeneratePhase(log, reportPhases, "typecheck_emit", typecheckStart)
 	if err != nil {
 		return err
 	}
@@ -196,7 +232,11 @@ func runGenerateList(opts generateOptions, cfg *ForstConfig, isDir bool, log *lo
 
 // runGenerateOnce performs a single generate pass into outDir/dist/.
 func runGenerateOnce(opts generateOptions, cfg *ForstConfig, isDir bool, log *logrus.Logger) error {
+	reportPhases := cfg.Compiler.ReportPhases
+
+	discoverStart := time.Now()
 	forstFiles, outputDir, err := discoverForstFilesForGenerate(cfg, opts.target, isDir)
+	logGeneratePhase(log, reportPhases, "discover", discoverStart)
 	if err != nil {
 		return err
 	}
@@ -216,22 +256,22 @@ func runGenerateOnce(opts generateOptions, cfg *ForstConfig, isDir bool, log *lo
 		"link":        genCfg.ShouldLink(boundaryRoot),
 		"emit":        genCfg.Emit,
 		"effect":      genCfg.Effect,
-	}).Info("Resolved generate config")
+	}).Debug("Resolved generate config")
 
 	if len(forstFiles) == 0 {
 		log.Warn("No .ft files found for generation (check ftconfig include/exclude)")
 		return nil
 	}
 
-	log.Infof("Found %d Forst files", len(forstFiles))
+	log.Debugf("Found %d Forst files", len(forstFiles))
 
 	if err := validateDiscoveredFileStemsHook(forstFiles, opts.allowStemMismatch, log); err != nil {
 		return err
 	}
 
-	outputs, err := generateTSOutputsByPackageHook(forstFiles, log, &transformerts.GenerateTSOptions{
-		GenerateStreamingClients: cfg.Compiler.GenerateStreamingClients,
-	})
+	typecheckStart := time.Now()
+	outputs, err := generateTSOutputsByPackageHook(forstFiles, log, generateTSOptions(cfg))
+	logGeneratePhase(log, reportPhases, "typecheck_emit", typecheckStart)
 	if err != nil {
 		return err
 	}
@@ -282,6 +322,7 @@ func runGenerateOnce(opts generateOptions, cfg *ForstConfig, isDir bool, log *lo
 
 	var stats generateWriteStats
 
+	writeStart := time.Now()
 	clientOutputs := runnableClientOutputs(outputs)
 	if err := writeGeneratedDistModules(distDir, coreDir, pkgDir, merged, clientOutputs, genCfg, runtime, invokePort, log, &stats); err != nil {
 		return err
@@ -308,10 +349,13 @@ func runGenerateOnce(opts generateOptions, cfg *ForstConfig, isDir bool, log *lo
 	if err := writeForstGeneratedMarker(outDir, boundaryRoot, genCfg.PackageName, &stats); err != nil {
 		return err
 	}
+	logGeneratePhase(log, reportPhases, "write", writeStart)
 
+	linkStart := time.Now()
 	if err := maybeLinkGeneratedClient(boundaryRoot, outDir, genCfg, log); err != nil {
 		return err
 	}
+	logGeneratePhase(log, reportPhases, "link", linkStart)
 	warnMissingLifecycleScript(boundaryRoot, genCfg, log)
 
 	printGenerateSummary(genCfg, clientOutputs)
@@ -319,12 +363,8 @@ func runGenerateOnce(opts generateOptions, cfg *ForstConfig, isDir bool, log *lo
 	log.WithFields(logrus.Fields{
 		"filesWritten": stats.Written,
 		"filesSkipped": stats.Skipped,
-	}).Info("Generate write summary")
-	log.WithFields(logrus.Fields{
-		"filesWritten": stats.Written,
-		"filesSkipped": stats.Skipped,
-	}).Debug("Generate write summary (debug)")
+	}).Debug("Generate write summary")
 
-	log.Info("TypeScript client generation completed")
+	log.Debug("TypeScript client generation completed")
 	return nil
 }

--- a/forst/cmd/forst/generate_client_package.go
+++ b/forst/cmd/forst/generate_client_package.go
@@ -49,7 +49,7 @@ func generateClientPackage(
 	if err := writeGeneratedFile(indexJSPath, []byte(indexJS), stats); err != nil {
 		return fmt.Errorf("failed to write client index.js: %w", err)
 	}
-	log.Infof("Generated client index: %s", indexJSPath)
+	log.Debugf("Generated client index: %s", indexJSPath)
 
 	indexDTS := transformerts.EmitIndexDTS(packageNames, domainErrors, runtime)
 	if runtime == transformerts.RuntimeEffect {
@@ -84,7 +84,7 @@ func generateClientPackage(
 	if err := writeGeneratedFile(testingJSPath, []byte(testingJS), stats); err != nil {
 		return fmt.Errorf("failed to write testing.js: %w", err)
 	}
-	log.Infof("Generated testing module: %s", testingJSPath)
+	log.Debugf("Generated testing module: %s", testingJSPath)
 
 	testingDTSPath := filepath.Join(outDir, "dist", testingKey+".d.ts")
 	if err := writeGeneratedFile(testingDTSPath, []byte(testingDTS), stats); err != nil {
@@ -96,14 +96,14 @@ func generateClientPackage(
 	if err := writeGeneratedFile(packagePath, []byte(packageContent), stats); err != nil {
 		return fmt.Errorf("failed to write client package.json: %w", err)
 	}
-	log.Infof("Generated client package.json: %s", packagePath)
+	log.Debugf("Generated client package.json: %s", packagePath)
 
 	readme := generateClientREADME(genCfg, invokePort, outputs)
 	readmePath := filepath.Join(outDir, "README.md")
 	if err := writeGeneratedFile(readmePath, []byte(readme), stats); err != nil {
 		return fmt.Errorf("failed to write client README: %w", err)
 	}
-	log.Infof("Generated client README: %s", readmePath)
+	log.Debugf("Generated client README: %s", readmePath)
 
 	return nil
 }

--- a/forst/cmd/forst/generate_dist.go
+++ b/forst/cmd/forst/generate_dist.go
@@ -58,14 +58,14 @@ func writeGeneratedDistModules(
 	if err := writeGeneratedFile(typesPath, []byte(typesCode), stats); err != nil {
 		return fmt.Errorf("failed to write types declaration file: %w", err)
 	}
-	log.WithFields(logrus.Fields{"path": typesPath}).Info("Generated types declaration file")
+	log.WithFields(logrus.Fields{"path": typesPath}).Debug("Generated types declaration file")
 
 	errorsJSPath := filepath.Join(distDir, "errors.js")
 	errorsJS := transformerts.EmitErrorsESM(genCfg.PackageName, merged.DomainErrors, runtime)
 	if err := writeGeneratedFile(errorsJSPath, []byte(errorsJS), stats); err != nil {
 		return fmt.Errorf("failed to write errors.js: %w", err)
 	}
-	log.WithFields(logrus.Fields{"path": errorsJSPath}).Info("Generated errors module")
+	log.WithFields(logrus.Fields{"path": errorsJSPath}).Debug("Generated errors module")
 
 	errorsDTSPath := filepath.Join(distDir, "errors.d.ts")
 	if err := writeGeneratedFile(errorsDTSPath, []byte(transformerts.EmitErrorsDTS(genCfg.PackageName, merged.DomainErrors, runtime)), stats); err != nil {
@@ -76,7 +76,7 @@ func writeGeneratedDistModules(
 	if err := writeGeneratedFile(transportJSPath, []byte(transformerts.EmitTransportESM(invokePort, runtime)), stats); err != nil {
 		return fmt.Errorf("failed to write transport.js: %w", err)
 	}
-	log.WithFields(logrus.Fields{"path": transportJSPath}).Info("Generated transport module")
+	log.WithFields(logrus.Fields{"path": transportJSPath}).Debug("Generated transport module")
 
 	transportDTSPath := filepath.Join(distDir, "transport.d.ts")
 	if err := writeGeneratedFile(transportDTSPath, []byte(transformerts.EmitTransportDTS()), stats); err != nil {
@@ -92,7 +92,7 @@ func writeGeneratedDistModules(
 		if err := writeGeneratedFile(effectDTSPath, []byte(transformerts.EmitEffectSupportDTS(genCfg.PackageName)), stats); err != nil {
 			return fmt.Errorf("failed to write effect.d.ts: %w", err)
 		}
-		log.WithFields(logrus.Fields{"path": effectJSPath}).Info("Generated Effect transport support module")
+		log.WithFields(logrus.Fields{"path": effectJSPath}).Debug("Generated Effect transport support module")
 	}
 
 	activePackages := make(map[string]struct{}, len(clientOutputs))
@@ -113,7 +113,7 @@ func writeGeneratedDistModules(
 			"forstPackage":  pkg,
 			"functionCount": len(out.Functions),
 			"path":          coreJS,
-		}).Info("Generated core module")
+		}).Debug("Generated core module")
 
 		pkgJS := filepath.Join(pkgDir, pkg+".js")
 		if err := writeGeneratedFile(pkgJS, []byte(transformerts.EmitPackageESM(mod, runtime, genCfg.PackageName)), stats); err != nil {
@@ -128,7 +128,7 @@ func writeGeneratedDistModules(
 			"functionCount": len(out.Functions),
 			"path":          pkgJS,
 			"runtime":       runtime.String(),
-		}).Info("Generated package module")
+		}).Debug("Generated package module")
 	}
 
 	return nil
@@ -218,7 +218,7 @@ func pruneStaleClientModules(distDir string, activePackages map[string]struct{},
 			if err := generateIO.Remove(path); err != nil {
 				return err
 			}
-			log.Infof("Pruned stale client module: %s", path)
+			log.Debugf("Pruned stale client module: %s", path)
 		}
 	}
 	return nil
@@ -255,7 +255,7 @@ func pruneStaleModulesInDir(dir string, activePackages map[string]struct{}, log 
 		if err := generateIO.Remove(path); err != nil {
 			return err
 		}
-		log.Infof("Pruned stale client module: %s", path)
+		log.Debugf("Pruned stale client module: %s", path)
 	}
 	return nil
 }

--- a/forst/cmd/forst/generate_ssr.go
+++ b/forst/cmd/forst/generate_ssr.go
@@ -67,7 +67,7 @@ func writeSSRModule(
 	log.WithFields(logrus.Fields{
 		"ssrModule": ssrRelPath,
 		"path":      modulePath,
-	}).Info("Generated SSR invoke module")
+	}).Debug("Generated SSR invoke module")
 	return nil
 }
 

--- a/forst/cmd/forst/generate_test.go
+++ b/forst/cmd/forst/generate_test.go
@@ -183,13 +183,13 @@ func TestGenerateCommand_logsResolvedGenerateConfig(t *testing.T) {
 	t.Cleanup(func() { newGenerateLogger = prev })
 	newGenerateLogger = func() *logrus.Logger {
 		log := logrus.New()
-		log.SetLevel(logrus.InfoLevel)
+		log.SetLevel(logrus.DebugLevel)
 		log.SetOutput(&buf)
 		log.SetFormatter(&logrus.TextFormatter{DisableColors: true, DisableTimestamp: true})
 		return log
 	}
 
-	if err := generateCommand([]string{dir}); err != nil {
+	if err := generateCommand([]string{"-log-level", "debug", dir}); err != nil {
 		t.Fatalf("generateCommand: %v", err)
 	}
 	out := buf.String()
@@ -674,6 +674,41 @@ func TestGenerateClientPackage_writePackageJSONFails(t *testing.T) {
 	err := generateClientPackage(dir, genCfg, testClientPackageOutputs("a"), "6321", log, nil)
 	if err == nil || !strings.Contains(err.Error(), "package.json") {
 		t.Fatalf("got %v", err)
+	}
+}
+
+func TestParseGenerateArgs_logLevelFlag(t *testing.T) {
+	opts, err := parseGenerateArgs([]string{"-log-level", "debug", "."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.logLevel != "debug" {
+		t.Fatalf("logLevel = %q, want debug", opts.logLevel)
+	}
+	if opts.target != "." {
+		t.Fatalf("target = %q, want .", opts.target)
+	}
+}
+
+func TestGenerateTSOptions_passesReportPhases(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Compiler.ReportPhases = true
+	opts := generateTSOptions(cfg)
+	if !opts.ReportPhases {
+		t.Fatal("expected ReportPhases true")
+	}
+	if opts.GenerateStreamingClients != cfg.Compiler.GenerateStreamingClients {
+		t.Fatal("expected GenerateStreamingClients to match config")
+	}
+}
+
+func TestConfigureGenerateLogger_flagOverridesConfig(t *testing.T) {
+	log := logrus.New()
+	cfg := DefaultConfig()
+	cfg.Dev.LogLevel = "warn"
+	configureGenerateLogger(log, generateOptions{logLevel: "debug"}, cfg)
+	if log.GetLevel() != logrus.DebugLevel {
+		t.Fatalf("level = %v, want debug", log.GetLevel())
 	}
 }
 

--- a/forst/internal/ftconfig/ftconfig.go
+++ b/forst/internal/ftconfig/ftconfig.go
@@ -193,7 +193,7 @@ func Default() *Config {
 		},
 		Files: FilesConfig{
 			Include:  []string{"**/*.ft"},
-			Exclude:  []string{"**/node_modules/**", "**/.git/**"},
+			Exclude:  []string{"**/node_modules/**", "**/.git/**", "**/build/**", "**/.forst/**"},
 			MaxDepth: 10,
 		},
 		Output: OutputConfig{
@@ -379,6 +379,12 @@ func (c *Config) FindForstFiles(rootDir string) ([]string, error) {
 			return walkErr
 		}
 		if d.IsDir() {
+			if path != "." {
+				absPath := root.AbsPath(path)
+				if c.matchesExcludePatterns(absPath) {
+					return fs.SkipDir
+				}
+			}
 			return nil
 		}
 		absPath := root.AbsPath(path)

--- a/forst/internal/ftconfig/ftconfig_test.go
+++ b/forst/internal/ftconfig/ftconfig_test.go
@@ -1,10 +1,12 @@
 package ftconfig
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDefault_saneDefaults(t *testing.T) {
@@ -338,6 +340,74 @@ func TestBoundaryRootFromDir_notFound(t *testing.T) {
 	_, err := BoundaryRootFromDir(dir)
 	if err == nil {
 		t.Fatal("expected error when ftconfig.json missing")
+	}
+}
+
+func TestConfig_FindForstFiles_skipsExcludedDirectoryTrees(t *testing.T) {
+	root := t.TempDir()
+	keep := filepath.Join(root, "keep.ft")
+	if err := os.WriteFile(keep, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	skipRoot := filepath.Join(root, "skipme")
+	deep := skipRoot
+	for i := 0; i < 100; i++ {
+		deep = filepath.Join(deep, fmt.Sprintf("level%d", i))
+		if err := os.MkdirAll(deep, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	hidden := filepath.Join(deep, "hidden.ft")
+	if err := os.WriteFile(hidden, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Default()
+	cfg.Files.Exclude = []string{"**/skipme/**"}
+
+	start := time.Now()
+	files, err := cfg.FindForstFiles(root)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || filepath.Base(files[0]) != "keep.ft" {
+		t.Fatalf("want only keep.ft, got %v", files)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("discovery took %v; excluded tree was likely descended into", elapsed)
+	}
+}
+
+func TestDefault_excludesBuildAndForstDirectories(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	build := filepath.Join(root, "build")
+	forstDir := filepath.Join(root, ".forst")
+	for _, d := range []string{src, build, forstDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ok := filepath.Join(src, "ok.ft")
+	for _, p := range []string{
+		ok,
+		filepath.Join(build, "skip.ft"),
+		filepath.Join(forstDir, "skip.ft"),
+	} {
+		if err := os.WriteFile(p, []byte("package main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := Default()
+	files, err := cfg.FindForstFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || filepath.Base(files[0]) != "ok.ft" {
+		t.Fatalf("want only src/ok.ft, got %v", files)
 	}
 }
 

--- a/forst/internal/transformer/ts/forst_file_project.go
+++ b/forst/internal/transformer/ts/forst_file_project.go
@@ -58,6 +58,7 @@ func ParseMergedTypecheckProject(filePaths []string, log *logrus.Logger) ([]Fors
 // GenerateTSOptions configures per-run TypeScript emission (forst generate).
 type GenerateTSOptions struct {
 	GenerateStreamingClients bool
+	ReportPhases             bool
 }
 
 // ForstFileStem returns the basename of path without the .ft extension.
@@ -149,7 +150,7 @@ func GenerateTypeScriptOutputsByPackage(filePaths []string, log *logrus.Logger, 
 			return nil, fmt.Errorf("package %q missing merged AST", pkgName)
 		}
 
-		tc := typechecker.New(log, false)
+		tc := typechecker.New(log, opts.ReportPhases)
 		tc.ConfigureForForstFile(moduleRoot, filepath.Dir(pkgPaths[0]), nodes)
 		tc.SetModuleResult(modResult)
 		if err := tc.CheckTypes(nodes); err != nil {


### PR DESCRIPTION
`FindForstFiles` returns `fs.SkipDir` when a directory matches `files.exclude`, so `generate` no longer walks `node_modules`, `.git`, `build`, or `.forst` trees. Default exclude globs now include `build` and `.forst`.

feat(generate): add log-level flag and phase timing

Wire `-log-level` (falling back to `dev.logLevel`) and pass `compiler.reportPhases` into typechecking. Log discover, `typecheck_emit`, `write`, and `link` durations when `reportPhases` is enabled.

fix(generate): demote verbose default output to debug

Move per-file emit logs, config resolution, and write summaries from info to debug so successful runs show only warnings and the stdout summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable log levels to the `forst generate` command.
  * Added optional timing reports for discovery, type checking, writing, and linking phases.
* **Bug Fixes**
  * Excluded `build` and `.forst` directories from file discovery and traversal by default.
  * Reduced routine generation output at standard log levels for less noisy command-line results.
* **Tests**
  * Added coverage for log-level handling, phase reporting, and excluded-directory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->